### PR TITLE
Bug: Unregistered tags cause playback to resume

### DIFF
--- a/jukebox/domain/use_cases/handle_tag_event.py
+++ b/jukebox/domain/use_cases/handle_tag_event.py
@@ -39,12 +39,12 @@ class HandleTagEvent:
             session.tag_removed_seconds = 0
 
         elif action == PlaybackAction.PLAY:
-            session.previous_tag = tag_event.tag_id
             LOGGER.info(f"Found card with UID: {tag_event.tag_id}")
 
             disc = self.library.get_disc(tag_event.tag_id) if tag_event.tag_id else None
             if disc is not None:
                 LOGGER.info(f"Found corresponding disc: {disc}")
+                session.previous_tag = tag_event.tag_id
                 self.player.play(disc.uri, disc.option.shuffle)
                 session.awaiting_seconds = 0
                 session.tag_removed_seconds = 0


### PR DESCRIPTION
If you leave an unregistered tag on the scanner it will RESUME playback of the previous tag. To prevent this, only update the previous tag if a valid tag from the library is scanned.

**To Reproduce**
1. Scan good tag
2. Remove good tag
3. Scan unknown tag
4. Wait

**Expected:** Nothing should play
**Actual:** Playback of valid tag resumes

_Note:_ This fix results in the PLAY action being attempted continuously while an unknown tag is on the reader, which might be undesired.  If you'd prefer the reader enter a different state while an unknown tag is being read, happy to adjust.