### PR TITLE
👷 add code format check to ci

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Install the project
         run: uv sync --locked --all-extras --dev
 
+      - name: Check format with ruff
+        run: uv run ruff format --check
+
       - name: Lint with ruff
         run: uv run ruff check
 

--- a/jukebox/adapters/outbound/readers/dryrun_reader_adapter.py
+++ b/jukebox/adapters/outbound/readers/dryrun_reader_adapter.py
@@ -46,7 +46,9 @@ class DryrunReaderAdapter(ReaderPort):
                 self.uid = commands[0]
                 self.hold_until = time.monotonic() + duration_seconds
             except ValueError:
-                LOGGER.warning(f"Duration parameter should be a non-negative number of seconds, received: `{commands[1]}`")
+                LOGGER.warning(
+                    f"Duration parameter should be a non-negative number of seconds, received: `{commands[1]}`"
+                )
             return self.uid
         LOGGER.warning(f"Invalid input, should be `tag_uid duration_seconds`, received: {commands}")
         return None

--- a/jukebox/shared/dependency_messages.py
+++ b/jukebox/shared/dependency_messages.py
@@ -1,6 +1,4 @@
-def optional_extra_dependency_message(
-    subject: str, extra_name: str, source_command: str
-) -> str:
+def optional_extra_dependency_message(subject: str, extra_name: str, source_command: str) -> str:
     return (
         f"{subject} requires the optional `{extra_name}` dependencies.\n\n"
         "If you installed the package, reinstall it with extras enabled using your package manager:\n"

--- a/tests/discstore/adapters/inbound/test_api_controller.py
+++ b/tests/discstore/adapters/inbound/test_api_controller.py
@@ -32,11 +32,12 @@ def test_dependencies_import_failure(mocker):
 @pytest.mark.parametrize("known_in_library", [True, False])
 def test_get_current_tag_returns_current_tag_payload(known_in_library):
     get_current_tag_status = create_autospec(GetCurrentTagStatus, instance=True, spec_set=True)
-    get_current_tag_status.execute.return_value = CurrentTagStatus(
-        tag_id="tag-123", known_in_library=known_in_library
-    )
+    get_current_tag_status.execute.return_value = CurrentTagStatus(tag_id="tag-123", known_in_library=known_in_library)
     controller = APIController(MagicMock(), MagicMock(), MagicMock(), MagicMock(), get_current_tag_status)
-    route = cast(APIRoute, next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/v1/current-tag"))
+    route = cast(
+        APIRoute,
+        next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/v1/current-tag"),
+    )
 
     response = route.endpoint()
 
@@ -51,7 +52,10 @@ def test_get_current_tag_returns_no_content_when_absent():
     get_current_tag_status = create_autospec(GetCurrentTagStatus, instance=True, spec_set=True)
     get_current_tag_status.execute.return_value = None
     controller = APIController(MagicMock(), MagicMock(), MagicMock(), MagicMock(), get_current_tag_status)
-    route = cast(APIRoute, next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/v1/current-tag"))
+    route = cast(
+        APIRoute,
+        next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/v1/current-tag"),
+    )
 
     response = route.endpoint()
 

--- a/tests/discstore/adapters/inbound/test_ui_controller.py
+++ b/tests/discstore/adapters/inbound/test_ui_controller.py
@@ -96,7 +96,9 @@ def test_ui_controller_registers_fastui_routes_and_page_structure():
     all_components = list(walk_components(page.components))
     server_load = next(component for component in all_components if component.type == "ServerLoad")
     add_button = next(
-        component for component in all_components if component.type == "Button" and component.text == "➕ Add a new disc"
+        component
+        for component in all_components
+        if component.type == "Button" and component.text == "➕ Add a new disc"
     )
     edit_button = next(
         component
@@ -116,7 +118,9 @@ def test_ui_controller_registers_fastui_routes_and_page_structure():
     new_page = new_route.endpoint()[0]
     assert new_page.components[0].text == "Add disc"
 
-    edit_route = next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/ui/discs/{tag_id}/edit")
+    edit_route = next(
+        route for route in controller.app.routes if getattr(route, "path", None) == "/api/ui/discs/{tag_id}/edit"
+    )
     edit_page = edit_route.endpoint("tag-123")[0]
     assert edit_page.components[0].text == "Edit disc tag-123"
     delete_button = next(
@@ -136,11 +140,7 @@ def test_ui_controller_registers_fastui_routes_and_page_structure():
     assert delete_page.components[0].text == "Delete disc tag-123"
     assert delete_page.components[1].text == 'Are you sure you want to delete the disc with tag "tag-123"?'
     all_delete_page_components = list(walk_components(delete_page.components))
-    confirm_deletion_form = next(
-        component
-        for component in all_delete_page_components
-        if component.type == "Form"
-    )
+    confirm_deletion_form = next(component for component in all_delete_page_components if component.type == "Form")
     cancel_deletion_button = next(
         component
         for component in all_delete_page_components
@@ -196,7 +196,9 @@ def test_current_tag_banner_for_unknown_disc_offers_add_cta():
 
     controller = build_controller()
 
-    components = controller._build_current_tag_banner_components(CurrentTagStatus(tag_id="tag-123", known_in_library=False))
+    components = controller._build_current_tag_banner_components(
+        CurrentTagStatus(tag_id="tag-123", known_in_library=False)
+    )
     all_components = list(walk_components(components))
     heading = next(component for component in all_components if component.type == "Heading")
     button = next(component for component in all_components if component.type == "Button")
@@ -215,7 +217,9 @@ def test_current_tag_banner_for_known_disc_is_informational_only():
 
     controller = build_controller()
 
-    components = controller._build_current_tag_banner_components(CurrentTagStatus(tag_id="tag-123", known_in_library=True))
+    components = controller._build_current_tag_banner_components(
+        CurrentTagStatus(tag_id="tag-123", known_in_library=True)
+    )
     all_components = list(walk_components(components))
     button = next(component for component in all_components if component.type == "Button")
 

--- a/tests/jukebox/adapters/outbound/readers/test_dryrun_reader_adapters.py
+++ b/tests/jukebox/adapters/outbound/readers/test_dryrun_reader_adapters.py
@@ -33,7 +33,9 @@ def test_init_creates_reader(caplog):
 def test_read(monkeypatch, input, now, expected_uid, expected_hold_until):
     """Should read the tag uid and optional hold duration."""
     fake_stdin = FakeStdin(f"{input}\n")
-    monkeypatch.setattr("jukebox.adapters.outbound.readers.dryrun_reader_adapter.select.select", lambda *args: ([fake_stdin], [], []))
+    monkeypatch.setattr(
+        "jukebox.adapters.outbound.readers.dryrun_reader_adapter.select.select", lambda *args: ([fake_stdin], [], [])
+    )
     monkeypatch.setattr(sys, "stdin", fake_stdin)
     monkeypatch.setattr("jukebox.adapters.outbound.readers.dryrun_reader_adapter.time.monotonic", lambda: now)
 
@@ -64,7 +66,9 @@ def test_read(monkeypatch, input, now, expected_uid, expected_hold_until):
 def test_read_invalid_input(monkeypatch, caplog, input, expected_error):
     """Should raise a warning when the input is invalid."""
     fake_stdin = FakeStdin(f"{input}\n")
-    monkeypatch.setattr("jukebox.adapters.outbound.readers.dryrun_reader_adapter.select.select", lambda *args: ([fake_stdin], [], []))
+    monkeypatch.setattr(
+        "jukebox.adapters.outbound.readers.dryrun_reader_adapter.select.select", lambda *args: ([fake_stdin], [], [])
+    )
     monkeypatch.setattr(sys, "stdin", fake_stdin)
 
     adapter = DryrunReaderAdapter()
@@ -96,7 +100,9 @@ def test_read_with_duration(monkeypatch):
 
     monkeypatch.setattr("jukebox.adapters.outbound.readers.dryrun_reader_adapter.time.monotonic", lambda: 102.0)
     fake_stdin = FakeStdin("uri\n")
-    monkeypatch.setattr("jukebox.adapters.outbound.readers.dryrun_reader_adapter.select.select", lambda *args: ([fake_stdin], [], []))
+    monkeypatch.setattr(
+        "jukebox.adapters.outbound.readers.dryrun_reader_adapter.select.select", lambda *args: ([fake_stdin], [], [])
+    )
     monkeypatch.setattr(sys, "stdin", fake_stdin)
     with patch.object(fake_stdin, "readline", wraps=fake_stdin.readline) as mock_readline:
         result = adapter.read()
@@ -109,7 +115,9 @@ def test_read_with_duration(monkeypatch):
 def test_read_returns_none_when_no_input_is_ready(monkeypatch):
     """Should return None without attempting to consume stdin."""
     fake_stdin = FakeStdin("uri\n")
-    monkeypatch.setattr("jukebox.adapters.outbound.readers.dryrun_reader_adapter.select.select", lambda *args: ([], [], []))
+    monkeypatch.setattr(
+        "jukebox.adapters.outbound.readers.dryrun_reader_adapter.select.select", lambda *args: ([], [], [])
+    )
     monkeypatch.setattr(sys, "stdin", fake_stdin)
 
     adapter = DryrunReaderAdapter()

--- a/tests/jukebox/domain/use_cases/test_handle_tag_event.py
+++ b/tests/jukebox/domain/use_cases/test_handle_tag_event.py
@@ -84,9 +84,7 @@ def test_unknown_tag_writes_current_tag(handle_tag_event, mock_current_tag_repos
     mock_current_tag_repository.set.assert_called_once_with("unknown-tag")
 
 
-def test_same_tag_does_not_rewrite_current_tag_unnecessarily(
-    handle_tag_event, mock_current_tag_repository
-):
+def test_same_tag_does_not_rewrite_current_tag_unnecessarily(handle_tag_event, mock_current_tag_repository):
     session = PlaybackSession()
 
     session = handle_tag_event.execute(TagEvent(tag_id="same-tag", timestamp=100.0), session)
@@ -96,9 +94,7 @@ def test_same_tag_does_not_rewrite_current_tag_unnecessarily(
     assert session.physical_tag == "same-tag"
 
 
-def test_different_tag_replaces_current_tag_state(
-    handle_tag_event, mock_current_tag_repository
-):
+def test_different_tag_replaces_current_tag_state(handle_tag_event, mock_current_tag_repository):
     session = PlaybackSession()
 
     session = handle_tag_event.execute(TagEvent(tag_id="tag-a", timestamp=100.0), session)
@@ -147,9 +143,7 @@ def test_unknown_tag_promotes_to_known_without_rewriting_current_tag(
     assert session.current_tag == "promote-tag"
 
 
-def test_current_tag_set_failure_does_not_block_playback(
-    handle_tag_event, mock_current_tag_repository, mock_player
-):
+def test_current_tag_set_failure_does_not_block_playback(handle_tag_event, mock_current_tag_repository, mock_player):
     mock_current_tag_repository.set.side_effect = OSError("disk full")
     session = PlaybackSession()
 
@@ -160,9 +154,7 @@ def test_current_tag_set_failure_does_not_block_playback(
     assert new_session.previous_tag == "known-tag"
 
 
-def test_current_tag_clear_failure_does_not_block_pause(
-    handle_tag_event, mock_current_tag_repository, mock_player
-):
+def test_current_tag_clear_failure_does_not_block_pause(handle_tag_event, mock_current_tag_repository, mock_player):
     handle_tag_event.determine_action.pause_delay = 0.25
     mock_current_tag_repository.clear.side_effect = OSError("permission denied")
     session = PlaybackSession(


### PR DESCRIPTION
This PR adds a code format check to the CI pipeline to ensure consistent code style across the project.
It helps prevent unnecessary diffs and reduces noise in future PRs.

As a future improvement, setting up pre-commit hooks could enforce formatting locally before pushing code.