### PR TITLE
🔨 add prek pre-commit configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ pip install "gukebox[nfc]"
 - For non-system Python 3.13+, you can still install via pip/uv/poetry/etc. but you must build the `lgpio` package from source and it may require other system packages.
 - All releases can be downloaded and installed from the [GitHub releases page](https://github.com/Gudsfile/jukebox/releases).
 
-### Developer setup
+### Installation for development
 
 For development read the [Developer setup](#developer-setup) section.
 
@@ -304,6 +304,15 @@ Other commands are available:
 | `uv run ruff check` | Check the code. |
 | `uv run ruff check --fix` | Fix the code. |
 | `uv run pytest` | Run the tests. |
+
+### Pre-commit
+
+[prek](https://github.com/j178/prek) is configured; you can [install it](https://github.com/j178/prek?tab=readme-ov-file#installation) to automatically run validations on each commit.
+
+```shell
+uv tool install prek
+prek install
+```
 
 ## Contributing
 

--- a/prek.toml
+++ b/prek.toml
@@ -1,0 +1,26 @@
+[[repos]]
+repo = "https://github.com/pre-commit/pre-commit-hooks"
+rev = "v6.0.0"
+hooks = [
+  { id = "check-yaml" },
+  { id = "end-of-file-fixer" },
+]
+
+[[repos]]
+repo = "https://github.com/astral-sh/ruff-pre-commit"
+rev = "v0.15.4" # Ruff version.
+hooks = [
+  # Run the linter.
+  { id = "ruff-check", args = ["--fix"], types_or = ["python", "pyi"] },
+
+  # Run the formatter.
+  { id = "ruff-format", types_or = ["python", "pyi"] },
+]
+
+[[repos]]
+repo = "https://github.com/astral-sh/uv-pre-commit"
+rev = "0.10.12" # uv version.
+hooks = [
+    # Update the uv lockfile
+    { id = "uv-lock" },
+]


### PR DESCRIPTION
Builds on https://github.com/Gudsfile/jukebox/pull/132.

Optionally enforce code formatting locally before pushing.

Chose [`prek`](https://github.com/j178/prek) to try it out and because our existing tools use it. An alternative is [pre-commit](https://pre-commit.com).