### PR TITLE
👷 add version bump step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,9 +107,9 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create "v${{ needs.bump.outputs.version }}" --title "Release v${{ needs.bump.outputs.version }}" --notes "New version v${{ needs.bump.outputs.version }} 🚀" --draft
-
-      - name: Add binaries to release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload v${{ needs.bump.outputs.version }} dist/*
+        run: |
+          gh release create "v${{ needs.bump.outputs.version }}" \
+            --title "v${{ needs.bump.outputs.version }}" \
+            --generate-notes \
+            --draft \
+            dist/*


### PR DESCRIPTION
**Problem:**
Currently, the version bump commit and tag creation are done manually to trigger the release.

**Proposal:**
Include the version bump and tag creation in the release workflow. This workflow is triggered manually via the GitHub UI.