### PR TITLE
👷 separate bump-version and release workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,65 @@
+name: bump-version
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump type"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - stable
+          - alpha
+          - beta
+          - rc
+          - post
+          - dev
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  UV_PROJECT_ENVIRONMENT: $pythonLocation
+
+jobs:
+  bump:
+    name: Bump Version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Bump version
+        run: uv version --bump ${{ github.event.inputs.bump }}
+
+      - name: Get new version
+        id: version
+        run: echo "version=$(uv version | awk '{print $2}')" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml uv.lock
+          git commit -m "🔖 v${{ steps.version.outputs.version }}"
+          git push origin HEAD:auto-bump/v${{ steps.version.outputs.version }}
+          gh pr create \
+            --title "🔖 v${{ steps.version.outputs.version }}" \
+            --body "Automated version bump to v${{ steps.version.outputs.version }}\n\nThis PR was created by the bump-version workflow." \
+            --label auto-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,9 @@
 name: release
 
 on:
-  workflow_dispatch:
-    inputs:
-      bump:
-        description: "Version bump type"
-        required: true
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
-          - stable
-          - alpha
-          - beta
-          - rc
-          - post
-          - dev
-      dryrun:
-        description: "Enable dry run mode (no PyPI deployment)"
-        required: false
-        default: "false"
-        type: boolean
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 permissions:
   contents: write
@@ -31,57 +13,16 @@ env:
   UV_PROJECT_ENVIRONMENT: $pythonLocation
 
 jobs:
-  bump:
-    name: Bump Version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-
-      - name: Bump version
-        run: uv version --bump ${{ github.event.inputs.bump }}
-
-      - name: Get new version
-        id: version
-        run: echo "version=$(uv version | awk '{print $2}')" >> $GITHUB_OUTPUT
-
-      - uses: actions/create-github-app-token@v3
-        id: app-token
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.PRIVATE_KEY }}
-
-      - name: Get GitHub App User ID
-        id: get-user-id
-        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-
-      - name: Commit and push tag
-        run: |
-          git config user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
-          git config user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
-          git add pyproject.toml uv.lock
-          git commit -m "🔖 v${{ steps.version.outputs.version }}"
-          git tag "v${{ steps.version.outputs.version }}"
-          git push origin ${{ github.ref_name }} --follow-tags
-
   build-and-publish:
     name: Build & Publish to PyPI
-    needs: bump
     runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.merged == true
+      && startsWith(github.head_ref, 'auto-bump/')
+      && contains(github.event.pull_request.labels.*.name, 'auto-release')
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: "v${{ needs.bump.outputs.version }}"
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -97,12 +38,7 @@ jobs:
         run: uv build
 
       - name: Publish to PyPI
-        if: ${{ github.event.inputs.dryrun != 'true' }}
         run: uv publish
-
-      - name: Publish to PyPI (dry run)
-        if: ${{ github.event.inputs.dryrun == 'true' }}
-        run: uv publish --dry-run
 
       - name: Upload package artifact
         uses: actions/upload-artifact@v7
@@ -112,13 +48,11 @@ jobs:
 
   github-release:
     name: Create GitHub Release
-    needs: [bump, build-and-publish]
+    needs: build-and-publish
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: "v${{ needs.bump.outputs.version }}"
 
       - name: Download built package
         uses: actions/download-artifact@v8
@@ -126,12 +60,21 @@ jobs:
           name: built-package
           path: dist/
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Get version
+        id: version
+        run: echo "version=$(uv version | awk '{print $2}')" >> $GITHUB_OUTPUT
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "v${{ needs.bump.outputs.version }}" \
-            --title "v${{ needs.bump.outputs.version }}" \
+          gh release create "v${{ steps.version.outputs.version }}" \
+            --title "v${{ steps.version.outputs.version }}" \
             --generate-notes \
             --draft \
             dist/*


### PR DESCRIPTION
Commits to the default branch are not allowed, so the bump-version step now opens a PR. When the PR opened by the bump-version step is merged, the release workflow should start.

This commit:
- Reverts dryrun mode and GitHub app usage (#137)
- *Attempts to* fix the release workflow (#134)