### PR TITLE
🐛 revert the continue action conditon

### DIFF
--- a/jukebox/domain/use_cases/determine_action.py
+++ b/jukebox/domain/use_cases/determine_action.py
@@ -23,11 +23,11 @@ class DetermineAction:
         is_acceptable_pause_duration = paused_duration < self.max_pause_duration
         is_within_grace_period = removal_duration < self.pause_delay
 
-        if is_detecting_tag and is_same_tag_as_previous and tag_removed_at is not None:
+        if is_detecting_tag and is_same_tag_as_previous and not is_paused:
             return PlaybackAction.CONTINUE
         elif is_detecting_tag and is_same_tag_as_previous and is_paused and is_acceptable_pause_duration:
             return PlaybackAction.RESUME
-        elif is_detecting_tag and not (is_same_tag_as_previous and is_acceptable_pause_duration):
+        elif is_detecting_tag:
             return PlaybackAction.PLAY
         elif not is_detecting_tag and not is_same_tag_as_previous and not is_paused and is_within_grace_period:
             return PlaybackAction.WAITING

--- a/tests/jukebox/domain/use_cases/test_determine_action.py
+++ b/tests/jukebox/domain/use_cases/test_determine_action.py
@@ -25,14 +25,14 @@ def test_continue_when_tag_returns_after_being_removed(determine_action, playing
     assert action == PlaybackAction.CONTINUE
 
 
-def test_idle_when_same_tag_detected_without_removal(determine_action):
-    """Should idle when the same tag is detected without any prior removal."""
+def test_continue_when_same_tag_detected_without_removal(determine_action):
+    """Should continue when the same tag is detected without any prior removal."""
     session = PlaybackSession(playing_tag="id-1", paused_at=None, playing_tag_removed_at=None)
     tag_event = TagEvent(tag_id="id-1", timestamp=100.0)
 
     action = determine_action.execute(tag_event, session)
 
-    assert action == PlaybackAction.IDLE
+    assert action == PlaybackAction.CONTINUE
 
 
 def test_resume_when_same_tag_and_paused(determine_action):
@@ -40,7 +40,7 @@ def test_resume_when_same_tag_and_paused(determine_action):
     session = PlaybackSession(
         playing_tag="id-1",
         paused_at=80.0,  # Paused but < max_pause_duration
-        playing_tag_removed_at=None,
+        playing_tag_removed_at=50.0,
     )
     tag_event = TagEvent(tag_id="id-1", timestamp=100.0)
 
@@ -121,7 +121,7 @@ def test_stop_when_paused_too_long(determine_action):
     session = PlaybackSession(
         playing_tag="id-1",
         paused_at=40.0,  # > max_pause_duration (50)
-        playing_tag_removed_at=None,
+        playing_tag_removed_at=40.0,
     )
     tag_event = TagEvent(tag_id=None, timestamp=100.0)
 
@@ -135,7 +135,7 @@ def test_idle_when_no_tag_and_no_playing_tag(determine_action):
     session = PlaybackSession(
         playing_tag=None,
         paused_at=10.0,
-        playing_tag_removed_at=None,
+        playing_tag_removed_at=10.0,
     )
     tag_event = TagEvent(tag_id=None, timestamp=100.0)
 
@@ -149,7 +149,7 @@ def test_play_when_same_tag_but_paused_too_long(determine_action):
     session = PlaybackSession(
         playing_tag="id-1",
         paused_at=40.0,  # > max_pause_duration (50)
-        playing_tag_removed_at=None,
+        playing_tag_removed_at=40.0,
     )
     tag_event = TagEvent(tag_id="id-1", timestamp=100.0)
 

--- a/tests/jukebox/domain/use_cases/test_handle_tag_event.py
+++ b/tests/jukebox/domain/use_cases/test_handle_tag_event.py
@@ -426,3 +426,27 @@ def test_same_tag_detection_resets_logical_removal_grace_period(handle_tag_event
     mock_player.pause.assert_not_called()
     assert session.paused_at is None
     assert session.playing_tag_removed_at == 103.2
+
+
+def test_same_tag_returns_after_pause_resumes_immediately(handle_tag_event, mock_player):
+    session = PlaybackSession(
+        playing_tag="test-tag",
+        physical_tag="test-tag",
+        last_event_timestamp=100.0,
+    )
+
+    # First missed read starts the grace window.
+    session = handle_tag_event.execute(TagEvent(tag_id=None, timestamp=100.1), session)
+    assert session.playing_tag_removed_at == 100.1
+
+    # After the grace period expires, playback pauses.
+    session = handle_tag_event.execute(TagEvent(tag_id=None, timestamp=103.2), session)
+    mock_player.pause.assert_called_once()
+    assert session.paused_at == 103.2
+
+    # The first same-tag read should resume immediately.
+    session = handle_tag_event.execute(TagEvent(tag_id="test-tag", timestamp=103.3), session)
+
+    mock_player.resume.assert_called_once()
+    assert session.paused_at is None
+    assert session.playing_tag_removed_at is None


### PR DESCRIPTION
This reverts commit b562f13 (but keep the tests), It introduced a bug/regression:
> "users have to present the tag twice to resume playback (so RESUME will be a bit delayed)"
> https://github.com/Gudsfile/jukebox/pull/150#issuecomment-4130344736
