### PR TITLE
Tighten `selected_group` persistence to Sonos UID-only

### DIFF
--- a/jukebox/adapters/outbound/players/sonos_player_adapter.py
+++ b/jukebox/adapters/outbound/players/sonos_player_adapter.py
@@ -89,10 +89,7 @@ class SonosPlayerAdapter(PlayerPort):
         applied_operations = []
 
         if group.is_partial:
-            LOGGER.warning(
-                "Applying Sonos group best-effort with missing saved members: "
-                f"{[member.name for member in group.missing_members]}"
-            )
+            LOGGER.warning(f"Applying Sonos group best-effort with missing saved members: {group.missing_member_uids}")
 
         try:
             for member in group.members:

--- a/jukebox/settings/entities.py
+++ b/jukebox/settings/entities.py
@@ -18,13 +18,9 @@ class StrictModel(BaseModel):
 
 class SelectedSonosSpeakerSettings(StrictModel):
     uid: str
-    name: str
-    household_id: Optional[str] = None
-    last_known_host: Optional[str] = None
 
 
 class SelectedSonosGroupSettings(StrictModel):
-    household_id: Optional[str] = None
     coordinator_uid: str
     members: list[SelectedSonosSpeakerSettings]
 
@@ -119,13 +115,9 @@ class AppSettings(PersistedAppSettings):
 
 class SparseSelectedSonosSpeakerSettings(StrictModel):
     uid: Optional[str] = None
-    name: Optional[str] = None
-    household_id: Optional[str] = None
-    last_known_host: Optional[str] = None
 
 
 class SparseSelectedSonosGroupSettings(StrictModel):
-    household_id: Optional[str] = None
     coordinator_uid: Optional[str] = None
     members: Optional[list[SparseSelectedSonosSpeakerSettings]] = None
 
@@ -212,7 +204,7 @@ class ResolvedSonosGroupRuntime(StrictModel):
     household_id: str
     coordinator: ResolvedSonosSpeakerRuntime
     members: list[ResolvedSonosSpeakerRuntime]
-    missing_members: list[SelectedSonosSpeakerSettings] = Field(default_factory=list)
+    missing_member_uids: list[str] = Field(default_factory=list)
 
     @model_validator(mode="after")
     def validate_group_shape(self):
@@ -228,19 +220,19 @@ class ResolvedSonosGroupRuntime(StrictModel):
             raise ValueError("resolved Sonos group members must belong to the same household")
 
         reachable_member_uids = {member.uid for member in self.members}
-        missing_member_uids = {member.uid for member in self.missing_members}
+        missing_member_uids = set(self.missing_member_uids)
         if reachable_member_uids & missing_member_uids:
-            raise ValueError("resolved Sonos group missing_members must not overlap with resolved members")
+            raise ValueError("resolved Sonos group missing_member_uids must not overlap with resolved members")
 
         return self
 
     @property
     def desired_member_uids(self) -> set[str]:
-        return {member.uid for member in self.members} | {member.uid for member in self.missing_members}
+        return {member.uid for member in self.members} | set(self.missing_member_uids)
 
     @property
     def is_partial(self) -> bool:
-        return bool(self.missing_members)
+        return bool(self.missing_member_uids)
 
 
 class ResolvedJukeboxRuntimeConfig(StrictModel):

--- a/jukebox/settings/sonos_runtime.py
+++ b/jukebox/settings/sonos_runtime.py
@@ -27,7 +27,7 @@ class SoCoSonosGroupResolver:
 
         available_speakers = self._discover_available_speakers(soco)
         resolved_members = []
-        missing_members = []
+        missing_member_uids = []
         coordinator_resolution_error = None
 
         for saved_member in selected_group.members:
@@ -49,8 +49,6 @@ class SoCoSonosGroupResolver:
                         discovered_host = None
                     if discovered_host:
                         host_candidates.append(discovered_host)
-                if saved_member.last_known_host is not None and saved_member.last_known_host not in host_candidates:
-                    host_candidates.append(saved_member.last_known_host)
 
                 host_errors = []
                 for host in host_candidates:
@@ -63,10 +61,10 @@ class SoCoSonosGroupResolver:
 
                 if runtime_member is None and host_errors:
                     member_resolution_error = "; ".join(host_errors)
-                elif runtime_member is None and saved_member.last_known_host is None:
-                    member_resolution_error = f"{saved_member.uid}: not found on network and has no last_known_host"
+                elif runtime_member is None and resolved_speaker is None:
+                    member_resolution_error = f"{saved_member.uid}: not found on network"
                 else:
-                    member_resolution_error = f"{saved_member.uid} via {saved_member.last_known_host}: not reachable"
+                    member_resolution_error = f"{saved_member.uid}: discovered speaker could not be resolved"
 
             else:
                 member_resolution_error = None
@@ -75,7 +73,7 @@ class SoCoSonosGroupResolver:
                 if saved_member.uid == selected_group.coordinator_uid:
                     coordinator_resolution_error = member_resolution_error
                 else:
-                    missing_members.append(saved_member)
+                    missing_member_uids.append(saved_member.uid)
                 continue
 
             resolved_members.append(runtime_member)
@@ -93,14 +91,11 @@ class SoCoSonosGroupResolver:
         if len(household_ids) != 1:
             raise ValueError("Resolved Sonos group members must belong to the same household")
 
-        if selected_group.household_id is not None and selected_group.household_id not in household_ids:
-            raise ValueError("Resolved Sonos group household does not match the saved selected_group household_id")
-
         return ResolvedSonosGroupRuntime(
             household_id=coordinator.household_id,
             coordinator=coordinator,
             members=resolved_members,
-            missing_members=missing_members,
+            missing_member_uids=missing_member_uids,
         )
 
     @staticmethod

--- a/tests/discstore/adapters/inbound/test_api_controller.py
+++ b/tests/discstore/adapters/inbound/test_api_controller.py
@@ -201,7 +201,7 @@ def test_patch_settings_updates_player_settings():
                     "sonos": {
                         "selected_group": {
                             "coordinator_uid": "speaker-1",
-                            "members": [{"uid": "speaker-1", "name": "Living Room", "last_known_host": "192.168.1.20"}],
+                            "members": [{"uid": "speaker-1"}],
                         }
                     },
                 }
@@ -227,13 +227,7 @@ def test_patch_settings_updates_player_settings():
                         "sonos": {
                             "selected_group": {
                                 "coordinator_uid": "speaker-1",
-                                "members": [
-                                    {
-                                        "uid": "speaker-1",
-                                        "name": "Living Room",
-                                        "last_known_host": "192.168.1.20",
-                                    }
-                                ],
+                                "members": [{"uid": "speaker-1"}],
                             }
                         },
                     }
@@ -251,7 +245,7 @@ def test_patch_settings_updates_player_settings():
                     "sonos": {
                         "selected_group": {
                             "coordinator_uid": "speaker-1",
-                            "members": [{"uid": "speaker-1", "name": "Living Room", "last_known_host": "192.168.1.20"}],
+                            "members": [{"uid": "speaker-1"}],
                         }
                     },
                 }
@@ -266,7 +260,7 @@ def test_patch_settings_updates_player_settings():
                     "sonos": {
                         "selected_group": {
                             "coordinator_uid": "speaker-1",
-                            "members": [{"uid": "speaker-1", "name": "Living Room", "last_known_host": "192.168.1.20"}],
+                            "members": [{"uid": "speaker-1"}],
                         }
                     },
                 }

--- a/tests/discstore/test_discstore_app.py
+++ b/tests/discstore/test_discstore_app.py
@@ -241,12 +241,12 @@ def test_main_prints_settings_show_payload(app_mocks):
             SettingsSetCommand(
                 type="settings_set",
                 dotted_path="jukebox.player.sonos.selected_group",
-                value='{"coordinator_uid":"speaker-1","members":[{"uid":"speaker-1","name":"Living Room","last_known_host":"192.168.1.20"}]}',
+                value='{"coordinator_uid":"speaker-1","members":[{"uid":"speaker-1"}]}',
             ),
             "set_persisted_value",
             (
                 "jukebox.player.sonos.selected_group",
-                '{"coordinator_uid":"speaker-1","members":[{"uid":"speaker-1","name":"Living Room","last_known_host":"192.168.1.20"}]}',
+                '{"coordinator_uid":"speaker-1","members":[{"uid":"speaker-1"}]}',
             ),
         ),
         (

--- a/tests/jukebox/adapters/outbound/players/test_sonos_player_adapters.py
+++ b/tests/jukebox/adapters/outbound/players/test_sonos_player_adapters.py
@@ -226,7 +226,7 @@ def test_init_with_partial_group_prunes_extras_but_keeps_missing_desired_members
             ("speaker-1", "Kitchen", "192.168.1.30", "household-1"),
             ("speaker-2", "Living Room", "192.168.1.40", "household-1"),
         ],
-        missing_speakers=[("speaker-3", "Office", "192.168.1.50", None)],
+        missing_member_uids=["speaker-3"],
     )
 
     SonosPlayerAdapter(group=group)

--- a/tests/jukebox/settings/_helpers.py
+++ b/tests/jukebox/settings/_helpers.py
@@ -3,7 +3,6 @@ from typing import Optional, cast
 from jukebox.settings.entities import (
     ResolvedSonosGroupRuntime,
     ResolvedSonosSpeakerRuntime,
-    SelectedSonosSpeakerSettings,
 )
 from jukebox.settings.types import JsonObject, JsonValue
 
@@ -28,28 +27,19 @@ def build_resolved_sonos_group_runtime(
     coordinator_uid: str = "speaker-1",
     speakers: Optional[list[tuple[str, str, str, str]]] = None,
     household_id: str = "household-1",
-    missing_speakers: Optional[list[tuple[str, str, Optional[str], Optional[str]]]] = None,
+    missing_member_uids: Optional[list[str]] = None,
 ) -> ResolvedSonosGroupRuntime:
     speakers = speakers or [("speaker-1", "Living Room", "192.168.1.20", household_id)]
     members = [
         ResolvedSonosSpeakerRuntime(uid=uid, name=name, host=host, household_id=member_household_id)
         for uid, name, host, member_household_id in speakers
     ]
-    missing_members = [
-        SelectedSonosSpeakerSettings(
-            uid=uid,
-            name=name,
-            last_known_host=last_known_host,
-            household_id=member_household_id,
-        )
-        for uid, name, last_known_host, member_household_id in missing_speakers or []
-    ]
     coordinator = next(member for member in members if member.uid == coordinator_uid)
     return ResolvedSonosGroupRuntime(
         household_id=household_id,
         coordinator=coordinator,
         members=members,
-        missing_members=missing_members,
+        missing_member_uids=missing_member_uids or [],
     )
 
 

--- a/tests/jukebox/settings/test_file_settings_repository.py
+++ b/tests/jukebox/settings/test_file_settings_repository.py
@@ -60,6 +60,32 @@ def test_repository_rejects_persisted_manual_sonos_targets(tmp_path, field_name,
         repository.load_persisted_settings_data()
 
 
+def test_repository_rejects_legacy_selected_group_fields(tmp_path):
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "jukebox": {
+                    "player": {
+                        "sonos": {
+                            "selected_group": {
+                                "coordinator_uid": "speaker-1",
+                                "members": [{"uid": "speaker-1", "name": "Living Room"}],
+                            }
+                        }
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    repository = FileSettingsRepository(str(settings_path))
+
+    with pytest.raises(InvalidSettingsError):
+        repository.load_persisted_settings_data()
+
+
 def test_repository_migrates_missing_schema_version(tmp_path):
     settings_path = tmp_path / "settings.json"
     settings_path.write_text(json.dumps({"paths": {"library_path": "~/custom-library.json"}}), encoding="utf-8")

--- a/tests/jukebox/settings/test_settings_service_mutation_validation.py
+++ b/tests/jukebox/settings/test_settings_service_mutation_validation.py
@@ -69,7 +69,7 @@ def test_settings_service_set_rejects_invalid_selected_group_without_writing(tmp
     with pytest.raises(InvalidSettingsError, match="selected_group.coordinator_uid must match a member uid"):
         service.set_persisted_value(
             "jukebox.player.sonos.selected_group",
-            '{"coordinator_uid":"speaker-2","members":[{"uid":"speaker-1","name":"Living Room"}]}',
+            '{"coordinator_uid":"speaker-2","members":[{"uid":"speaker-1"}]}',
         )
 
     assert json.loads(settings_path.read_text(encoding="utf-8")) == {
@@ -88,6 +88,26 @@ def test_settings_service_set_rejects_non_json_selected_group_without_writing(tm
 
     with pytest.raises(InvalidSettingsError, match="must be valid JSON"):
         service.set_persisted_value("jukebox.player.sonos.selected_group", "not-json")
+
+    assert json.loads(settings_path.read_text(encoding="utf-8")) == {
+        "schema_version": 1,
+        "admin": {"api": {"port": 8100}},
+    }
+
+
+def test_settings_service_set_rejects_legacy_selected_group_fields_without_writing(tmp_path):
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(
+        json.dumps({"schema_version": 1, "admin": {"api": {"port": 8100}}}),
+        encoding="utf-8",
+    )
+    service = SettingsService(repository=FileSettingsRepository(str(settings_path)))
+
+    with pytest.raises(InvalidSettingsError, match="extra_forbidden"):
+        service.set_persisted_value(
+            "jukebox.player.sonos.selected_group",
+            '{"coordinator_uid":"speaker-1","members":[{"uid":"speaker-1","name":"Living Room"}]}',
+        )
 
     assert json.loads(settings_path.read_text(encoding="utf-8")) == {
         "schema_version": 1,

--- a/tests/jukebox/settings/test_settings_service_mutations.py
+++ b/tests/jukebox/settings/test_settings_service_mutations.py
@@ -184,8 +184,8 @@ def test_settings_service_reset_jukebox_resets_editable_player_reader_and_timing
                             "selected_group": {
                                 "coordinator_uid": "speaker-2",
                                 "members": [
-                                    {"uid": "speaker-1", "name": "Kitchen", "last_known_host": "192.168.1.30"},
-                                    {"uid": "speaker-2", "name": "Living Room", "last_known_host": "192.168.1.40"},
+                                    {"uid": "speaker-1"},
+                                    {"uid": "speaker-2"},
                                 ],
                             },
                         },
@@ -443,7 +443,7 @@ def test_settings_service_set_selected_group_from_json_string(tmp_path):
 
     result = service.set_persisted_value(
         "jukebox.player.sonos.selected_group",
-        '{"coordinator_uid":"speaker-1","members":[{"uid":"speaker-1","name":"Living Room","last_known_host":"192.168.1.20"}]}',
+        '{"coordinator_uid":"speaker-1","members":[{"uid":"speaker-1"}]}',
     )
 
     assert json.loads(settings_path.read_text(encoding="utf-8")) == {
@@ -453,15 +453,7 @@ def test_settings_service_set_selected_group_from_json_string(tmp_path):
                 "sonos": {
                     "selected_group": {
                         "coordinator_uid": "speaker-1",
-                        "household_id": None,
-                        "members": [
-                            {
-                                "uid": "speaker-1",
-                                "name": "Living Room",
-                                "household_id": None,
-                                "last_known_host": "192.168.1.20",
-                            }
-                        ],
+                        "members": [{"uid": "speaker-1"}],
                     }
                 }
             }
@@ -488,7 +480,7 @@ def test_settings_service_patch_updates_player_settings_and_reports_restart(tmp_
                     "sonos": {
                         "selected_group": {
                             "coordinator_uid": "speaker-1",
-                            "members": [{"uid": "speaker-1", "name": "Living Room", "last_known_host": "192.168.1.20"}],
+                            "members": [{"uid": "speaker-1"}],
                         }
                     },
                 }
@@ -504,15 +496,7 @@ def test_settings_service_patch_updates_player_settings_and_reports_restart(tmp_
                 "sonos": {
                     "selected_group": {
                         "coordinator_uid": "speaker-1",
-                        "household_id": None,
-                        "members": [
-                            {
-                                "uid": "speaker-1",
-                                "name": "Living Room",
-                                "household_id": None,
-                                "last_known_host": "192.168.1.20",
-                            }
-                        ],
+                        "members": [{"uid": "speaker-1"}],
                     }
                 },
             }
@@ -680,9 +664,7 @@ def test_settings_service_reset_removes_only_requested_selected_group_override(t
                         "sonos": {
                             "selected_group": {
                                 "coordinator_uid": "speaker-1",
-                                "members": [
-                                    {"uid": "speaker-1", "name": "Living Room", "last_known_host": "192.168.1.20"}
-                                ],
+                                "members": [{"uid": "speaker-1"}],
                             }
                         },
                     }

--- a/tests/jukebox/settings/test_settings_service_runtime_resolution.py
+++ b/tests/jukebox/settings/test_settings_service_runtime_resolution.py
@@ -122,7 +122,7 @@ def test_settings_service_allows_effective_view_with_selected_group_without_any_
                         "sonos": {
                             "selected_group": {
                                 "coordinator_uid": "speaker-1",
-                                "members": [{"uid": "speaker-1", "name": "Living Room"}],
+                                "members": [{"uid": "speaker-1"}],
                             }
                         },
                     }

--- a/tests/jukebox/settings/test_settings_service_sonos_resolution.py
+++ b/tests/jukebox/settings/test_settings_service_sonos_resolution.py
@@ -20,7 +20,7 @@ def test_settings_service_resolves_persisted_one_member_selected_group_into_runt
                         "sonos": {
                             "selected_group": {
                                 "coordinator_uid": "speaker-1",
-                                "members": [{"uid": "speaker-1", "name": "Living Room"}],
+                                "members": [{"uid": "speaker-1"}],
                             }
                         },
                     }
@@ -57,8 +57,8 @@ def test_settings_service_resolves_persisted_multi_member_selected_group_into_ru
                             "selected_group": {
                                 "coordinator_uid": "speaker-2",
                                 "members": [
-                                    {"uid": "speaker-1", "name": "Kitchen"},
-                                    {"uid": "speaker-2", "name": "Living Room"},
+                                    {"uid": "speaker-1"},
+                                    {"uid": "speaker-2"},
                                 ],
                             }
                         },
@@ -101,9 +101,9 @@ def test_settings_service_allows_best_effort_selected_group_resolution_with_miss
                             "selected_group": {
                                 "coordinator_uid": "speaker-2",
                                 "members": [
-                                    {"uid": "speaker-1", "name": "Kitchen"},
-                                    {"uid": "speaker-2", "name": "Living Room"},
-                                    {"uid": "speaker-3", "name": "Office", "last_known_host": "192.168.1.50"},
+                                    {"uid": "speaker-1"},
+                                    {"uid": "speaker-2"},
+                                    {"uid": "speaker-3"},
                                 ],
                             }
                         },
@@ -119,7 +119,7 @@ def test_settings_service_allows_best_effort_selected_group_resolution_with_miss
             ("speaker-1", "Kitchen", "192.168.1.30", "household-1"),
             ("speaker-2", "Living Room", "192.168.1.40", "household-1"),
         ],
-        missing_speakers=[("speaker-3", "Office", "192.168.1.50", None)],
+        missing_member_uids=["speaker-3"],
     )
     service = SettingsService(
         repository=FileSettingsRepository(str(settings_path)),
@@ -132,7 +132,7 @@ def test_settings_service_allows_best_effort_selected_group_resolution_with_miss
     assert runtime_config.sonos_group == resolved_group
     assert runtime_config.sonos_group is not None
     assert [member.uid for member in runtime_config.sonos_group.members] == ["speaker-1", "speaker-2"]
-    assert [member.uid for member in runtime_config.sonos_group.missing_members] == ["speaker-3"]
+    assert runtime_config.sonos_group.missing_member_uids == ["speaker-3"]
 
 
 def test_settings_service_env_host_override_beats_persisted_selected_group(tmp_path):
@@ -148,8 +148,8 @@ def test_settings_service_env_host_override_beats_persisted_selected_group(tmp_p
                             "selected_group": {
                                 "coordinator_uid": "speaker-2",
                                 "members": [
-                                    {"uid": "speaker-1", "name": "Kitchen", "last_known_host": "192.168.1.30"},
-                                    {"uid": "speaker-2", "name": "Living Room", "last_known_host": "192.168.1.40"},
+                                    {"uid": "speaker-1"},
+                                    {"uid": "speaker-2"},
                                 ],
                             },
                         },
@@ -190,8 +190,8 @@ def test_settings_service_env_host_override_beats_persisted_selected_group_witho
                             "selected_group": {
                                 "coordinator_uid": "speaker-2",
                                 "members": [
-                                    {"uid": "speaker-1", "name": "Kitchen", "last_known_host": "192.168.1.30"},
-                                    {"uid": "speaker-2", "name": "Living Room", "last_known_host": "192.168.1.40"},
+                                    {"uid": "speaker-1"},
+                                    {"uid": "speaker-2"},
                                 ],
                             },
                         },
@@ -228,8 +228,8 @@ def test_settings_service_cli_host_override_beats_persisted_selected_group(tmp_p
                             "selected_group": {
                                 "coordinator_uid": "speaker-2",
                                 "members": [
-                                    {"uid": "speaker-1", "name": "Kitchen"},
-                                    {"uid": "speaker-2", "name": "Living Room"},
+                                    {"uid": "speaker-1"},
+                                    {"uid": "speaker-2"},
                                 ],
                             },
                         },
@@ -270,8 +270,8 @@ def test_settings_service_cli_name_override_beats_persisted_selected_group_witho
                             "selected_group": {
                                 "coordinator_uid": "speaker-2",
                                 "members": [
-                                    {"uid": "speaker-1", "name": "Kitchen", "last_known_host": "192.168.1.30"},
-                                    {"uid": "speaker-2", "name": "Living Room", "last_known_host": "192.168.1.40"},
+                                    {"uid": "speaker-1"},
+                                    {"uid": "speaker-2"},
                                 ],
                             },
                         },

--- a/tests/jukebox/settings/test_sonos_runtime.py
+++ b/tests/jukebox/settings/test_sonos_runtime.py
@@ -53,8 +53,8 @@ def test_soco_sonos_group_resolver_resolves_multi_member_group_from_uids(mocker)
     selected_group = SelectedSonosGroupSettings(
         coordinator_uid="speaker-2",
         members=[
-            SelectedSonosSpeakerSettings(uid="speaker-1", name="Kitchen"),
-            SelectedSonosSpeakerSettings(uid="speaker-2", name="Living Room"),
+            SelectedSonosSpeakerSettings(uid="speaker-1"),
+            SelectedSonosSpeakerSettings(uid="speaker-2"),
         ],
     )
 
@@ -63,18 +63,16 @@ def test_soco_sonos_group_resolver_resolves_multi_member_group_from_uids(mocker)
     assert resolved_group.coordinator.uid == "speaker-2"
     assert resolved_group.coordinator.host == "192.168.1.40"
     assert [member.uid for member in resolved_group.members] == ["speaker-1", "speaker-2"]
+    assert resolved_group.missing_member_uids == []
 
 
-def test_soco_sonos_group_resolver_falls_back_to_last_known_host_for_missing_speaker(mocker):
+def test_soco_sonos_group_resolver_marks_unreachable_non_coordinator_missing(mocker):
     living_room = FakeSpeaker("speaker-1", "Living Room", "192.168.1.20", "household-1")
-    kitchen = FakeSpeaker("speaker-2", "Kitchen", "192.168.1.30", "household-1")
-    living_room.all_zones = {living_room}
-    kitchen.all_zones = {living_room, kitchen}
     mocker.patch.dict(
         "sys.modules",
         build_fake_soco_module(
             discover=lambda: {living_room},
-            soco_constructor=lambda host: {"192.168.1.20": living_room, "192.168.1.30": kitchen}[host],
+            soco_constructor=lambda host: living_room,
         ),
     )
 
@@ -82,51 +80,38 @@ def test_soco_sonos_group_resolver_falls_back_to_last_known_host_for_missing_spe
     selected_group = SelectedSonosGroupSettings(
         coordinator_uid="speaker-1",
         members=[
-            SelectedSonosSpeakerSettings(uid="speaker-1", name="Living Room"),
-            SelectedSonosSpeakerSettings(
-                uid="speaker-2",
-                name="Kitchen",
-                last_known_host="192.168.1.30",
-            ),
+            SelectedSonosSpeakerSettings(uid="speaker-1"),
+            SelectedSonosSpeakerSettings(uid="speaker-2"),
         ],
     )
 
     resolved_group = resolver.resolve_selected_group(selected_group)
 
-    assert [member.uid for member in resolved_group.members] == ["speaker-1", "speaker-2"]
+    assert [member.uid for member in resolved_group.members] == ["speaker-1"]
+    assert resolved_group.missing_member_uids == ["speaker-2"]
 
 
-def test_soco_sonos_group_resolver_falls_back_to_last_known_hosts_when_discovery_is_empty(mocker):
-    living_room = FakeSpeaker("speaker-1", "Living Room", "192.168.1.20", "household-1")
-    kitchen = FakeSpeaker("speaker-2", "Kitchen", "192.168.1.30", "household-1")
+def test_soco_sonos_group_resolver_rejects_unreachable_coordinator(mocker):
+    kitchen = FakeSpeaker("speaker-1", "Kitchen", "192.168.1.30", "household-1")
     mocker.patch.dict(
         "sys.modules",
         build_fake_soco_module(
-            discover=lambda: None,
-            soco_constructor=lambda host: {"192.168.1.20": living_room, "192.168.1.30": kitchen}[host],
+            discover=lambda: {kitchen},
+            soco_constructor=lambda host: kitchen,
         ),
     )
 
     resolver = SoCoSonosGroupResolver()
     selected_group = SelectedSonosGroupSettings(
-        coordinator_uid="speaker-1",
+        coordinator_uid="speaker-2",
         members=[
-            SelectedSonosSpeakerSettings(
-                uid="speaker-1",
-                name="Living Room",
-                last_known_host="192.168.1.20",
-            ),
-            SelectedSonosSpeakerSettings(
-                uid="speaker-2",
-                name="Kitchen",
-                last_known_host="192.168.1.30",
-            ),
+            SelectedSonosSpeakerSettings(uid="speaker-1"),
+            SelectedSonosSpeakerSettings(uid="speaker-2"),
         ],
     )
 
-    resolved_group = resolver.resolve_selected_group(selected_group)
-
-    assert [member.uid for member in resolved_group.members] == ["speaker-1", "speaker-2"]
+    with pytest.raises(ValueError, match="Unable to resolve saved Sonos coordinator|Saved Sonos coordinator"):
+        resolver.resolve_selected_group(selected_group)
 
 
 def test_soco_sonos_group_resolver_rejects_members_from_different_households(mocker):
@@ -145,68 +130,13 @@ def test_soco_sonos_group_resolver_rejects_members_from_different_households(moc
     selected_group = SelectedSonosGroupSettings(
         coordinator_uid="speaker-2",
         members=[
-            SelectedSonosSpeakerSettings(uid="speaker-1", name="Kitchen"),
-            SelectedSonosSpeakerSettings(uid="speaker-2", name="Living Room", last_known_host="192.168.1.40"),
+            SelectedSonosSpeakerSettings(uid="speaker-1"),
+            SelectedSonosSpeakerSettings(uid="speaker-2"),
         ],
     )
 
     with pytest.raises(ValueError, match="same household"):
         resolver.resolve_selected_group(selected_group)
-
-
-def test_soco_sonos_group_resolver_marks_unreachable_non_coordinator_missing_after_host_fallback_failures(mocker):
-    living_room = FakeSpeaker("speaker-1", "Living Room", "192.168.1.20", "household-1")
-    impostor = FakeSpeaker("speaker-wrong", "Impostor", "192.168.1.30", "household-1")
-    mocker.patch.dict(
-        "sys.modules",
-        build_fake_soco_module(
-            discover=lambda: {living_room},
-            soco_constructor=lambda host: {"192.168.1.20": living_room, "192.168.1.30": impostor}[host],
-        ),
-    )
-
-    resolver = SoCoSonosGroupResolver()
-    selected_group = SelectedSonosGroupSettings(
-        coordinator_uid="speaker-1",
-        members=[
-            SelectedSonosSpeakerSettings(uid="speaker-1", name="Living Room"),
-            SelectedSonosSpeakerSettings(
-                uid="speaker-2",
-                name="Kitchen",
-                last_known_host="192.168.1.30",
-            ),
-        ],
-    )
-
-    resolved_group = resolver.resolve_selected_group(selected_group)
-
-    assert [member.uid for member in resolved_group.members] == ["speaker-1"]
-    assert [member.uid for member in resolved_group.missing_members] == ["speaker-2"]
-
-
-def test_soco_sonos_group_resolver_reports_missing_non_coordinator_without_last_known_host(mocker):
-    living_room = FakeSpeaker("speaker-1", "Living Room", "192.168.1.20", "household-1")
-    mocker.patch.dict(
-        "sys.modules",
-        build_fake_soco_module(
-            discover=lambda: {living_room},
-            soco_constructor=lambda host: living_room,
-        ),
-    )
-
-    resolver = SoCoSonosGroupResolver()
-    selected_group = SelectedSonosGroupSettings(
-        coordinator_uid="speaker-1",
-        members=[
-            SelectedSonosSpeakerSettings(uid="speaker-1", name="Living Room"),
-            SelectedSonosSpeakerSettings(uid="speaker-2", name="Kitchen"),
-        ],
-    )
-
-    resolved_group = resolver.resolve_selected_group(selected_group)
-
-    assert [member.uid for member in resolved_group.members] == ["speaker-1"]
-    assert [member.uid for member in resolved_group.missing_members] == ["speaker-2"]
 
 
 def test_soco_sonos_group_resolver_wraps_discovery_errors(mocker):
@@ -221,74 +151,10 @@ def test_soco_sonos_group_resolver_wraps_discovery_errors(mocker):
     resolver = SoCoSonosGroupResolver()
     selected_group = SelectedSonosGroupSettings(
         coordinator_uid="speaker-1",
-        members=[SelectedSonosSpeakerSettings(uid="speaker-1", name="Living Room")],
+        members=[SelectedSonosSpeakerSettings(uid="speaker-1")],
     )
 
     with pytest.raises(ValueError, match="Failed to discover Sonos speakers: network unavailable"):
-        resolver.resolve_selected_group(selected_group)
-
-
-def test_soco_sonos_group_resolver_marks_non_coordinator_missing_when_host_contact_fails(mocker):
-    living_room = FakeSpeaker("speaker-1", "Living Room", "192.168.1.20", "household-1")
-
-    def raise_timeout(host):
-        raise TimeoutError(f"{host} timed out")
-
-    mocker.patch.dict(
-        "sys.modules",
-        build_fake_soco_module(
-            discover=lambda: {living_room},
-            soco_constructor=raise_timeout,
-        ),
-    )
-
-    resolver = SoCoSonosGroupResolver()
-    selected_group = SelectedSonosGroupSettings(
-        coordinator_uid="speaker-1",
-        members=[
-            SelectedSonosSpeakerSettings(uid="speaker-1", name="Living Room"),
-            SelectedSonosSpeakerSettings(
-                uid="speaker-2",
-                name="Kitchen",
-                last_known_host="192.168.1.30",
-            ),
-        ],
-    )
-
-    resolved_group = resolver.resolve_selected_group(selected_group)
-
-    assert [member.uid for member in resolved_group.members] == ["speaker-1"]
-    assert [member.uid for member in resolved_group.missing_members] == ["speaker-2"]
-
-
-def test_soco_sonos_group_resolver_rejects_unreachable_coordinator(mocker):
-    kitchen = FakeSpeaker("speaker-1", "Kitchen", "192.168.1.30", "household-1")
-
-    def raise_timeout(host):
-        raise TimeoutError(f"{host} timed out")
-
-    mocker.patch.dict(
-        "sys.modules",
-        build_fake_soco_module(
-            discover=lambda: {kitchen},
-            soco_constructor=raise_timeout,
-        ),
-    )
-
-    resolver = SoCoSonosGroupResolver()
-    selected_group = SelectedSonosGroupSettings(
-        coordinator_uid="speaker-2",
-        members=[
-            SelectedSonosSpeakerSettings(uid="speaker-1", name="Kitchen"),
-            SelectedSonosSpeakerSettings(
-                uid="speaker-2",
-                name="Living Room",
-                last_known_host="192.168.1.40",
-            ),
-        ],
-    )
-
-    with pytest.raises(ValueError, match="Unable to resolve saved Sonos coordinator"):
         resolver.resolve_selected_group(selected_group)
 
 
@@ -317,7 +183,7 @@ def test_soco_sonos_group_resolver_ignores_stale_discovered_zones_for_other_spea
     resolver = SoCoSonosGroupResolver()
     selected_group = SelectedSonosGroupSettings(
         coordinator_uid="speaker-1",
-        members=[SelectedSonosSpeakerSettings(uid="speaker-1", name="Living Room")],
+        members=[SelectedSonosSpeakerSettings(uid="speaker-1")],
     )
 
     resolved_group = resolver.resolve_selected_group(selected_group)
@@ -325,7 +191,7 @@ def test_soco_sonos_group_resolver_ignores_stale_discovered_zones_for_other_spea
     assert resolved_group.coordinator.uid == "speaker-1"
 
 
-def test_soco_sonos_group_resolver_falls_back_to_last_known_host_when_discovered_member_is_stale(mocker):
+def test_soco_sonos_group_resolver_retries_stale_discovered_member_via_discovered_ip(mocker):
     class StaleDiscoveredSpeaker:
         def __init__(self, uid, host):
             self._uid = uid
@@ -360,180 +226,51 @@ def test_soco_sonos_group_resolver_falls_back_to_last_known_host_when_discovered
     resolver = SoCoSonosGroupResolver()
     selected_group = SelectedSonosGroupSettings(
         coordinator_uid="speaker-1",
-        members=[
-            SelectedSonosSpeakerSettings(
-                uid="speaker-1",
-                name="Living Room",
-                last_known_host="192.168.1.20",
-            )
-        ],
+        members=[SelectedSonosSpeakerSettings(uid="speaker-1")],
     )
 
     resolved_group = resolver.resolve_selected_group(selected_group)
 
+    assert resolved_group.coordinator.uid == "speaker-1"
     assert resolved_group.coordinator.name == "Living Room"
 
 
-def test_soco_sonos_group_resolver_falls_back_to_last_known_host_when_discovered_ip_is_stale(mocker):
-    class StaleDiscoveredSpeaker:
-        def __init__(self, uid):
-            self._uid = uid
-            self.all_zones = {self}
-
-        @property
-        def uid(self):
-            return self._uid
-
-        @property
-        def player_name(self):
-            raise OSError("stale topology")
-
-        @property
-        def ip_address(self):
-            raise RuntimeError("stale ip")
-
-        @property
-        def household_id(self):
-            return "household-1"
-
-        def __hash__(self):
-            return hash(self._uid)
-
-    discovered_speaker = StaleDiscoveredSpeaker("speaker-1")
-    healthy_speaker = FakeSpeaker("speaker-1", "Living Room", "192.168.1.20", "household-1")
-    mocker.patch.dict(
-        "sys.modules",
-        build_fake_soco_module(
-            discover=lambda: {discovered_speaker},
-            soco_constructor=lambda host: {"192.168.1.20": healthy_speaker}[host],
-        ),
-    )
-
-    resolver = SoCoSonosGroupResolver()
-    selected_group = SelectedSonosGroupSettings(
-        coordinator_uid="speaker-1",
-        members=[
-            SelectedSonosSpeakerSettings(
-                uid="speaker-1",
-                name="Living Room",
-                last_known_host="192.168.1.20",
-            )
-        ],
-    )
-
-    resolved_group = resolver.resolve_selected_group(selected_group)
-
-    assert resolved_group.coordinator.name == "Living Room"
-
-
-def test_soco_sonos_group_resolver_falls_back_to_last_known_host_when_discovered_ip_raises_oserror(mocker):
-    class StaleDiscoveredSpeaker:
-        def __init__(self, uid):
-            self._uid = uid
-            self.all_zones = {self}
-
-        @property
-        def uid(self):
-            return self._uid
-
-        @property
-        def player_name(self):
-            raise OSError("stale topology")
-
-        @property
-        def ip_address(self):
-            raise OSError("stale ip")
-
-        @property
-        def household_id(self):
-            return "household-1"
-
-        def __hash__(self):
-            return hash(self._uid)
-
-    discovered_speaker = StaleDiscoveredSpeaker("speaker-1")
-    healthy_speaker = FakeSpeaker("speaker-1", "Living Room", "192.168.1.20", "household-1")
-    mocker.patch.dict(
-        "sys.modules",
-        build_fake_soco_module(
-            discover=lambda: {discovered_speaker},
-            soco_constructor=lambda host: {"192.168.1.20": healthy_speaker}[host],
-        ),
-    )
-
-    resolver = SoCoSonosGroupResolver()
-    selected_group = SelectedSonosGroupSettings(
-        coordinator_uid="speaker-1",
-        members=[
-            SelectedSonosSpeakerSettings(
-                uid="speaker-1",
-                name="Living Room",
-                last_known_host="192.168.1.20",
-            )
-        ],
-    )
-
-    resolved_group = resolver.resolve_selected_group(selected_group)
-
-    assert resolved_group.coordinator.name == "Living Room"
-
-
-def test_soco_sonos_group_resolver_retries_stale_discovered_member_via_discovered_ip_without_saved_host(mocker):
-    class StaleDiscoveredSpeaker:
-        def __init__(self, uid, host):
-            self._uid = uid
-            self.ip_address = host
-            self.all_zones = {self}
-
-        @property
-        def uid(self):
-            return self._uid
-
-        @property
-        def player_name(self):
-            raise OSError("stale topology")
-
-        @property
-        def household_id(self):
-            return "household-1"
-
-        def __hash__(self):
-            return hash((self._uid, self.ip_address))
-
-    discovered_speaker = StaleDiscoveredSpeaker("speaker-1", "192.168.1.20")
-    healthy_speaker = FakeSpeaker("speaker-1", "Living Room", "192.168.1.20", "household-1")
-    mocker.patch.dict(
-        "sys.modules",
-        build_fake_soco_module(
-            discover=lambda: {discovered_speaker},
-            soco_constructor=lambda host: {"192.168.1.20": healthy_speaker}[host],
-        ),
-    )
-
-    resolver = SoCoSonosGroupResolver()
-    selected_group = SelectedSonosGroupSettings(
-        coordinator_uid="speaker-1",
-        members=[SelectedSonosSpeakerSettings(uid="speaker-1", name="Living Room")],
-    )
-
-    resolved_group = resolver.resolve_selected_group(selected_group)
-
-    assert resolved_group.coordinator.name == "Living Room"
-
-
-def test_soco_sonos_group_resolver_marks_non_coordinator_missing_when_host_uid_resolution_breaks(mocker):
+def test_soco_sonos_group_resolver_marks_non_coordinator_missing_when_discovered_retry_fails(mocker):
     living_room = FakeSpeaker("speaker-1", "Living Room", "192.168.1.20", "household-1")
 
-    class BrokenHostSpeaker:
+    class StaleDiscoveredSpeaker:
+        def __init__(self, uid, host):
+            self._uid = uid
+            self.ip_address = host
+            self.all_zones = {self}
+
         @property
         def uid(self):
-            raise RuntimeError("uid exploded")
+            return self._uid
+
+        @property
+        def player_name(self):
+            raise OSError("stale topology")
+
+        @property
+        def household_id(self):
+            return "household-1"
+
+        def __hash__(self):
+            return hash((self._uid, self.ip_address))
+
+    stale_kitchen = StaleDiscoveredSpeaker("speaker-2", "192.168.1.30")
+
+    def raise_timeout(host):
+        if host == "192.168.1.30":
+            raise TimeoutError("192.168.1.30 timed out")
+        return living_room
 
     mocker.patch.dict(
         "sys.modules",
         build_fake_soco_module(
-            discover=lambda: {living_room},
-            soco_constructor=lambda host: BrokenHostSpeaker(),
+            discover=lambda: {living_room, stale_kitchen},
+            soco_constructor=raise_timeout,
         ),
     )
 
@@ -541,20 +278,31 @@ def test_soco_sonos_group_resolver_marks_non_coordinator_missing_when_host_uid_r
     selected_group = SelectedSonosGroupSettings(
         coordinator_uid="speaker-1",
         members=[
-            SelectedSonosSpeakerSettings(
-                uid="speaker-1",
-                name="Living Room",
-                last_known_host="192.168.1.20",
-            ),
-            SelectedSonosSpeakerSettings(
-                uid="speaker-2",
-                name="Kitchen",
-                last_known_host="192.168.1.30",
-            ),
+            SelectedSonosSpeakerSettings(uid="speaker-1"),
+            SelectedSonosSpeakerSettings(uid="speaker-2"),
         ],
     )
 
     resolved_group = resolver.resolve_selected_group(selected_group)
 
     assert [member.uid for member in resolved_group.members] == ["speaker-1"]
-    assert [member.uid for member in resolved_group.missing_members] == ["speaker-2"]
+    assert resolved_group.missing_member_uids == ["speaker-2"]
+
+
+def test_soco_sonos_group_resolver_rejects_missing_coordinator_when_discovery_is_empty(mocker):
+    mocker.patch.dict(
+        "sys.modules",
+        build_fake_soco_module(
+            discover=lambda: None,
+            soco_constructor=lambda host: None,
+        ),
+    )
+
+    resolver = SoCoSonosGroupResolver()
+    selected_group = SelectedSonosGroupSettings(
+        coordinator_uid="speaker-1",
+        members=[SelectedSonosSpeakerSettings(uid="speaker-1")],
+    )
+
+    with pytest.raises(ValueError, match="speaker-1: not found on network"):
+        resolver.resolve_selected_group(selected_group)

--- a/tests/jukebox/test_jukebox_app.py
+++ b/tests/jukebox/test_jukebox_app.py
@@ -131,7 +131,7 @@ def test_build_settings_service_reads_persisted_reader_and_timing_settings(tmp_p
 def test_build_settings_service_reads_persisted_selected_group_target(tmp_path, mocker):
     settings_path = tmp_path / "settings.json"
     settings_path.write_text(
-        '{"schema_version": 1, "jukebox": {"player": {"type": "sonos", "sonos": {"selected_group": {"coordinator_uid": "speaker-2", "members": [{"uid": "speaker-1", "name": "Kitchen", "last_known_host": "192.168.1.30"}, {"uid": "speaker-2", "name": "Living Room", "last_known_host": "192.168.1.40"}]}}}}}',
+        '{"schema_version": 1, "jukebox": {"player": {"type": "sonos", "sonos": {"selected_group": {"coordinator_uid": "speaker-2", "members": [{"uid": "speaker-1"}, {"uid": "speaker-2"}]}}}}}',
         encoding="utf-8",
     )
     mocker.patch("jukebox.app.FileSettingsRepository", return_value=FileSettingsRepository(str(settings_path)))


### PR DESCRIPTION
## Summary

This PR tightens the persisted Sonos `selected_group` contract so it stores only durable speaker identity.

Previously, `jukebox.player.sonos.selected_group` mixed user-managed selection with runtime-ish metadata like speaker `name`, `household_id`, and `last_known_host`. This change makes persisted selection UID-only and removes the remaining saved-host fallback behavior from runtime resolution.

After this change, persisted `selected_group` contains only:

```json
{
  "coordinator_uid": "speaker-2",
  "members": [
    { "uid": "speaker-1" },
    { "uid": "speaker-2" }
  ]
}
```

This is a schema break. Old branch-local `selected_group` payloads that still contain `name`, `household_id`, or `last_known_host` are now invalid. There is no migration in this PR (happy to introduce a migration script and bump `schema_version`, if needed).

## What Changed

- Tightened Sonos selection models to UID-only speaker/member shape.
- Removed persisted `household_id` from `selected_group`.
- Removed all saved `last_known_host` fallback behavior from Sonos runtime group resolution.
- Changed partial-group runtime state from persisted speaker objects to `missing_member_uids`.
- Updated partial-group logging/warnings to report unresolved member UIDs.
- Updated settings mutation and file-validation coverage to reject legacy `selected_group` payloads.
- Reworked Sonos runtime tests around the new UID-only and no-saved-fallback behavior.

## Runtime Behavior

- Group resolution still resolves selected members by discovered speaker UID.
- If a non-coordinator member cannot be resolved, startup can continue with a partial group and that member is tracked in `missing_member_uids`.
- If the coordinator cannot be resolved, startup fails.
- If resolved members span more than one runtime Sonos household, startup fails. (can relax this in a future update)
- There is no longer any persisted host fallback.

## Why

This keeps persisted settings focused on durable user intent instead of cached runtime state.

`selected_group` should answer:
- which speaker is the coordinator?
- which speakers should belong to the group?

It should not also act as:
- a display-name cache
- a household snapshot
- a saved network recovery mechanism

Future UI / CLI name-based selection should come from a separate live Sonos inventory/read path that maps speaker names to UIDs before writing the UID-only selection back to settings.

## Notes

This is strictly worse CLI UX, since now we can't output/display unreachable speaker names easily.  We can resolve this in a followup by adding a Sonos topology cache, which is managed separately from the settings.