### PR TITLE
Sonos speaker selection in CLI and API

### DIFF
--- a/discstore/adapters/inbound/api_controller.py
+++ b/discstore/adapters/inbound/api_controller.py
@@ -19,10 +19,11 @@ from discstore.domain.use_cases.list_discs import ListDiscs
 from discstore.domain.use_cases.remove_disc import RemoveDisc
 from jukebox.settings.entities import SelectedSonosGroupSettings
 from jukebox.settings.errors import SettingsError
+from jukebox.settings.selected_sonos_group_repository import SettingsSelectedSonosGroupRepository
 from jukebox.settings.service_protocols import SettingsService
 from jukebox.settings.types import JsonObject
 from jukebox.sonos.discovery import DiscoveredSonosSpeaker, SonosDiscoveryError
-from jukebox.sonos.selection import GetSonosSelectionStatus, SelectDefaultSonosSpeaker
+from jukebox.sonos.selection import GetSonosSelectionStatus, PlanSonosSelection, SaveSonosSelection
 from jukebox.sonos.service import SonosService
 
 
@@ -130,7 +131,10 @@ class APIController:
         @self.app.get("/api/v1/sonos/selection", response_model=SonosSelectionOutput)
         def get_sonos_selection():
             try:
-                return GetSonosSelectionStatus(self.settings_service, self.sonos_service).execute()
+                return GetSonosSelectionStatus(
+                    SettingsSelectedSonosGroupRepository(self.settings_service),
+                    self.sonos_service,
+                ).execute()
             except SonosDiscoveryError as err:
                 raise HTTPException(status_code=502, detail=str(err))
             except Exception as err:
@@ -139,13 +143,22 @@ class APIController:
         @self.app.put("/api/v1/sonos/selection", response_model=SonosSelectionUpdateOutput)
         def put_sonos_selection(payload: SonosSelectionInput):
             try:
-                if len(payload.uids) != 1:
-                    raise HTTPException(status_code=400, detail="`uids` must contain exactly one UID in this phase.")
+                plan = PlanSonosSelection(self.sonos_service).execute(requested_uids=payload.uids)
+                if plan.status in {"invalid_request", "none_available"}:
+                    raise HTTPException(status_code=400, detail=str(plan.error_message))
+                if plan.status == "needs_choice" or plan.selected_uid is None:
+                    raise HTTPException(status_code=400, detail="No Sonos speaker selection was made.")
 
-                result = SelectDefaultSonosSpeaker(self.settings_service, self.sonos_service).execute(payload.uids[0])
+                result = SaveSonosSelection(
+                    SettingsSelectedSonosGroupRepository(self.settings_service),
+                    self.sonos_service,
+                ).execute(plan.selected_uid)
                 return SonosSelectionUpdateOutput(
-                    selected_group=result.selected_group,
-                    availability=SonosSelectionAvailabilityOutput(status="available", speaker=result.speaker),
+                    selected_group=SelectedSonosGroupOutput(**result.selected_group.model_dump()),
+                    availability=SonosSelectionAvailabilityOutput(
+                        status="available",
+                        speaker=SonosSpeakerOutput(**result.speaker.model_dump()),
+                    ),
                     message=result.settings_message,
                     restart_required=result.restart_required,
                 )

--- a/discstore/adapters/inbound/api_controller.py
+++ b/discstore/adapters/inbound/api_controller.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, cast
+from typing import Any, Dict, Optional, cast
 
 from pydantic import BaseModel, RootModel
 
@@ -17,10 +17,12 @@ from discstore.domain.use_cases.edit_disc import EditDisc
 from discstore.domain.use_cases.get_current_tag_status import GetCurrentTagStatus
 from discstore.domain.use_cases.list_discs import ListDiscs
 from discstore.domain.use_cases.remove_disc import RemoveDisc
+from jukebox.settings.entities import SelectedSonosGroupSettings
 from jukebox.settings.errors import SettingsError
 from jukebox.settings.service_protocols import SettingsService
 from jukebox.settings.types import JsonObject
 from jukebox.sonos.discovery import DiscoveredSonosSpeaker, SonosDiscoveryError
+from jukebox.sonos.selection import GetSonosSelectionStatus, SelectDefaultSonosSpeaker
 from jukebox.sonos.service import SonosService
 
 
@@ -38,6 +40,31 @@ class CurrentTagStatusOutput(CurrentTagStatus):
 
 class SonosSpeakerOutput(DiscoveredSonosSpeaker):
     pass
+
+
+class SelectedSonosGroupOutput(SelectedSonosGroupSettings):
+    pass
+
+
+class SonosSelectionAvailabilityOutput(BaseModel):
+    status: str
+    speaker: Optional[SonosSpeakerOutput] = None
+
+
+class SonosSelectionOutput(BaseModel):
+    selected_group: Optional[SelectedSonosGroupOutput] = None
+    availability: SonosSelectionAvailabilityOutput
+
+
+class SonosSelectionInput(BaseModel):
+    uids: list[str]
+
+
+class SonosSelectionUpdateOutput(BaseModel):
+    selected_group: SelectedSonosGroupOutput
+    availability: SonosSelectionAvailabilityOutput
+    message: str
+    restart_required: bool
 
 
 class SettingsResetInput(BaseModel):
@@ -97,6 +124,37 @@ class APIController:
                 return self.sonos_service.list_available_speakers()
             except SonosDiscoveryError as err:
                 raise HTTPException(status_code=502, detail=str(err))
+            except Exception as err:
+                raise HTTPException(status_code=500, detail=f"Server error: {str(err)}")
+
+        @self.app.get("/api/v1/sonos/selection", response_model=SonosSelectionOutput)
+        def get_sonos_selection():
+            try:
+                return GetSonosSelectionStatus(self.settings_service, self.sonos_service).execute()
+            except SonosDiscoveryError as err:
+                raise HTTPException(status_code=502, detail=str(err))
+            except Exception as err:
+                raise HTTPException(status_code=500, detail=f"Server error: {str(err)}")
+
+        @self.app.put("/api/v1/sonos/selection", response_model=SonosSelectionUpdateOutput)
+        def put_sonos_selection(payload: SonosSelectionInput):
+            try:
+                if len(payload.uids) != 1:
+                    raise HTTPException(status_code=400, detail="`uids` must contain exactly one UID in this phase.")
+
+                result = SelectDefaultSonosSpeaker(self.settings_service, self.sonos_service).execute(payload.uids[0])
+                return SonosSelectionUpdateOutput(
+                    selected_group=result.selected_group,
+                    availability=SonosSelectionAvailabilityOutput(status="available", speaker=result.speaker),
+                    message=result.settings_message,
+                    restart_required=result.restart_required,
+                )
+            except SonosDiscoveryError as err:
+                raise HTTPException(status_code=502, detail=str(err))
+            except ValueError as err:
+                raise HTTPException(status_code=400, detail=str(err))
+            except HTTPException:
+                raise
             except Exception as err:
                 raise HTTPException(status_code=500, detail=f"Server error: {str(err)}")
 

--- a/jukebox/admin/app.py
+++ b/jukebox/admin/app.py
@@ -20,8 +20,9 @@ from discstore.di_container import build_cli_controller, build_interactive_cli_c
 from jukebox.settings.errors import SettingsError
 from jukebox.shared.config_utils import get_package_version
 from jukebox.shared.logger import set_logger
+from jukebox.sonos.discovery import DiscoveredSonosSpeaker
 
-from .cli_presentation import render_cli_error
+from .cli_presentation import build_sonos_speaker_choice_label, render_cli_error
 from .command_handlers import execute_server_command, execute_settings_command, execute_sonos_command
 from .commands import (
     ApiCommand,
@@ -29,6 +30,8 @@ from .commands import (
     SettingsSetCommand,
     SettingsShowCommand,
     SonosListCommand,
+    SonosSelectCommand,
+    SonosShowCommand,
     UiCommand,
     is_settings_command,
     is_sonos_command,
@@ -74,7 +77,12 @@ def _run_command(ctx: typer.Context, command: object) -> None:
                     source_command="jukebox-admin",
                 )
             elif is_sonos_command(command):
-                execute_sonos_command(command=command, sonos_service=services.sonos)
+                execute_sonos_command(
+                    command=command,
+                    sonos_service=services.sonos,
+                    settings_service=services.settings,
+                    speaker_prompt_fn=_prompt_for_sonos_speaker_selection,
+                )
             else:
                 execute_server_command(
                     verbose=state.verbose,
@@ -146,10 +154,28 @@ def _exit_on_command_validation_error(err: ValidationError) -> None:
     raise SystemExit(str(err)) from err
 
 
+def _prompt_for_sonos_speaker_selection(speakers: list[DiscoveredSonosSpeaker]) -> Optional[str]:
+    import questionary
+
+    try:
+        return questionary.select(
+            "Select a Sonos speaker",
+            choices=[
+                questionary.Choice(
+                    title=build_sonos_speaker_choice_label(speaker),
+                    value=speaker.uid,
+                )
+                for speaker in speakers
+            ],
+        ).ask()
+    except KeyboardInterrupt:
+        return None
+
+
 app = typer.Typer(help="Admin CLI for jukebox")
 settings_app = typer.Typer(help="Inspect and manage application settings")
 library_app = typer.Typer(help="Manage the library")
-sonos_app = typer.Typer(help="Inspect Sonos speakers discovered on the network")
+sonos_app = typer.Typer(help="Inspect Sonos speakers and manage the saved Sonos selection")
 app.add_typer(settings_app, name="settings")
 app.add_typer(library_app, name="library")
 app.add_typer(sonos_app, name="sonos")
@@ -261,6 +287,22 @@ def ui(
 @sonos_app.command("list")
 def sonos_list(ctx: typer.Context) -> None:
     _run_command(ctx, SonosListCommand(type="sonos_list"))
+
+
+@sonos_app.command("select")
+def sonos_select(
+    ctx: typer.Context,
+    uids: Annotated[
+        Optional[list[str]],
+        typer.Option("--uids", help="discover and persist exactly one Sonos speaker UID"),
+    ] = None,
+) -> None:
+    _run_command(ctx, SonosSelectCommand(type="sonos_select", uids=uids))
+
+
+@sonos_app.command("show")
+def sonos_show(ctx: typer.Context) -> None:
+    _run_command(ctx, SonosShowCommand(type="sonos_show"))
 
 
 @library_app.command("add")

--- a/jukebox/admin/cli_presentation.py
+++ b/jukebox/admin/cli_presentation.py
@@ -13,6 +13,7 @@ from jukebox.settings.errors import (
 from jukebox.settings.types import JsonObject, JsonValue
 from jukebox.settings.view_utils import MISSING, lookup_object, lookup_optional_dotted_path, lookup_provenance_label
 from jukebox.sonos.discovery import DiscoveredSonosSpeaker
+from jukebox.sonos.selection import SonosSelectionResult, SonosSelectionStatus
 
 from .commands import SettingsResetCommand, SettingsSetCommand, SettingsShowCommand
 
@@ -71,6 +72,39 @@ def render_sonos_speakers_output(speakers: list[DiscoveredSonosSpeaker]) -> str:
         )
         for index, speaker in enumerate(speakers, start=1)
     )
+
+
+def build_sonos_speaker_choice_label(speaker: DiscoveredSonosSpeaker) -> str:
+    return "{} ({})".format(speaker.name, speaker.host)
+
+
+def render_sonos_selection_saved_output(result: SonosSelectionResult) -> str:
+    return "\n".join(
+        [
+            "Selected Sonos speaker: {}".format(result.speaker.name),
+            "UID: {}".format(result.speaker.uid),
+            result.settings_message,
+        ]
+    )
+
+
+def render_sonos_selection_status_output(status: SonosSelectionStatus) -> str:
+    lines = ["Selected Sonos Speaker", ""]
+
+    if status.selected_group is None:
+        lines.append("- Status: not selected")
+        return "\n".join(lines)
+
+    lines.append("- UID: {}".format(status.selected_group.coordinator_uid))
+    lines.append("- Status: {}".format(status.availability.status))
+
+    speaker = status.availability.speaker
+    if speaker is not None:
+        lines.append("- Name: {}".format(speaker.name))
+        lines.append("- Host: {}".format(speaker.host))
+        lines.append("- Household: {}".format(speaker.household_id))
+
+    return "\n".join(lines)
 
 
 def _render_persisted_settings(payload: JsonObject) -> str:

--- a/jukebox/admin/command_handlers.py
+++ b/jukebox/admin/command_handlers.py
@@ -2,10 +2,11 @@ import sys
 from importlib import import_module
 from typing import Callable, Optional, Protocol
 
+from jukebox.settings.selected_sonos_group_repository import SettingsSelectedSonosGroupRepository
 from jukebox.settings.service_protocols import SettingsService
 from jukebox.shared.dependency_messages import optional_extra_dependency_message
 from jukebox.sonos.discovery import DiscoveredSonosSpeaker
-from jukebox.sonos.selection import GetSonosSelectionStatus, SelectDefaultSonosSpeaker
+from jukebox.sonos.selection import GetSonosSelectionStatus, PlanSonosSelection, SaveSonosSelection
 from jukebox.sonos.service import SonosService
 
 from .cli_presentation import (
@@ -118,18 +119,26 @@ def execute_sonos_command(
         if settings_service is None:
             raise TypeError("settings_service is required for Sonos select commands")
 
-        selected_uid = _resolve_sonos_selected_uid(
-            command=command,
-            sonos_service=sonos_service,
-            speaker_prompt_fn=speaker_prompt_fn,
-        )
+        plan = PlanSonosSelection(sonos_service=sonos_service).execute(requested_uids=command.uids)
+        if plan.status in {"invalid_request", "none_available"}:
+            raise RuntimeError(str(plan.error_message))
+
+        selected_uid = plan.selected_uid
+        if plan.status == "needs_choice":
+            if speaker_prompt_fn is None:
+                raise RuntimeError("Interactive Sonos speaker selection is not available in this context.")
+            selected_uid = speaker_prompt_fn(plan.speakers)
+            if selected_uid is None:
+                return
+
         if selected_uid is None:
-            return
+            raise RuntimeError("No Sonos speaker selection was made.")
 
         try:
-            result = SelectDefaultSonosSpeaker(settings_service=settings_service, sonos_service=sonos_service).execute(
-                selected_uid
-            )
+            result = SaveSonosSelection(
+                selected_group_repository=SettingsSelectedSonosGroupRepository(settings_service),
+                sonos_service=sonos_service,
+            ).execute(selected_uid)
         except ValueError as err:
             raise RuntimeError(str(err)) from err
         stdout_fn(render_sonos_selection_saved_output(result))
@@ -139,38 +148,14 @@ def execute_sonos_command(
         if settings_service is None:
             raise TypeError("settings_service is required for Sonos show commands")
 
-        status = GetSonosSelectionStatus(settings_service=settings_service, sonos_service=sonos_service).execute()
+        status = GetSonosSelectionStatus(
+            selected_group_repository=SettingsSelectedSonosGroupRepository(settings_service),
+            sonos_service=sonos_service,
+        ).execute()
         stdout_fn(render_sonos_selection_status_output(status))
         return
 
     raise TypeError("Unsupported Sonos command")
-
-
-def _resolve_sonos_selected_uid(
-    command: SonosSelectCommand,
-    sonos_service: SonosService,
-    speaker_prompt_fn: Optional[Callable[[list[DiscoveredSonosSpeaker]], Optional[str]]],
-) -> Optional[str]:
-    available_speakers = sonos_service.list_available_speakers()
-    if command.uids:
-        if len(command.uids) != 1:
-            raise RuntimeError("`jukebox-admin sonos select --uids` requires exactly one UID in this phase.")
-
-        selected_uid = command.uids[0]
-        if selected_uid not in {speaker.uid for speaker in available_speakers}:
-            raise RuntimeError("Selected Sonos speaker is not currently discoverable: {}".format(selected_uid))
-        return selected_uid
-
-    if not available_speakers:
-        raise RuntimeError("No visible Sonos speakers found.")
-
-    if len(available_speakers) == 1:
-        return available_speakers[0].uid
-
-    if speaker_prompt_fn is None:
-        raise RuntimeError("Interactive Sonos speaker selection is not available in this context.")
-
-    return speaker_prompt_fn(available_speakers)
 
 
 def execute_server_command(

--- a/jukebox/admin/command_handlers.py
+++ b/jukebox/admin/command_handlers.py
@@ -4,11 +4,15 @@ from typing import Callable, Optional, Protocol
 
 from jukebox.settings.service_protocols import SettingsService
 from jukebox.shared.dependency_messages import optional_extra_dependency_message
+from jukebox.sonos.discovery import DiscoveredSonosSpeaker
+from jukebox.sonos.selection import GetSonosSelectionStatus, SelectDefaultSonosSpeaker
 from jukebox.sonos.service import SonosService
 
 from .cli_presentation import (
     build_discstore_settings_deprecation_warning,
     render_settings_output,
+    render_sonos_selection_saved_output,
+    render_sonos_selection_status_output,
     render_sonos_speakers_output,
 )
 from .commands import (
@@ -17,6 +21,8 @@ from .commands import (
     SettingsSetCommand,
     SettingsShowCommand,
     SonosListCommand,
+    SonosSelectCommand,
+    SonosShowCommand,
     UiCommand,
 )
 from .services import AdminServices
@@ -100,13 +106,71 @@ def execute_settings_command(
 def execute_sonos_command(
     command: object,
     sonos_service: SonosService,
+    settings_service: Optional[SettingsService] = None,
+    speaker_prompt_fn: Optional[Callable[[list[DiscoveredSonosSpeaker]], Optional[str]]] = None,
     stdout_fn: Callable[[str], None] = print,
 ) -> None:
     if isinstance(command, SonosListCommand):
         stdout_fn(render_sonos_speakers_output(sonos_service.list_available_speakers()))
         return
 
+    if isinstance(command, SonosSelectCommand):
+        if settings_service is None:
+            raise TypeError("settings_service is required for Sonos select commands")
+
+        selected_uid = _resolve_sonos_selected_uid(
+            command=command,
+            sonos_service=sonos_service,
+            speaker_prompt_fn=speaker_prompt_fn,
+        )
+        if selected_uid is None:
+            return
+
+        try:
+            result = SelectDefaultSonosSpeaker(settings_service=settings_service, sonos_service=sonos_service).execute(
+                selected_uid
+            )
+        except ValueError as err:
+            raise RuntimeError(str(err)) from err
+        stdout_fn(render_sonos_selection_saved_output(result))
+        return
+
+    if isinstance(command, SonosShowCommand):
+        if settings_service is None:
+            raise TypeError("settings_service is required for Sonos show commands")
+
+        status = GetSonosSelectionStatus(settings_service=settings_service, sonos_service=sonos_service).execute()
+        stdout_fn(render_sonos_selection_status_output(status))
+        return
+
     raise TypeError("Unsupported Sonos command")
+
+
+def _resolve_sonos_selected_uid(
+    command: SonosSelectCommand,
+    sonos_service: SonosService,
+    speaker_prompt_fn: Optional[Callable[[list[DiscoveredSonosSpeaker]], Optional[str]]],
+) -> Optional[str]:
+    available_speakers = sonos_service.list_available_speakers()
+    if command.uids:
+        if len(command.uids) != 1:
+            raise RuntimeError("`jukebox-admin sonos select --uids` requires exactly one UID in this phase.")
+
+        selected_uid = command.uids[0]
+        if selected_uid not in {speaker.uid for speaker in available_speakers}:
+            raise RuntimeError("Selected Sonos speaker is not currently discoverable: {}".format(selected_uid))
+        return selected_uid
+
+    if not available_speakers:
+        raise RuntimeError("No visible Sonos speakers found.")
+
+    if len(available_speakers) == 1:
+        return available_speakers[0].uid
+
+    if speaker_prompt_fn is None:
+        raise RuntimeError("Interactive Sonos speaker selection is not available in this context.")
+
+    return speaker_prompt_fn(available_speakers)
 
 
 def execute_server_command(

--- a/jukebox/admin/commands.py
+++ b/jukebox/admin/commands.py
@@ -22,6 +22,15 @@ class SonosListCommand(BaseModel):
     type: Literal["sonos_list"]
 
 
+class SonosSelectCommand(BaseModel):
+    type: Literal["sonos_select"]
+    uids: Optional[list[str]] = None
+
+
+class SonosShowCommand(BaseModel):
+    type: Literal["sonos_show"]
+
+
 class SettingsShowCommand(BaseModel):
     type: Literal["settings_show"]
     effective: bool = False
@@ -47,6 +56,8 @@ AdminCommand = Union[
     SettingsSetCommand,
     SettingsShowCommand,
     SonosListCommand,
+    SonosSelectCommand,
+    SonosShowCommand,
     UiCommand,
 ]
 
@@ -60,6 +71,8 @@ def is_admin_command(command: object) -> bool:
             SettingsSetCommand,
             SettingsShowCommand,
             SonosListCommand,
+            SonosSelectCommand,
+            SonosShowCommand,
             UiCommand,
         ),
     )
@@ -77,4 +90,4 @@ def is_settings_command(command: object) -> bool:
 
 
 def is_sonos_command(command: object) -> bool:
-    return isinstance(command, SonosListCommand)
+    return isinstance(command, (SonosListCommand, SonosSelectCommand, SonosShowCommand))

--- a/jukebox/settings/selected_sonos_group_repository.py
+++ b/jukebox/settings/selected_sonos_group_repository.py
@@ -1,0 +1,60 @@
+from typing import Optional
+
+from jukebox.sonos.selection import (
+    SaveSelectedSonosGroupResult,
+    SelectedSonosGroupRepository,
+)
+
+from .entities import SelectedSonosGroupSettings
+from .service_protocols import SettingsService
+from .types import JsonObject
+
+
+class SettingsSelectedSonosGroupRepository(SelectedSonosGroupRepository):
+    def __init__(self, settings_service: SettingsService):
+        self.settings_service = settings_service
+
+    def get_selected_group(self) -> Optional[SelectedSonosGroupSettings]:
+        persisted = self.settings_service.get_persisted_settings_view()
+        selected_group_data = _lookup_selected_group(persisted)
+        if selected_group_data is None:
+            return None
+        return SelectedSonosGroupSettings.model_validate(selected_group_data)
+
+    def save_selected_group(self, selected_group: SelectedSonosGroupSettings) -> SaveSelectedSonosGroupResult:
+        settings_result = self.settings_service.patch_persisted_settings(
+            {
+                "jukebox": {
+                    "player": {
+                        "type": "sonos",
+                        "sonos": {
+                            "selected_group": selected_group.model_dump(mode="python"),
+                        },
+                    }
+                }
+            }
+        )
+        return SaveSelectedSonosGroupResult(
+            message=str(settings_result.get("message", "Settings saved.")),
+            restart_required=bool(settings_result.get("restart_required", False)),
+        )
+
+
+def _lookup_selected_group(persisted: JsonObject) -> Optional[JsonObject]:
+    jukebox_settings = persisted.get("jukebox")
+    if not isinstance(jukebox_settings, dict):
+        return None
+
+    player_settings = jukebox_settings.get("player")
+    if not isinstance(player_settings, dict):
+        return None
+
+    sonos_settings = player_settings.get("sonos")
+    if not isinstance(sonos_settings, dict):
+        return None
+
+    selected_group = sonos_settings.get("selected_group")
+    if not isinstance(selected_group, dict):
+        return None
+
+    return selected_group

--- a/jukebox/sonos/__init__.py
+++ b/jukebox/sonos/__init__.py
@@ -4,13 +4,25 @@ from .discovery import (
     SonosDiscoveryPort,
     sort_sonos_speakers,
 )
+from .selection import (
+    GetSonosSelectionStatus,
+    SelectDefaultSonosSpeaker,
+    SonosSelectionAvailability,
+    SonosSelectionResult,
+    SonosSelectionStatus,
+)
 from .service import DefaultSonosService, SonosService
 
 __all__ = [
     "DefaultSonosService",
     "DiscoveredSonosSpeaker",
+    "GetSonosSelectionStatus",
+    "SelectDefaultSonosSpeaker",
     "SonosDiscoveryError",
     "SonosDiscoveryPort",
+    "SonosSelectionAvailability",
+    "SonosSelectionResult",
+    "SonosSelectionStatus",
     "SonosService",
     "sort_sonos_speakers",
 ]

--- a/jukebox/sonos/__init__.py
+++ b/jukebox/sonos/__init__.py
@@ -6,8 +6,10 @@ from .discovery import (
 )
 from .selection import (
     GetSonosSelectionStatus,
-    SelectDefaultSonosSpeaker,
+    PlanSonosSelection,
+    SaveSonosSelection,
     SonosSelectionAvailability,
+    SonosSelectionPlan,
     SonosSelectionResult,
     SonosSelectionStatus,
 )
@@ -17,10 +19,12 @@ __all__ = [
     "DefaultSonosService",
     "DiscoveredSonosSpeaker",
     "GetSonosSelectionStatus",
-    "SelectDefaultSonosSpeaker",
+    "PlanSonosSelection",
+    "SaveSonosSelection",
     "SonosDiscoveryError",
     "SonosDiscoveryPort",
     "SonosSelectionAvailability",
+    "SonosSelectionPlan",
     "SonosSelectionResult",
     "SonosSelectionStatus",
     "SonosService",

--- a/jukebox/sonos/selection.py
+++ b/jukebox/sonos/selection.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Protocol
 
 try:
     from typing import Literal
@@ -11,8 +11,6 @@ from jukebox.settings.entities import (
     SelectedSonosGroupSettings,
     SelectedSonosSpeakerSettings,
 )
-from jukebox.settings.service_protocols import ReadOnlySettingsService, SettingsService
-from jukebox.settings.types import JsonObject
 
 from .discovery import DiscoveredSonosSpeaker
 from .service import SonosService
@@ -45,9 +43,60 @@ class SonosSelectionResult(StrictModel):
     restart_required: bool = False
 
 
-class SelectDefaultSonosSpeaker:
-    def __init__(self, settings_service: SettingsService, sonos_service: SonosService):
-        self.settings_service = settings_service
+class SaveSelectedSonosGroupResult(StrictModel):
+    message: str = "Settings saved."
+    restart_required: bool = False
+
+
+class SelectedSonosGroupRepository(Protocol):
+    def get_selected_group(self) -> Optional[SelectedSonosGroupSettings]: ...
+
+    def save_selected_group(self, selected_group: SelectedSonosGroupSettings) -> SaveSelectedSonosGroupResult: ...
+
+
+class SonosSelectionPlan(StrictModel):
+    status: Literal["resolved", "needs_choice", "invalid_request", "none_available"]
+    selected_uid: Optional[str] = None
+    speakers: list[DiscoveredSonosSpeaker] = []
+    error_message: Optional[str] = None
+
+
+class PlanSonosSelection:
+    def __init__(self, sonos_service: SonosService):
+        self.sonos_service = sonos_service
+
+    def execute(self, requested_uids: Optional[list[str]] = None) -> SonosSelectionPlan:
+        available_speakers = self.sonos_service.list_available_speakers()
+        if requested_uids is not None:
+            if len(requested_uids) != 1:
+                return SonosSelectionPlan(
+                    status="invalid_request",
+                    error_message="`uids` must contain exactly one UID in this phase.",
+                )
+
+            selected_uid = requested_uids[0]
+            if selected_uid not in {speaker.uid for speaker in available_speakers}:
+                return SonosSelectionPlan(
+                    status="invalid_request",
+                    error_message="Selected Sonos speaker is not currently discoverable: {}".format(selected_uid),
+                )
+            return SonosSelectionPlan(status="resolved", selected_uid=selected_uid)
+
+        if not available_speakers:
+            return SonosSelectionPlan(
+                status="none_available",
+                error_message="No visible Sonos speakers found.",
+            )
+
+        if len(available_speakers) == 1:
+            return SonosSelectionPlan(status="resolved", selected_uid=available_speakers[0].uid)
+
+        return SonosSelectionPlan(status="needs_choice", speakers=available_speakers)
+
+
+class SaveSonosSelection:
+    def __init__(self, selected_group_repository: SelectedSonosGroupRepository, sonos_service: SonosService):
+        self.selected_group_repository = selected_group_repository
         self.sonos_service = sonos_service
 
     def execute(self, uid: str) -> SonosSelectionResult:
@@ -60,41 +109,28 @@ class SelectDefaultSonosSpeaker:
             coordinator_uid=uid,
             members=[SelectedSonosSpeakerSettings(uid=uid)],
         )
-        settings_result = self.settings_service.patch_persisted_settings(
-            {
-                "jukebox": {
-                    "player": {
-                        "type": "sonos",
-                        "sonos": {
-                            "selected_group": selected_group.model_dump(mode="python"),
-                        },
-                    }
-                }
-            }
-        )
+        settings_result = self.selected_group_repository.save_selected_group(selected_group)
         return SonosSelectionResult(
             speaker=speaker,
             selected_group=selected_group,
-            settings_message=str(settings_result.get("message", "Settings saved.")),
-            restart_required=bool(settings_result.get("restart_required", False)),
+            settings_message=settings_result.message,
+            restart_required=settings_result.restart_required,
         )
 
 
 class GetSonosSelectionStatus:
-    def __init__(self, settings_service: ReadOnlySettingsService, sonos_service: SonosService):
-        self.settings_service = settings_service
+    def __init__(self, selected_group_repository: SelectedSonosGroupRepository, sonos_service: SonosService):
+        self.selected_group_repository = selected_group_repository
         self.sonos_service = sonos_service
 
     def execute(self) -> SonosSelectionStatus:
-        persisted = self.settings_service.get_persisted_settings_view()
-        selected_group_data = _lookup_selected_group(persisted)
-        if selected_group_data is None:
+        selected_group = self.selected_group_repository.get_selected_group()
+        if selected_group is None:
             return SonosSelectionStatus(
                 selected_group=None,
                 availability=SonosSelectionAvailability(status="not_selected", speaker=None),
             )
 
-        selected_group = SelectedSonosGroupSettings.model_validate(selected_group_data)
         available_speakers = {speaker.uid: speaker for speaker in self.sonos_service.list_available_speakers()}
         selected_speaker = available_speakers.get(selected_group.coordinator_uid)
         if selected_speaker is None:
@@ -106,23 +142,3 @@ class GetSonosSelectionStatus:
             selected_group=selected_group,
             availability=availability,
         )
-
-
-def _lookup_selected_group(persisted: JsonObject) -> Optional[JsonObject]:
-    jukebox_settings = persisted.get("jukebox")
-    if not isinstance(jukebox_settings, dict):
-        return None
-
-    player_settings = jukebox_settings.get("player")
-    if not isinstance(player_settings, dict):
-        return None
-
-    sonos_settings = player_settings.get("sonos")
-    if not isinstance(sonos_settings, dict):
-        return None
-
-    selected_group = sonos_settings.get("selected_group")
-    if not isinstance(selected_group, dict):
-        return None
-
-    return selected_group

--- a/jukebox/sonos/selection.py
+++ b/jukebox/sonos/selection.py
@@ -1,0 +1,128 @@
+from typing import Optional
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from jukebox.settings.entities import (
+    SelectedSonosGroupSettings,
+    SelectedSonosSpeakerSettings,
+)
+from jukebox.settings.service_protocols import ReadOnlySettingsService, SettingsService
+from jukebox.settings.types import JsonObject
+
+from .discovery import DiscoveredSonosSpeaker
+from .service import SonosService
+
+
+class StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class SonosSelectionAvailability(StrictModel):
+    status: Literal["not_selected", "available", "unavailable"]
+    speaker: Optional[DiscoveredSonosSpeaker] = None
+
+
+class SonosSelectionStatus(StrictModel):
+    selected_group: Optional[SelectedSonosGroupSettings] = None
+    availability: SonosSelectionAvailability
+
+    @property
+    def selected_uid(self) -> Optional[str]:
+        if self.selected_group is None:
+            return None
+        return self.selected_group.coordinator_uid
+
+
+class SonosSelectionResult(StrictModel):
+    speaker: DiscoveredSonosSpeaker
+    selected_group: SelectedSonosGroupSettings
+    settings_message: str
+    restart_required: bool = False
+
+
+class SelectDefaultSonosSpeaker:
+    def __init__(self, settings_service: SettingsService, sonos_service: SonosService):
+        self.settings_service = settings_service
+        self.sonos_service = sonos_service
+
+    def execute(self, uid: str) -> SonosSelectionResult:
+        speakers_by_uid = {speaker.uid: speaker for speaker in self.sonos_service.list_available_speakers()}
+        speaker = speakers_by_uid.get(uid)
+        if speaker is None:
+            raise ValueError("Selected Sonos speaker is not currently discoverable: {}".format(uid))
+
+        selected_group = SelectedSonosGroupSettings(
+            coordinator_uid=uid,
+            members=[SelectedSonosSpeakerSettings(uid=uid)],
+        )
+        settings_result = self.settings_service.patch_persisted_settings(
+            {
+                "jukebox": {
+                    "player": {
+                        "type": "sonos",
+                        "sonos": {
+                            "selected_group": selected_group.model_dump(mode="python"),
+                        },
+                    }
+                }
+            }
+        )
+        return SonosSelectionResult(
+            speaker=speaker,
+            selected_group=selected_group,
+            settings_message=str(settings_result.get("message", "Settings saved.")),
+            restart_required=bool(settings_result.get("restart_required", False)),
+        )
+
+
+class GetSonosSelectionStatus:
+    def __init__(self, settings_service: ReadOnlySettingsService, sonos_service: SonosService):
+        self.settings_service = settings_service
+        self.sonos_service = sonos_service
+
+    def execute(self) -> SonosSelectionStatus:
+        persisted = self.settings_service.get_persisted_settings_view()
+        selected_group_data = _lookup_selected_group(persisted)
+        if selected_group_data is None:
+            return SonosSelectionStatus(
+                selected_group=None,
+                availability=SonosSelectionAvailability(status="not_selected", speaker=None),
+            )
+
+        selected_group = SelectedSonosGroupSettings.model_validate(selected_group_data)
+        available_speakers = {speaker.uid: speaker for speaker in self.sonos_service.list_available_speakers()}
+        selected_speaker = available_speakers.get(selected_group.coordinator_uid)
+        if selected_speaker is None:
+            availability = SonosSelectionAvailability(status="unavailable", speaker=None)
+        else:
+            availability = SonosSelectionAvailability(status="available", speaker=selected_speaker)
+
+        return SonosSelectionStatus(
+            selected_group=selected_group,
+            availability=availability,
+        )
+
+
+def _lookup_selected_group(persisted: JsonObject) -> Optional[JsonObject]:
+    jukebox_settings = persisted.get("jukebox")
+    if not isinstance(jukebox_settings, dict):
+        return None
+
+    player_settings = jukebox_settings.get("player")
+    if not isinstance(player_settings, dict):
+        return None
+
+    sonos_settings = player_settings.get("sonos")
+    if not isinstance(sonos_settings, dict):
+        return None
+
+    selected_group = sonos_settings.get("selected_group")
+    if not isinstance(selected_group, dict):
+        return None
+
+    return selected_group

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = { file = "LICENSE" }
 requires-python = ">=3.9,<3.14"
 dependencies = [
     "pydantic==2.12.5",
-    "questionary==2.1.0",
+    "questionary==2.1.1",
     "soco==0.30.14",
     "typer==0.23.2; python_version < '3.10'",
     "typer==0.24.1; python_version >= '3.10'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ license = { file = "LICENSE" }
 requires-python = ">=3.9,<3.14"
 dependencies = [
     "pydantic==2.12.5",
+    "questionary==2.1.0",
     "soco==0.30.14",
     "typer==0.23.2; python_version < '3.10'",
     "typer==0.24.1; python_version >= '3.10'",

--- a/tests/discstore/adapters/inbound/test_api_controller.py
+++ b/tests/discstore/adapters/inbound/test_api_controller.py
@@ -11,7 +11,12 @@ if FASTAPI_INSTALLED:
     from fastapi import HTTPException
     from fastapi.routing import APIRoute
 
-    from discstore.adapters.inbound.api_controller import APIController, SettingsPatchInput, SettingsResetInput
+    from discstore.adapters.inbound.api_controller import (
+        APIController,
+        SettingsPatchInput,
+        SettingsResetInput,
+        SonosSelectionInput,
+    )
     from discstore.domain.entities import CurrentTagStatus
     from discstore.domain.use_cases.get_current_tag_status import GetCurrentTagStatus
     from jukebox.settings.errors import InvalidSettingsError
@@ -146,6 +151,287 @@ def test_get_sonos_speakers_returns_502_on_discovery_failure():
 
     with pytest.raises(HTTPException) as err:
         route.endpoint()
+
+    assert err.value.status_code == 502
+    assert err.value.detail == "Failed to discover Sonos speakers: network unavailable"
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_get_sonos_selection_returns_not_selected_without_discovery():
+    settings_service = MagicMock()
+    settings_service.get_persisted_settings_view.return_value = {"schema_version": 1}
+    sonos_service = MagicMock()
+    controller = build_controller(settings_service=settings_service, sonos_service=sonos_service)
+    route = cast(
+        APIRoute,
+        next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/v1/sonos/selection"),
+    )
+
+    response = route.endpoint()
+
+    assert route.response_model is not None
+    assert response.model_dump() == {
+        "selected_group": None,
+        "availability": {
+            "status": "not_selected",
+            "speaker": None,
+        },
+    }
+    sonos_service.list_available_speakers.assert_not_called()
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_get_sonos_selection_returns_available_saved_selection():
+    settings_service = MagicMock()
+    settings_service.get_persisted_settings_view.return_value = {
+        "schema_version": 1,
+        "jukebox": {
+            "player": {
+                "sonos": {
+                    "selected_group": {
+                        "coordinator_uid": "speaker-1",
+                        "members": [{"uid": "speaker-1"}],
+                    }
+                }
+            }
+        },
+    }
+    sonos_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = [
+        DiscoveredSonosSpeaker(
+            uid="speaker-1",
+            name="Kitchen",
+            host="192.168.1.30",
+            household_id="household-1",
+            is_visible=True,
+        )
+    ]
+    controller = build_controller(settings_service=settings_service, sonos_service=sonos_service)
+    route = cast(
+        APIRoute,
+        next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/v1/sonos/selection"),
+    )
+
+    response = route.endpoint()
+
+    assert response.model_dump() == {
+        "selected_group": {
+            "coordinator_uid": "speaker-1",
+            "members": [{"uid": "speaker-1"}],
+        },
+        "availability": {
+            "status": "available",
+            "speaker": {
+                "uid": "speaker-1",
+                "name": "Kitchen",
+                "host": "192.168.1.30",
+                "household_id": "household-1",
+                "is_visible": True,
+            },
+        },
+    }
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_get_sonos_selection_returns_unavailable_saved_selection():
+    settings_service = MagicMock()
+    settings_service.get_persisted_settings_view.return_value = {
+        "schema_version": 1,
+        "jukebox": {
+            "player": {
+                "sonos": {
+                    "selected_group": {
+                        "coordinator_uid": "speaker-1",
+                        "members": [{"uid": "speaker-1"}],
+                    }
+                }
+            }
+        },
+    }
+    sonos_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = []
+    controller = build_controller(settings_service=settings_service, sonos_service=sonos_service)
+    route = cast(
+        APIRoute,
+        next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/v1/sonos/selection"),
+    )
+
+    response = route.endpoint()
+
+    assert response.model_dump() == {
+        "selected_group": {
+            "coordinator_uid": "speaker-1",
+            "members": [{"uid": "speaker-1"}],
+        },
+        "availability": {
+            "status": "unavailable",
+            "speaker": None,
+        },
+    }
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_get_sonos_selection_returns_502_on_discovery_failure():
+    settings_service = MagicMock()
+    settings_service.get_persisted_settings_view.return_value = {
+        "schema_version": 1,
+        "jukebox": {
+            "player": {
+                "sonos": {
+                    "selected_group": {
+                        "coordinator_uid": "speaker-1",
+                        "members": [{"uid": "speaker-1"}],
+                    }
+                }
+            }
+        },
+    }
+    sonos_service = MagicMock()
+    sonos_service.list_available_speakers.side_effect = SonosDiscoveryError(
+        "Failed to discover Sonos speakers: network unavailable"
+    )
+    controller = build_controller(settings_service=settings_service, sonos_service=sonos_service)
+    route = cast(
+        APIRoute,
+        next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/v1/sonos/selection"),
+    )
+
+    with pytest.raises(HTTPException) as err:
+        route.endpoint()
+
+    assert err.value.status_code == 502
+    assert err.value.detail == "Failed to discover Sonos speakers: network unavailable"
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_put_sonos_selection_persists_single_speaker_selection():
+    settings_service = MagicMock()
+    settings_service.patch_persisted_settings.return_value = {
+        "message": "Settings saved. Changes take effect after restart.",
+        "restart_required": True,
+    }
+    sonos_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = [
+        DiscoveredSonosSpeaker(
+            uid="speaker-1",
+            name="Kitchen",
+            host="192.168.1.30",
+            household_id="household-1",
+            is_visible=True,
+        )
+    ]
+    controller = build_controller(settings_service=settings_service, sonos_service=sonos_service)
+    route = cast(
+        APIRoute,
+        next(
+            route
+            for route in controller.app.routes
+            if getattr(route, "path", None) == "/api/v1/sonos/selection" and "PUT" in getattr(route, "methods", set())
+        ),
+    )
+
+    response = route.endpoint(SonosSelectionInput(uids=["speaker-1"]))
+
+    assert response.model_dump() == {
+        "selected_group": {
+            "coordinator_uid": "speaker-1",
+            "members": [{"uid": "speaker-1"}],
+        },
+        "availability": {
+            "status": "available",
+            "speaker": {
+                "uid": "speaker-1",
+                "name": "Kitchen",
+                "host": "192.168.1.30",
+                "household_id": "household-1",
+                "is_visible": True,
+            },
+        },
+        "message": "Settings saved. Changes take effect after restart.",
+        "restart_required": True,
+    }
+    settings_service.patch_persisted_settings.assert_called_once_with(
+        {
+            "jukebox": {
+                "player": {
+                    "type": "sonos",
+                    "sonos": {
+                        "selected_group": {
+                            "coordinator_uid": "speaker-1",
+                            "members": [{"uid": "speaker-1"}],
+                        }
+                    },
+                }
+            }
+        }
+    )
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+@pytest.mark.parametrize("uids", [[], ["speaker-1", "speaker-2"]])
+def test_put_sonos_selection_rejects_non_single_uid_payloads(uids):
+    settings_service = MagicMock()
+    sonos_service = MagicMock()
+    controller = build_controller(settings_service=settings_service, sonos_service=sonos_service)
+    route = cast(
+        APIRoute,
+        next(
+            route
+            for route in controller.app.routes
+            if getattr(route, "path", None) == "/api/v1/sonos/selection" and "PUT" in getattr(route, "methods", set())
+        ),
+    )
+
+    with pytest.raises(HTTPException) as err:
+        route.endpoint(SonosSelectionInput(uids=uids))
+
+    assert err.value.status_code == 400
+    assert err.value.detail == "`uids` must contain exactly one UID in this phase."
+    settings_service.patch_persisted_settings.assert_not_called()
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_put_sonos_selection_rejects_unknown_uid():
+    settings_service = MagicMock()
+    sonos_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = []
+    controller = build_controller(settings_service=settings_service, sonos_service=sonos_service)
+    route = cast(
+        APIRoute,
+        next(
+            route
+            for route in controller.app.routes
+            if getattr(route, "path", None) == "/api/v1/sonos/selection" and "PUT" in getattr(route, "methods", set())
+        ),
+    )
+
+    with pytest.raises(HTTPException) as err:
+        route.endpoint(SonosSelectionInput(uids=["speaker-9"]))
+
+    assert err.value.status_code == 400
+    assert err.value.detail == "Selected Sonos speaker is not currently discoverable: speaker-9"
+    settings_service.patch_persisted_settings.assert_not_called()
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_put_sonos_selection_returns_502_on_discovery_failure():
+    settings_service = MagicMock()
+    sonos_service = MagicMock()
+    sonos_service.list_available_speakers.side_effect = SonosDiscoveryError(
+        "Failed to discover Sonos speakers: network unavailable"
+    )
+    controller = build_controller(settings_service=settings_service, sonos_service=sonos_service)
+    route = cast(
+        APIRoute,
+        next(
+            route
+            for route in controller.app.routes
+            if getattr(route, "path", None) == "/api/v1/sonos/selection" and "PUT" in getattr(route, "methods", set())
+        ),
+    )
+
+    with pytest.raises(HTTPException) as err:
+        route.endpoint(SonosSelectionInput(uids=["speaker-1"]))
 
     assert err.value.status_code == 502
     assert err.value.detail == "Failed to discover Sonos speakers: network unavailable"

--- a/tests/jukebox/admin/test_app.py
+++ b/tests/jukebox/admin/test_app.py
@@ -20,6 +20,8 @@ from jukebox.admin.commands import (
     SettingsSetCommand,
     SettingsShowCommand,
     SonosListCommand,
+    SonosSelectCommand,
+    SonosShowCommand,
     UiCommand,
 )
 
@@ -69,6 +71,12 @@ def app_mocks(mocker):
             "execute_settings_command",
         ),
         (["sonos", "list"], SonosListCommand(type="sonos_list"), "execute_sonos_command"),
+        (
+            ["sonos", "select", "--uids", "speaker-1"],
+            SonosSelectCommand(type="sonos_select", uids=["speaker-1"]),
+            "execute_sonos_command",
+        ),
+        (["sonos", "show"], SonosShowCommand(type="sonos_show"), "execute_sonos_command"),
         (["api", "--port", "9000"], ApiCommand(type="api", port=9000), "execute_server_command"),
         (["ui", "--port", "9100"], UiCommand(type="ui", port=9100), "execute_server_command"),
     ],
@@ -98,7 +106,12 @@ def test_jukebox_admin_routes_admin_commands_by_category(app_mocks, args, expect
         app_mocks.execute_sonos_command.assert_not_called()
         app_mocks.execute_server_command.assert_not_called()
     elif executor_name == "execute_sonos_command":
-        executor.assert_called_once_with(command=expected_command, sonos_service=services.sonos)
+        executor.assert_called_once_with(
+            command=expected_command,
+            sonos_service=services.sonos,
+            settings_service=services.settings,
+            speaker_prompt_fn=ANY,
+        )
         app_mocks.execute_settings_command.assert_not_called()
         app_mocks.execute_server_command.assert_not_called()
     else:

--- a/tests/jukebox/admin/test_cli_presentation.py
+++ b/tests/jukebox/admin/test_cli_presentation.py
@@ -1,16 +1,21 @@
 from jukebox.admin.cli_presentation import (
     build_discstore_settings_deprecation_warning,
+    build_sonos_speaker_choice_label,
     render_cli_error,
     render_settings_output,
+    render_sonos_selection_saved_output,
+    render_sonos_selection_status_output,
     render_sonos_speakers_output,
 )
 from jukebox.admin.commands import SettingsResetCommand, SettingsSetCommand, SettingsShowCommand
+from jukebox.settings.entities import SelectedSonosGroupSettings, SelectedSonosSpeakerSettings
 from jukebox.settings.errors import (
     InvalidSettingsError,
     MalformedSettingsFileError,
     UnsupportedSettingsVersionError,
 )
 from jukebox.sonos.discovery import DiscoveredSonosSpeaker
+from jukebox.sonos.selection import SonosSelectionAvailability, SonosSelectionResult, SonosSelectionStatus
 
 
 def test_render_settings_output_persisted_groups_overrides_by_section():
@@ -297,6 +302,81 @@ def test_render_sonos_speakers_output_is_stable_and_human_readable():
 
 def test_render_sonos_speakers_output_handles_empty_results():
     assert render_sonos_speakers_output([]) == "No visible Sonos speakers found."
+
+
+def test_build_sonos_speaker_choice_label_includes_host_for_disambiguation():
+    assert (
+        build_sonos_speaker_choice_label(
+            DiscoveredSonosSpeaker(
+                uid="speaker-1",
+                name="Kitchen",
+                host="192.168.1.30",
+                household_id="household-1",
+                is_visible=True,
+            )
+        )
+        == "Kitchen (192.168.1.30)"
+    )
+
+
+def test_render_sonos_selection_saved_output_is_human_readable():
+    rendered = render_sonos_selection_saved_output(
+        SonosSelectionResult(
+            speaker=DiscoveredSonosSpeaker(
+                uid="speaker-1",
+                name="Kitchen",
+                host="192.168.1.30",
+                household_id="household-1",
+                is_visible=True,
+            ),
+            selected_group=SelectedSonosGroupSettings(
+                coordinator_uid="speaker-1",
+                members=[SelectedSonosSpeakerSettings(uid="speaker-1")],
+            ),
+            settings_message="Settings saved. Changes take effect after restart.",
+        )
+    )
+
+    assert "Selected Sonos speaker: Kitchen" in rendered
+    assert "UID: speaker-1" in rendered
+    assert "Settings saved. Changes take effect after restart." in rendered
+
+
+def test_render_sonos_selection_status_output_for_not_selected():
+    rendered = render_sonos_selection_status_output(
+        SonosSelectionStatus(
+            selected_group=None,
+            availability=SonosSelectionAvailability(status="not_selected", speaker=None),
+        )
+    )
+
+    assert rendered == "Selected Sonos Speaker\n\n- Status: not selected"
+
+
+def test_render_sonos_selection_status_output_for_available_selection():
+    rendered = render_sonos_selection_status_output(
+        SonosSelectionStatus(
+            selected_group=SelectedSonosGroupSettings(
+                coordinator_uid="speaker-1",
+                members=[SelectedSonosSpeakerSettings(uid="speaker-1")],
+            ),
+            availability=SonosSelectionAvailability(
+                status="available",
+                speaker=DiscoveredSonosSpeaker(
+                    uid="speaker-1",
+                    name="Kitchen",
+                    host="192.168.1.30",
+                    household_id="household-1",
+                    is_visible=True,
+                ),
+            ),
+        )
+    )
+
+    assert "Selected Sonos Speaker" in rendered
+    assert "- UID: speaker-1" in rendered
+    assert "- Status: available" in rendered
+    assert "- Household: household-1" in rendered
 
 
 def test_render_settings_output_json_mode_preserves_payload_shape():

--- a/tests/jukebox/admin/test_command_handlers.py
+++ b/tests/jukebox/admin/test_command_handlers.py
@@ -14,6 +14,8 @@ from jukebox.admin.commands import (
     SettingsSetCommand,
     SettingsShowCommand,
     SonosListCommand,
+    SonosSelectCommand,
+    SonosShowCommand,
     UiCommand,
 )
 from jukebox.admin.services import AdminServices
@@ -422,6 +424,187 @@ def test_execute_sonos_command_preserves_sonos_discovery_failures():
         execute_sonos_command(
             command=SonosListCommand(type="sonos_list"),
             sonos_service=sonos_service,
+        )
+
+
+def test_execute_sonos_command_selects_requested_uid_and_renders_success():
+    stdout_fn = MagicMock()
+    sonos_service = MagicMock()
+    settings_service = MagicMock()
+    settings_service.patch_persisted_settings.return_value = {
+        "message": "Settings saved. Changes take effect after restart."
+    }
+    sonos_service.list_available_speakers.return_value = [
+        DiscoveredSonosSpeaker(
+            uid="speaker-1",
+            name="Kitchen",
+            host="192.168.1.30",
+            household_id="household-1",
+            is_visible=True,
+        )
+    ]
+
+    execute_sonos_command(
+        command=SonosSelectCommand(type="sonos_select", uids=["speaker-1"]),
+        sonos_service=sonos_service,
+        settings_service=settings_service,
+        stdout_fn=stdout_fn,
+    )
+
+    settings_service.patch_persisted_settings.assert_called_once()
+    rendered_output = stdout_fn.call_args.args[0]
+    assert "Selected Sonos speaker: Kitchen" in rendered_output
+    assert "UID: speaker-1" in rendered_output
+
+
+def test_execute_sonos_command_selects_single_discovered_speaker_without_prompt():
+    stdout_fn = MagicMock()
+    prompt_fn = MagicMock()
+    sonos_service = MagicMock()
+    settings_service = MagicMock()
+    settings_service.patch_persisted_settings.return_value = {"message": "Settings saved."}
+    sonos_service.list_available_speakers.return_value = [
+        DiscoveredSonosSpeaker(
+            uid="speaker-1",
+            name="Kitchen",
+            host="192.168.1.30",
+            household_id="household-1",
+            is_visible=True,
+        )
+    ]
+
+    execute_sonos_command(
+        command=SonosSelectCommand(type="sonos_select"),
+        sonos_service=sonos_service,
+        settings_service=settings_service,
+        speaker_prompt_fn=prompt_fn,
+        stdout_fn=stdout_fn,
+    )
+
+    prompt_fn.assert_not_called()
+    settings_service.patch_persisted_settings.assert_called_once()
+
+
+def test_execute_sonos_command_uses_prompt_for_multiple_speakers():
+    stdout_fn = MagicMock()
+    prompt_fn = MagicMock(return_value="speaker-2")
+    sonos_service = MagicMock()
+    settings_service = MagicMock()
+    settings_service.patch_persisted_settings.return_value = {"message": "Settings saved."}
+    sonos_service.list_available_speakers.return_value = [
+        DiscoveredSonosSpeaker(
+            uid="speaker-1",
+            name="Kitchen",
+            host="192.168.1.30",
+            household_id="household-1",
+            is_visible=True,
+        ),
+        DiscoveredSonosSpeaker(
+            uid="speaker-2",
+            name="Kitchen",
+            host="192.168.1.31",
+            household_id="household-1",
+            is_visible=True,
+        ),
+    ]
+
+    execute_sonos_command(
+        command=SonosSelectCommand(type="sonos_select"),
+        sonos_service=sonos_service,
+        settings_service=settings_service,
+        speaker_prompt_fn=prompt_fn,
+        stdout_fn=stdout_fn,
+    )
+
+    prompt_fn.assert_called_once_with(sonos_service.list_available_speakers.return_value)
+    settings_service.patch_persisted_settings.assert_called_once()
+    assert "speaker-2" in stdout_fn.call_args.args[0]
+
+
+def test_execute_sonos_command_cancel_does_not_write_settings():
+    stdout_fn = MagicMock()
+    prompt_fn = MagicMock(return_value=None)
+    sonos_service = MagicMock()
+    settings_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = [
+        DiscoveredSonosSpeaker(
+            uid="speaker-1",
+            name="Kitchen",
+            host="192.168.1.30",
+            household_id="household-1",
+            is_visible=True,
+        ),
+        DiscoveredSonosSpeaker(
+            uid="speaker-2",
+            name="Living Room",
+            host="192.168.1.31",
+            household_id="household-1",
+            is_visible=True,
+        ),
+    ]
+
+    execute_sonos_command(
+        command=SonosSelectCommand(type="sonos_select"),
+        sonos_service=sonos_service,
+        settings_service=settings_service,
+        speaker_prompt_fn=prompt_fn,
+        stdout_fn=stdout_fn,
+    )
+
+    settings_service.patch_persisted_settings.assert_not_called()
+    stdout_fn.assert_not_called()
+
+
+def test_execute_sonos_command_show_renders_saved_selection_status():
+    stdout_fn = MagicMock()
+    sonos_service = MagicMock()
+    settings_service = MagicMock()
+    settings_service.get_persisted_settings_view.return_value = {
+        "schema_version": 1,
+        "jukebox": {
+            "player": {
+                "sonos": {
+                    "selected_group": {
+                        "coordinator_uid": "speaker-1",
+                        "members": [{"uid": "speaker-1"}],
+                    }
+                }
+            }
+        },
+    }
+    sonos_service.list_available_speakers.return_value = [
+        DiscoveredSonosSpeaker(
+            uid="speaker-1",
+            name="Kitchen",
+            host="192.168.1.30",
+            household_id="household-1",
+            is_visible=True,
+        )
+    ]
+
+    execute_sonos_command(
+        command=SonosShowCommand(type="sonos_show"),
+        sonos_service=sonos_service,
+        settings_service=settings_service,
+        stdout_fn=stdout_fn,
+    )
+
+    rendered_output = stdout_fn.call_args.args[0]
+    assert "Selected Sonos Speaker" in rendered_output
+    assert "- Status: available" in rendered_output
+    assert "- Host: 192.168.1.30" in rendered_output
+
+
+def test_execute_sonos_command_rejects_multiple_scripted_uids():
+    sonos_service = MagicMock()
+    settings_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = []
+
+    with pytest.raises(RuntimeError, match="requires exactly one UID"):
+        execute_sonos_command(
+            command=SonosSelectCommand(type="sonos_select", uids=["speaker-1", "speaker-2"]),
+            sonos_service=sonos_service,
+            settings_service=settings_service,
         )
 
 

--- a/tests/jukebox/admin/test_command_handlers.py
+++ b/tests/jukebox/admin/test_command_handlers.py
@@ -600,7 +600,7 @@ def test_execute_sonos_command_rejects_multiple_scripted_uids():
     settings_service = MagicMock()
     sonos_service.list_available_speakers.return_value = []
 
-    with pytest.raises(RuntimeError, match="requires exactly one UID"):
+    with pytest.raises(RuntimeError, match="exactly one UID"):
         execute_sonos_command(
             command=SonosSelectCommand(type="sonos_select", uids=["speaker-1", "speaker-2"]),
             sonos_service=sonos_service,

--- a/tests/jukebox/settings/test_selected_sonos_group_repository.py
+++ b/tests/jukebox/settings/test_selected_sonos_group_repository.py
@@ -1,13 +1,53 @@
-from jukebox.settings.entities import SelectedSonosGroupSettings, SelectedSonosSpeakerSettings
+from typing import Optional
+
+from jukebox.settings.entities import (
+    ResolvedAdminRuntimeConfig,
+    SelectedSonosGroupSettings,
+    SelectedSonosSpeakerSettings,
+)
 from jukebox.settings.selected_sonos_group_repository import SettingsSelectedSonosGroupRepository
+from jukebox.settings.types import JsonObject
+
+
+class StubSettingsService:
+    def __init__(
+        self,
+        persisted_view: Optional[JsonObject] = None,
+        patch_result: Optional[JsonObject] = None,
+    ):
+        if persisted_view is None:
+            persisted_view = {"schema_version": 1}
+        if patch_result is None:
+            patch_result = {
+                "message": "Settings saved. Changes take effect after restart.",
+                "restart_required": True,
+            }
+        self.persisted_view: JsonObject = persisted_view
+        self.patch_result: JsonObject = patch_result
+        self.patch = None
+
+    def get_persisted_settings_view(self) -> JsonObject:
+        return self.persisted_view
+
+    def get_effective_settings_view(self) -> JsonObject:
+        raise AssertionError("get_effective_settings_view should not be called in this test")
+
+    def set_persisted_value(self, dotted_path: str, raw_value: str) -> JsonObject:
+        raise AssertionError("set_persisted_value should not be called in this test")
+
+    def reset_persisted_value(self, dotted_path: str) -> JsonObject:
+        raise AssertionError("reset_persisted_value should not be called in this test")
+
+    def patch_persisted_settings(self, patch: JsonObject) -> JsonObject:
+        self.patch = patch
+        return self.patch_result
+
+    def resolve_admin_runtime(self, verbose: bool = False) -> ResolvedAdminRuntimeConfig:
+        raise AssertionError("resolve_admin_runtime should not be called in this test")
 
 
 def test_get_selected_group_returns_none_when_not_persisted():
-    settings_service = type(
-        "StubSettingsService",
-        (),
-        {"get_persisted_settings_view": lambda self: {"schema_version": 1}},
-    )()
+    settings_service = StubSettingsService()
 
     repository = SettingsSelectedSonosGroupRepository(settings_service)
 
@@ -15,25 +55,21 @@ def test_get_selected_group_returns_none_when_not_persisted():
 
 
 def test_get_selected_group_loads_saved_group_from_settings_schema():
-    settings_service = type(
-        "StubSettingsService",
-        (),
-        {
-            "get_persisted_settings_view": lambda self: {
-                "schema_version": 1,
-                "jukebox": {
-                    "player": {
-                        "sonos": {
-                            "selected_group": {
-                                "coordinator_uid": "speaker-1",
-                                "members": [{"uid": "speaker-1"}],
-                            }
+    settings_service = StubSettingsService(
+        persisted_view={
+            "schema_version": 1,
+            "jukebox": {
+                "player": {
+                    "sonos": {
+                        "selected_group": {
+                            "coordinator_uid": "speaker-1",
+                            "members": [{"uid": "speaker-1"}],
                         }
                     }
-                },
-            }
-        },
-    )()
+                }
+            },
+        }
+    )
 
     repository = SettingsSelectedSonosGroupRepository(settings_service)
 
@@ -44,17 +80,6 @@ def test_get_selected_group_loads_saved_group_from_settings_schema():
 
 
 def test_save_selected_group_persists_through_settings_service():
-    class StubSettingsService:
-        def __init__(self):
-            self.patch = None
-
-        def patch_persisted_settings(self, patch):
-            self.patch = patch
-            return {
-                "message": "Settings saved. Changes take effect after restart.",
-                "restart_required": True,
-            }
-
     settings_service = StubSettingsService()
     repository = SettingsSelectedSonosGroupRepository(settings_service)
     selected_group = SelectedSonosGroupSettings(

--- a/tests/jukebox/settings/test_selected_sonos_group_repository.py
+++ b/tests/jukebox/settings/test_selected_sonos_group_repository.py
@@ -1,0 +1,81 @@
+from jukebox.settings.entities import SelectedSonosGroupSettings, SelectedSonosSpeakerSettings
+from jukebox.settings.selected_sonos_group_repository import SettingsSelectedSonosGroupRepository
+
+
+def test_get_selected_group_returns_none_when_not_persisted():
+    settings_service = type(
+        "StubSettingsService",
+        (),
+        {"get_persisted_settings_view": lambda self: {"schema_version": 1}},
+    )()
+
+    repository = SettingsSelectedSonosGroupRepository(settings_service)
+
+    assert repository.get_selected_group() is None
+
+
+def test_get_selected_group_loads_saved_group_from_settings_schema():
+    settings_service = type(
+        "StubSettingsService",
+        (),
+        {
+            "get_persisted_settings_view": lambda self: {
+                "schema_version": 1,
+                "jukebox": {
+                    "player": {
+                        "sonos": {
+                            "selected_group": {
+                                "coordinator_uid": "speaker-1",
+                                "members": [{"uid": "speaker-1"}],
+                            }
+                        }
+                    }
+                },
+            }
+        },
+    )()
+
+    repository = SettingsSelectedSonosGroupRepository(settings_service)
+
+    assert repository.get_selected_group() == SelectedSonosGroupSettings(
+        coordinator_uid="speaker-1",
+        members=[SelectedSonosSpeakerSettings(uid="speaker-1")],
+    )
+
+
+def test_save_selected_group_persists_through_settings_service():
+    class StubSettingsService:
+        def __init__(self):
+            self.patch = None
+
+        def patch_persisted_settings(self, patch):
+            self.patch = patch
+            return {
+                "message": "Settings saved. Changes take effect after restart.",
+                "restart_required": True,
+            }
+
+    settings_service = StubSettingsService()
+    repository = SettingsSelectedSonosGroupRepository(settings_service)
+    selected_group = SelectedSonosGroupSettings(
+        coordinator_uid="speaker-1",
+        members=[SelectedSonosSpeakerSettings(uid="speaker-1")],
+    )
+
+    result = repository.save_selected_group(selected_group)
+
+    assert settings_service.patch == {
+        "jukebox": {
+            "player": {
+                "type": "sonos",
+                "sonos": {
+                    "selected_group": {
+                        "coordinator_uid": "speaker-1",
+                        "members": [{"uid": "speaker-1"}],
+                    }
+                },
+            }
+        }
+    }
+    assert result.message == "Settings saved. Changes take effect after restart."
+    assert result.restart_required is True

--- a/tests/jukebox/sonos/test_selection.py
+++ b/tests/jukebox/sonos/test_selection.py
@@ -6,7 +6,9 @@ from jukebox.settings.entities import SelectedSonosGroupSettings, SelectedSonosS
 from jukebox.sonos.discovery import DiscoveredSonosSpeaker
 from jukebox.sonos.selection import (
     GetSonosSelectionStatus,
-    SelectDefaultSonosSpeaker,
+    PlanSonosSelection,
+    SaveSelectedSonosGroupResult,
+    SaveSonosSelection,
 )
 
 
@@ -20,57 +22,118 @@ def build_speaker(uid="speaker-1", name="Kitchen", host="192.168.1.30", househol
     )
 
 
-def test_select_default_sonos_speaker_persists_one_member_selected_group_and_player_type():
-    settings_service = MagicMock()
-    settings_service.patch_persisted_settings.return_value = {
-        "message": "Settings saved. Changes take effect after restart."
-    }
+def test_plan_sonos_selection_resolves_single_requested_uid():
     sonos_service = MagicMock()
     sonos_service.list_available_speakers.return_value = [build_speaker()]
 
-    result = SelectDefaultSonosSpeaker(settings_service=settings_service, sonos_service=sonos_service).execute(
-        "speaker-1"
+    plan = PlanSonosSelection(sonos_service=sonos_service).execute(requested_uids=["speaker-1"])
+
+    assert plan.status == "resolved"
+    assert plan.selected_uid == "speaker-1"
+
+
+def test_save_sonos_selection_persists_one_member_selected_group_and_player_type():
+    selected_group_repository = MagicMock()
+    selected_group_repository.save_selected_group.return_value = SaveSelectedSonosGroupResult(
+        message="Settings saved. Changes take effect after restart."
     )
+    sonos_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = [build_speaker()]
+
+    result = SaveSonosSelection(
+        selected_group_repository=selected_group_repository,
+        sonos_service=sonos_service,
+    ).execute("speaker-1")
 
     assert result.speaker.uid == "speaker-1"
     assert result.selected_group == SelectedSonosGroupSettings(
         coordinator_uid="speaker-1",
         members=[SelectedSonosSpeakerSettings(uid="speaker-1")],
     )
-    settings_service.patch_persisted_settings.assert_called_once_with(
-        {
-            "jukebox": {
-                "player": {
-                    "type": "sonos",
-                    "sonos": {
-                        "selected_group": {
-                            "coordinator_uid": "speaker-1",
-                            "members": [{"uid": "speaker-1"}],
-                        }
-                    },
-                }
-            }
-        }
+    selected_group_repository.save_selected_group.assert_called_once_with(
+        SelectedSonosGroupSettings(
+            coordinator_uid="speaker-1",
+            members=[SelectedSonosSpeakerSettings(uid="speaker-1")],
+        )
     )
 
 
-def test_select_default_sonos_speaker_rejects_unknown_uid_without_writing():
-    settings_service = MagicMock()
+def test_plan_sonos_selection_rejects_unknown_uid():
+    sonos_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = [build_speaker()]
+
+    plan = PlanSonosSelection(sonos_service=sonos_service).execute(requested_uids=["speaker-9"])
+
+    assert plan.status == "invalid_request"
+    assert plan.error_message == "Selected Sonos speaker is not currently discoverable: speaker-9"
+
+
+def test_save_sonos_selection_rejects_unknown_uid_without_writing():
+    selected_group_repository = MagicMock()
     sonos_service = MagicMock()
     sonos_service.list_available_speakers.return_value = [build_speaker()]
 
     with pytest.raises(ValueError, match="not currently discoverable: speaker-9"):
-        SelectDefaultSonosSpeaker(settings_service=settings_service, sonos_service=sonos_service).execute("speaker-9")
+        SaveSonosSelection(
+            selected_group_repository=selected_group_repository,
+            sonos_service=sonos_service,
+        ).execute("speaker-9")
 
-    settings_service.patch_persisted_settings.assert_not_called()
+    selected_group_repository.save_selected_group.assert_not_called()
+
+
+def test_plan_sonos_selection_rejects_non_single_uid_input():
+    sonos_service = MagicMock()
+
+    plan = PlanSonosSelection(sonos_service=sonos_service).execute(requested_uids=["speaker-1", "speaker-2"])
+
+    assert plan.status == "invalid_request"
+    assert "exactly one UID" in str(plan.error_message)
+
+
+def test_plan_sonos_selection_auto_selects_only_visible_speaker():
+    sonos_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = [build_speaker()]
+
+    plan = PlanSonosSelection(sonos_service=sonos_service).execute()
+
+    assert plan.status == "resolved"
+    assert plan.selected_uid == "speaker-1"
+
+
+def test_plan_sonos_selection_requires_choice_when_multiple_speakers_available():
+    sonos_service = MagicMock()
+    available_speakers = [
+        build_speaker(uid="speaker-1"),
+        build_speaker(uid="speaker-2", host="192.168.1.31"),
+    ]
+    sonos_service.list_available_speakers.return_value = available_speakers
+
+    plan = PlanSonosSelection(sonos_service=sonos_service).execute()
+
+    assert plan.status == "needs_choice"
+    assert plan.speakers == available_speakers
+
+
+def test_plan_sonos_selection_reports_none_available_when_no_speakers_found():
+    sonos_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = []
+
+    plan = PlanSonosSelection(sonos_service=sonos_service).execute()
+
+    assert plan.status == "none_available"
+    assert plan.error_message == "No visible Sonos speakers found."
 
 
 def test_get_sonos_selection_status_reports_not_selected_without_discovery():
-    settings_service = MagicMock()
-    settings_service.get_persisted_settings_view.return_value = {"schema_version": 1}
+    selected_group_repository = MagicMock()
+    selected_group_repository.get_selected_group.return_value = None
     sonos_service = MagicMock()
 
-    status = GetSonosSelectionStatus(settings_service=settings_service, sonos_service=sonos_service).execute()
+    status = GetSonosSelectionStatus(
+        selected_group_repository=selected_group_repository,
+        sonos_service=sonos_service,
+    ).execute()
 
     assert status.selected_group is None
     assert status.availability.status == "not_selected"
@@ -79,24 +142,18 @@ def test_get_sonos_selection_status_reports_not_selected_without_discovery():
 
 
 def test_get_sonos_selection_status_reports_available_selection():
-    settings_service = MagicMock()
-    settings_service.get_persisted_settings_view.return_value = {
-        "schema_version": 1,
-        "jukebox": {
-            "player": {
-                "sonos": {
-                    "selected_group": {
-                        "coordinator_uid": "speaker-1",
-                        "members": [{"uid": "speaker-1"}],
-                    }
-                }
-            }
-        },
-    }
+    selected_group_repository = MagicMock()
+    selected_group_repository.get_selected_group.return_value = SelectedSonosGroupSettings(
+        coordinator_uid="speaker-1",
+        members=[SelectedSonosSpeakerSettings(uid="speaker-1")],
+    )
     sonos_service = MagicMock()
     sonos_service.list_available_speakers.return_value = [build_speaker()]
 
-    status = GetSonosSelectionStatus(settings_service=settings_service, sonos_service=sonos_service).execute()
+    status = GetSonosSelectionStatus(
+        selected_group_repository=selected_group_repository,
+        sonos_service=sonos_service,
+    ).execute()
 
     assert status.selected_uid == "speaker-1"
     assert status.availability.status == "available"
@@ -105,24 +162,18 @@ def test_get_sonos_selection_status_reports_available_selection():
 
 
 def test_get_sonos_selection_status_reports_unavailable_selection():
-    settings_service = MagicMock()
-    settings_service.get_persisted_settings_view.return_value = {
-        "schema_version": 1,
-        "jukebox": {
-            "player": {
-                "sonos": {
-                    "selected_group": {
-                        "coordinator_uid": "speaker-1",
-                        "members": [{"uid": "speaker-1"}],
-                    }
-                }
-            }
-        },
-    }
+    selected_group_repository = MagicMock()
+    selected_group_repository.get_selected_group.return_value = SelectedSonosGroupSettings(
+        coordinator_uid="speaker-1",
+        members=[SelectedSonosSpeakerSettings(uid="speaker-1")],
+    )
     sonos_service = MagicMock()
     sonos_service.list_available_speakers.return_value = [build_speaker(uid="speaker-2", host="192.168.1.31")]
 
-    status = GetSonosSelectionStatus(settings_service=settings_service, sonos_service=sonos_service).execute()
+    status = GetSonosSelectionStatus(
+        selected_group_repository=selected_group_repository,
+        sonos_service=sonos_service,
+    ).execute()
 
     assert status.selected_uid == "speaker-1"
     assert status.availability.status == "unavailable"

--- a/tests/jukebox/sonos/test_selection.py
+++ b/tests/jukebox/sonos/test_selection.py
@@ -1,0 +1,129 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from jukebox.settings.entities import SelectedSonosGroupSettings, SelectedSonosSpeakerSettings
+from jukebox.sonos.discovery import DiscoveredSonosSpeaker
+from jukebox.sonos.selection import (
+    GetSonosSelectionStatus,
+    SelectDefaultSonosSpeaker,
+)
+
+
+def build_speaker(uid="speaker-1", name="Kitchen", host="192.168.1.30", household_id="household-1"):
+    return DiscoveredSonosSpeaker(
+        uid=uid,
+        name=name,
+        host=host,
+        household_id=household_id,
+        is_visible=True,
+    )
+
+
+def test_select_default_sonos_speaker_persists_one_member_selected_group_and_player_type():
+    settings_service = MagicMock()
+    settings_service.patch_persisted_settings.return_value = {
+        "message": "Settings saved. Changes take effect after restart."
+    }
+    sonos_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = [build_speaker()]
+
+    result = SelectDefaultSonosSpeaker(settings_service=settings_service, sonos_service=sonos_service).execute(
+        "speaker-1"
+    )
+
+    assert result.speaker.uid == "speaker-1"
+    assert result.selected_group == SelectedSonosGroupSettings(
+        coordinator_uid="speaker-1",
+        members=[SelectedSonosSpeakerSettings(uid="speaker-1")],
+    )
+    settings_service.patch_persisted_settings.assert_called_once_with(
+        {
+            "jukebox": {
+                "player": {
+                    "type": "sonos",
+                    "sonos": {
+                        "selected_group": {
+                            "coordinator_uid": "speaker-1",
+                            "members": [{"uid": "speaker-1"}],
+                        }
+                    },
+                }
+            }
+        }
+    )
+
+
+def test_select_default_sonos_speaker_rejects_unknown_uid_without_writing():
+    settings_service = MagicMock()
+    sonos_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = [build_speaker()]
+
+    with pytest.raises(ValueError, match="not currently discoverable: speaker-9"):
+        SelectDefaultSonosSpeaker(settings_service=settings_service, sonos_service=sonos_service).execute("speaker-9")
+
+    settings_service.patch_persisted_settings.assert_not_called()
+
+
+def test_get_sonos_selection_status_reports_not_selected_without_discovery():
+    settings_service = MagicMock()
+    settings_service.get_persisted_settings_view.return_value = {"schema_version": 1}
+    sonos_service = MagicMock()
+
+    status = GetSonosSelectionStatus(settings_service=settings_service, sonos_service=sonos_service).execute()
+
+    assert status.selected_group is None
+    assert status.availability.status == "not_selected"
+    assert status.availability.speaker is None
+    sonos_service.list_available_speakers.assert_not_called()
+
+
+def test_get_sonos_selection_status_reports_available_selection():
+    settings_service = MagicMock()
+    settings_service.get_persisted_settings_view.return_value = {
+        "schema_version": 1,
+        "jukebox": {
+            "player": {
+                "sonos": {
+                    "selected_group": {
+                        "coordinator_uid": "speaker-1",
+                        "members": [{"uid": "speaker-1"}],
+                    }
+                }
+            }
+        },
+    }
+    sonos_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = [build_speaker()]
+
+    status = GetSonosSelectionStatus(settings_service=settings_service, sonos_service=sonos_service).execute()
+
+    assert status.selected_uid == "speaker-1"
+    assert status.availability.status == "available"
+    assert status.availability.speaker is not None
+    assert status.availability.speaker.host == "192.168.1.30"
+
+
+def test_get_sonos_selection_status_reports_unavailable_selection():
+    settings_service = MagicMock()
+    settings_service.get_persisted_settings_view.return_value = {
+        "schema_version": 1,
+        "jukebox": {
+            "player": {
+                "sonos": {
+                    "selected_group": {
+                        "coordinator_uid": "speaker-1",
+                        "members": [{"uid": "speaker-1"}],
+                    }
+                }
+            }
+        },
+    }
+    sonos_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = [build_speaker(uid="speaker-2", host="192.168.1.31")]
+
+    status = GetSonosSelectionStatus(settings_service=settings_service, sonos_service=sonos_service).execute()
+
+    assert status.selected_uid == "speaker-1"
+    assert status.availability.status == "unavailable"
+    assert status.availability.speaker is None

--- a/uv.lock
+++ b/uv.lock
@@ -322,7 +322,7 @@ requires-dist = [
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "pyserial", marker = "extra == 'nfc'", specifier = "==3.5" },
     { name = "python-multipart", marker = "python_full_version >= '3.10' and extra == 'ui'", specifier = "==0.0.22" },
-    { name = "questionary", specifier = "==2.1.0" },
+    { name = "questionary", specifier = "==2.1.1" },
     { name = "soco", specifier = "==0.30.14" },
     { name = "spidev", marker = "extra == 'nfc'", specifier = "==3.8" },
     { name = "typer", marker = "python_full_version < '3.10'", specifier = "==0.23.2" },
@@ -769,14 +769,14 @@ wheels = [
 
 [[package]]
 name = "questionary"
-version = "2.1.0"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "prompt-toolkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/b8/d16eb579277f3de9e56e5ad25280fab52fc5774117fb70362e8c2e016559/questionary-2.1.0.tar.gz", hash = "sha256:6302cdd645b19667d8f6e6634774e9538bfcd1aad9be287e743d96cacaf95587", size = 26775, upload-time = "2024-12-29T11:49:17.802Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/3f/11dd4cd4f39e05128bfd20138faea57bec56f9ffba6185d276e3107ba5b2/questionary-2.1.0-py3-none-any.whl", hash = "sha256:44174d237b68bc828e4878c763a9ad6790ee61990e0ae72927694ead57bab8ec", size = 36747, upload-time = "2024-12-29T11:49:16.734Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -277,6 +277,7 @@ version = "1.0.0.dev4"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
+    { name = "questionary" },
     { name = "soco" },
     { name = "typer", version = "0.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "typer", version = "0.24.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -321,6 +322,7 @@ requires-dist = [
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "pyserial", marker = "extra == 'nfc'", specifier = "==3.5" },
     { name = "python-multipart", marker = "python_full_version >= '3.10' and extra == 'ui'", specifier = "==0.0.22" },
+    { name = "questionary", specifier = "==2.1.0" },
     { name = "soco", specifier = "==0.30.14" },
     { name = "spidev", marker = "extra == 'nfc'", specifier = "==3.8" },
     { name = "typer", marker = "python_full_version < '3.10'", specifier = "==0.23.2" },
@@ -573,6 +575,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -751,6 +765,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+]
+
+[[package]]
+name = "questionary"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/b8/d16eb579277f3de9e56e5ad25280fab52fc5774117fb70362e8c2e016559/questionary-2.1.0.tar.gz", hash = "sha256:6302cdd645b19667d8f6e6634774e9538bfcd1aad9be287e743d96cacaf95587", size = 26775, upload-time = "2024-12-29T11:49:17.802Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/3f/11dd4cd4f39e05128bfd20138faea57bec56f9ffba6185d276e3107ba5b2/questionary-2.1.0-py3-none-any.whl", hash = "sha256:44174d237b68bc828e4878c763a9ad6790ee61990e0ae72927694ead57bab8ec", size = 36747, upload-time = "2024-12-29T11:49:16.734Z" },
 ]
 
 [[package]]
@@ -1034,6 +1060,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #177.

## Summary

This PR adds Sonos speaker selection on top of the existing Sonos discovery/show work (#185).

It introduces a full selection flow that can:
- choose a Sonos speaker from currently discoverable devices
- persist that selection into settings as the active Sonos group
- report whether the saved selection is currently available on the network
- expose the same behavior through both the admin CLI and the API

## What Changed

- Added `jukebox-admin sonos select`
- Added `jukebox-admin sonos show`
- Added interactive speaker selection for the CLI when multiple Sonos speakers are visible
- Added validation for scripted selection via `--uids`, limited to exactly one discoverable UID in this phase
- Persisted the selected Sonos group through settings using a dedicated repository adapter
- Added selection/status domain logic for:
  - planning a selection
  - saving a selection
  - reporting current selection availability
- Added API support for Sonos selection:
  - `GET /api/v1/sonos/selection`
  - `PUT /api/v1/sonos/selection`
- Added human-readable CLI rendering for saved-selection status and successful selection output
- Added `questionary` as a dependency for interactive CLI prompting

## Behavior Notes

- If only one Sonos speaker is discoverable, selection resolves automatically
- If multiple speakers are discoverable and no UID is provided, the CLI prompts the user to choose one
- If no speakers are visible, the command/API returns an error instead of writing settings
- If a saved selection is no longer discoverable, status is reported as `unavailable`

## Follow Up

- One more PR to allow for selecting multiple sonos speakers as a group
