### PR TITLE
Sonos multi speaker selection in CLI/API

### DIFF
--- a/discstore/adapters/inbound/api_controller.py
+++ b/discstore/adapters/inbound/api_controller.py
@@ -54,9 +54,15 @@ class SelectedSonosGroupOutput(SelectedSonosGroupSettings):
     pass
 
 
-class SonosSelectionAvailabilityOutput(BaseModel):
+class SonosSelectionMemberAvailabilityOutput(BaseModel):
+    uid: str
     status: str
     speaker: Optional[SonosSpeakerOutput] = None
+
+
+class SonosSelectionAvailabilityOutput(BaseModel):
+    status: str
+    members: list[SonosSelectionMemberAvailabilityOutput]
 
 
 class SonosSelectionOutput(BaseModel):
@@ -66,6 +72,7 @@ class SonosSelectionOutput(BaseModel):
 
 class SonosSelectionInput(BaseModel):
     uids: list[str]
+    coordinator_uid: Optional[str] = None
 
 
 class SonosSelectionUpdateOutput(BaseModel):
@@ -137,21 +144,31 @@ class APIController:
         @self.app.put("/api/v1/sonos/selection", response_model=SonosSelectionUpdateOutput)
         def put_sonos_selection(payload: SonosSelectionInput):
             try:
-                plan = PlanSonosSelection(self.sonos_service).execute(requested_uids=payload.uids)
+                plan = PlanSonosSelection(self.sonos_service).execute(
+                    requested_uids=payload.uids,
+                    coordinator_uid=payload.coordinator_uid,
+                )
                 if plan.status in {"invalid_request", "none_available"}:
                     raise HTTPException(status_code=400, detail=str(plan.error_message))
-                if plan.status == "needs_choice" or plan.selected_uid is None:
+                if plan.status == "needs_choice" or plan.coordinator_uid is None:
                     raise HTTPException(status_code=400, detail="No Sonos speaker selection was made.")
 
                 result = SaveSonosSelection(
                     SettingsSelectedSonosGroupRepository(self.settings_service),
                     self.sonos_service,
-                ).execute(plan.selected_uid)
+                ).execute(plan.selected_uids, coordinator_uid=plan.coordinator_uid)
                 return SonosSelectionUpdateOutput(
                     selected_group=SelectedSonosGroupOutput(**result.selected_group.model_dump()),
                     availability=SonosSelectionAvailabilityOutput(
                         status="available",
-                        speaker=SonosSpeakerOutput(**result.speaker.model_dump()),
+                        members=[
+                            SonosSelectionMemberAvailabilityOutput(
+                                uid=member.uid,
+                                status="available",
+                                speaker=SonosSpeakerOutput(**member.model_dump()),
+                            )
+                            for member in result.members
+                        ],
                     ),
                     message=result.settings_message,
                     restart_required=result.restart_required,

--- a/discstore/adapters/inbound/api_controller.py
+++ b/discstore/adapters/inbound/api_controller.py
@@ -32,7 +32,7 @@ from jukebox.settings.entities import SelectedSonosGroupSettings
 from jukebox.settings.selected_sonos_group_repository import SettingsSelectedSonosGroupRepository
 from jukebox.settings.service_protocols import SettingsService
 from jukebox.sonos.discovery import DiscoveredSonosSpeaker, SonosDiscoveryError
-from jukebox.sonos.selection import GetSonosSelectionStatus, PlanSonosSelection, SaveSonosSelection
+from jukebox.sonos.selection import GetSonosSelectionStatus, SaveSonosSelection
 from jukebox.sonos.service import SonosService
 
 __all__ = [
@@ -144,19 +144,10 @@ class APIController:
         @self.app.put("/api/v1/sonos/selection", response_model=SonosSelectionUpdateOutput)
         def put_sonos_selection(payload: SonosSelectionInput):
             try:
-                plan = PlanSonosSelection(self.sonos_service).execute(
-                    requested_uids=payload.uids,
-                    coordinator_uid=payload.coordinator_uid,
-                )
-                if plan.status in {"invalid_request", "none_available"}:
-                    raise HTTPException(status_code=400, detail=str(plan.error_message))
-                if plan.status == "needs_choice" or plan.coordinator_uid is None:
-                    raise HTTPException(status_code=400, detail="No Sonos speaker selection was made.")
-
                 result = SaveSonosSelection(
                     SettingsSelectedSonosGroupRepository(self.settings_service),
                     self.sonos_service,
-                ).execute(plan.selected_uids, coordinator_uid=plan.coordinator_uid)
+                ).execute(payload.uids, coordinator_uid=payload.coordinator_uid)
                 return SonosSelectionUpdateOutput(
                     selected_group=SelectedSonosGroupOutput(**result.selected_group.model_dump()),
                     availability=SonosSelectionAvailabilityOutput(

--- a/jukebox/admin/app.py
+++ b/jukebox/admin/app.py
@@ -312,15 +312,20 @@ def sonos_list(ctx: typer.Context) -> None:
 def sonos_select(
     ctx: typer.Context,
     uids: Annotated[
-        Optional[str],
-        typer.Option("--uids", help="comma-separated Sonos speaker UIDs to persist as the selected group"),
+        Optional[list[str]],
+        typer.Option(
+            "--uids",
+            help="comma-separated Sonos speaker UIDs to persist as the selected group; may be repeated",
+        ),
     ] = None,
     coordinator: Annotated[
         Optional[str],
         typer.Option("--coordinator", help="coordinator UID for the selected Sonos group"),
     ] = None,
 ) -> None:
-    parsed_uids = None if uids is None else [uid.strip() for uid in uids.split(",") if uid.strip()]
+    parsed_uids = (
+        None if uids is None else [uid.strip() for raw_uids in uids for uid in raw_uids.split(",") if uid.strip()]
+    )
     _run_command(ctx, SonosSelectCommand(type="sonos_select", uids=parsed_uids, coordinator=coordinator))
 
 

--- a/jukebox/admin/app.py
+++ b/jukebox/admin/app.py
@@ -82,6 +82,7 @@ def _run_command(ctx: typer.Context, command: object) -> None:
                     sonos_service=services.sonos,
                     settings_service=services.settings,
                     speaker_prompt_fn=_prompt_for_sonos_speaker_selection,
+                    coordinator_prompt_fn=_prompt_for_sonos_group_coordinator,
                 )
             else:
                 execute_server_command(
@@ -154,12 +155,30 @@ def _exit_on_command_validation_error(err: ValidationError) -> None:
     raise SystemExit(str(err)) from err
 
 
-def _prompt_for_sonos_speaker_selection(speakers: list[DiscoveredSonosSpeaker]) -> Optional[str]:
+def _prompt_for_sonos_speaker_selection(speakers: list[DiscoveredSonosSpeaker]) -> Optional[list[str]]:
+    import questionary
+
+    try:
+        return questionary.checkbox(
+            "Select one or more Sonos speakers",
+            choices=[
+                questionary.Choice(
+                    title=build_sonos_speaker_choice_label(speaker),
+                    value=speaker.uid,
+                )
+                for speaker in speakers
+            ],
+        ).ask()
+    except KeyboardInterrupt:
+        return None
+
+
+def _prompt_for_sonos_group_coordinator(speakers: list[DiscoveredSonosSpeaker]) -> Optional[str]:
     import questionary
 
     try:
         return questionary.select(
-            "Select a Sonos speaker",
+            "Select the Sonos coordinator",
             choices=[
                 questionary.Choice(
                     title=build_sonos_speaker_choice_label(speaker),
@@ -293,11 +312,16 @@ def sonos_list(ctx: typer.Context) -> None:
 def sonos_select(
     ctx: typer.Context,
     uids: Annotated[
-        Optional[list[str]],
-        typer.Option("--uids", help="discover and persist exactly one Sonos speaker UID"),
+        Optional[str],
+        typer.Option("--uids", help="comma-separated Sonos speaker UIDs to persist as the selected group"),
+    ] = None,
+    coordinator: Annotated[
+        Optional[str],
+        typer.Option("--coordinator", help="coordinator UID for the selected Sonos group"),
     ] = None,
 ) -> None:
-    _run_command(ctx, SonosSelectCommand(type="sonos_select", uids=uids))
+    parsed_uids = None if uids is None else [uid.strip() for uid in uids.split(",") if uid.strip()]
+    _run_command(ctx, SonosSelectCommand(type="sonos_select", uids=parsed_uids, coordinator=coordinator))
 
 
 @sonos_app.command("show")

--- a/jukebox/admin/app.py
+++ b/jukebox/admin/app.py
@@ -326,7 +326,12 @@ def sonos_select(
     parsed_uids = (
         None if uids is None else [uid.strip() for raw_uids in uids for uid in raw_uids.split(",") if uid.strip()]
     )
-    _run_command(ctx, SonosSelectCommand(type="sonos_select", uids=parsed_uids, coordinator=coordinator))
+    try:
+        command = SonosSelectCommand(type="sonos_select", uids=parsed_uids, coordinator=coordinator)
+    except ValidationError as err:
+        _exit_on_command_validation_error(err)
+
+    _run_command(ctx, command)
 
 
 @sonos_app.command("show")

--- a/jukebox/admin/app.py
+++ b/jukebox/admin/app.py
@@ -315,7 +315,10 @@ def sonos_select(
         Optional[list[str]],
         typer.Option(
             "--uids",
-            help="comma-separated Sonos speaker UIDs to persist as the selected group; may be repeated",
+            help=(
+                "comma-separated Sonos speaker UIDs to persist as the selected group; may be repeated; "
+                "first UID is used as coordinator if --coordinator is omitted"
+            ),
         ),
     ] = None,
     coordinator: Annotated[

--- a/jukebox/admin/cli_presentation.py
+++ b/jukebox/admin/cli_presentation.py
@@ -98,7 +98,18 @@ def render_sonos_selection_status_output(status: SonosSelectionStatus) -> str:
         return "\n".join(lines)
 
     status_label = "partially available" if status.availability.status == "partial" else status.availability.status
-    lines.append("- Coordinator UID: {}".format(status.selected_group.coordinator_uid))
+    coordinator_speaker = next(
+        (
+            member.speaker
+            for member in status.availability.members
+            if member.uid == status.selected_group.coordinator_uid and member.speaker is not None
+        ),
+        None,
+    )
+    if coordinator_speaker is None:
+        lines.append("- Coordinator UID: {}".format(status.selected_group.coordinator_uid))
+    else:
+        lines.append("- Coordinator: {} [{}]".format(coordinator_speaker.name, coordinator_speaker.uid))
     lines.append("- Status: {}".format(status_label))
     lines.append("- Members:")
 

--- a/jukebox/admin/cli_presentation.py
+++ b/jukebox/admin/cli_presentation.py
@@ -79,12 +79,12 @@ def build_sonos_speaker_choice_label(speaker: DiscoveredSonosSpeaker) -> str:
 
 
 def render_sonos_selection_saved_output(result: SonosSelectionResult) -> str:
-    member_labels = ", ".join("{} [{}]".format(member.name, member.uid) for member in result.members)
+    member_labels = ", ".join(f"{member.name} [{member.uid}]" for member in result.members)
     return "\n".join(
         [
             "Selected Sonos group saved.",
-            "Coordinator: {} [{}]".format(result.coordinator.name, result.coordinator.uid),
-            "Members: {}".format(member_labels),
+            f"Coordinator: {result.coordinator.name} [{result.coordinator.uid}]",
+            f"Members: {member_labels}",
             result.settings_message,
         ]
     )
@@ -107,10 +107,10 @@ def render_sonos_selection_status_output(status: SonosSelectionStatus) -> str:
         None,
     )
     if coordinator_speaker is None:
-        lines.append("- Coordinator UID: {}".format(status.selected_group.coordinator_uid))
+        lines.append(f"- Coordinator UID: {status.selected_group.coordinator_uid}")
     else:
-        lines.append("- Coordinator: {} [{}]".format(coordinator_speaker.name, coordinator_speaker.uid))
-    lines.append("- Status: {}".format(status_label))
+        lines.append(f"- Coordinator: {coordinator_speaker.name} [{coordinator_speaker.uid}]")
+    lines.append(f"- Status: {status_label}")
     lines.append("- Members:")
 
     name_width = max(

--- a/jukebox/admin/cli_presentation.py
+++ b/jukebox/admin/cli_presentation.py
@@ -79,30 +79,55 @@ def build_sonos_speaker_choice_label(speaker: DiscoveredSonosSpeaker) -> str:
 
 
 def render_sonos_selection_saved_output(result: SonosSelectionResult) -> str:
+    member_labels = ", ".join("{} [{}]".format(member.name, member.uid) for member in result.members)
     return "\n".join(
         [
-            f"Selected Sonos speaker: {result.speaker.name}",
-            f"UID: {result.speaker.uid}",
+            "Selected Sonos group saved.",
+            "Coordinator: {} [{}]".format(result.coordinator.name, result.coordinator.uid),
+            "Members: {}".format(member_labels),
             result.settings_message,
         ]
     )
 
 
 def render_sonos_selection_status_output(status: SonosSelectionStatus) -> str:
-    lines = ["Selected Sonos Speaker", ""]
+    lines = ["Selected Sonos Group", ""]
 
     if status.selected_group is None:
         lines.append("- Status: not selected")
         return "\n".join(lines)
 
-    lines.append(f"- UID: {status.selected_group.coordinator_uid}")
-    lines.append(f"- Status: {status.availability.status}")
+    status_label = "partially available" if status.availability.status == "partial" else status.availability.status
+    lines.append("- Coordinator UID: {}".format(status.selected_group.coordinator_uid))
+    lines.append("- Status: {}".format(status_label))
+    lines.append("- Members:")
 
-    speaker = status.availability.speaker
-    if speaker is not None:
-        lines.append(f"- Name: {speaker.name}")
-        lines.append(f"- Host: {speaker.host}")
-        lines.append(f"- Household: {speaker.household_id}")
+    name_width = max(
+        len(member.speaker.name) if member.speaker is not None else len("unavailable")
+        for member in status.availability.members
+    )
+    host_width = max(
+        len(member.speaker.host) if member.speaker is not None else len("-") for member in status.availability.members
+    )
+    household_width = max(
+        len(member.speaker.household_id) if member.speaker is not None else len("-")
+        for member in status.availability.members
+    )
+
+    for member in status.availability.members:
+        speaker = member.speaker
+        lines.append(
+            "  - {uid:<18}  {name:<{name_width}}  {host:<{host_width}}  {household:<{household_width}}  {status}".format(
+                uid=member.uid,
+                name=speaker.name if speaker is not None else "unavailable",
+                name_width=name_width,
+                host=speaker.host if speaker is not None else "-",
+                host_width=host_width,
+                household=speaker.household_id if speaker is not None else "-",
+                household_width=household_width,
+                status=member.status,
+            )
+        )
 
     return "\n".join(lines)
 

--- a/jukebox/admin/command_handlers.py
+++ b/jukebox/admin/command_handlers.py
@@ -108,7 +108,8 @@ def execute_sonos_command(
     command: object,
     sonos_service: SonosService,
     settings_service: Optional[SettingsService] = None,
-    speaker_prompt_fn: Optional[Callable[[list[DiscoveredSonosSpeaker]], Optional[str]]] = None,
+    speaker_prompt_fn: Optional[Callable[[list[DiscoveredSonosSpeaker]], Optional[list[str]]]] = None,
+    coordinator_prompt_fn: Optional[Callable[[list[DiscoveredSonosSpeaker]], Optional[str]]] = None,
     stdout_fn: Callable[[str], None] = print,
 ) -> None:
     if isinstance(command, SonosListCommand):
@@ -119,26 +120,52 @@ def execute_sonos_command(
         if settings_service is None:
             raise TypeError("settings_service is required for Sonos select commands")
 
-        plan = PlanSonosSelection(sonos_service=sonos_service).execute(requested_uids=command.uids)
+        plan = PlanSonosSelection(sonos_service=sonos_service).execute(
+            requested_uids=command.uids,
+            coordinator_uid=command.coordinator,
+        )
         if plan.status in {"invalid_request", "none_available"}:
             raise RuntimeError(str(plan.error_message))
 
-        selected_uid = plan.selected_uid
+        selected_uids = list(plan.selected_uids)
+        coordinator_uid = plan.coordinator_uid
         if plan.status == "needs_choice":
             if speaker_prompt_fn is None:
                 raise RuntimeError("Interactive Sonos speaker selection is not available in this context.")
-            selected_uid = speaker_prompt_fn(plan.speakers)
-            if selected_uid is None:
+            prompt_result = speaker_prompt_fn(plan.speakers)
+            if prompt_result is None:
                 return
+            selected_uids = list(prompt_result)
+            if not selected_uids:
+                raise RuntimeError("At least one Sonos speaker must be selected.")
+            if len(selected_uids) == 1:
+                coordinator_uid = selected_uids[0]
+            else:
+                if coordinator_prompt_fn is None:
+                    raise RuntimeError("Interactive Sonos coordinator selection is not available in this context.")
+                speakers_by_uid = {speaker.uid: speaker for speaker in plan.speakers}
+                selected_speakers = [speakers_by_uid[uid] for uid in selected_uids if uid in speakers_by_uid]
+                coordinator_uid = coordinator_prompt_fn(selected_speakers)
+                if coordinator_uid is None:
+                    return
 
-        if selected_uid is None:
+            plan = PlanSonosSelection(sonos_service=sonos_service).execute(
+                requested_uids=selected_uids,
+                coordinator_uid=coordinator_uid,
+            )
+            if plan.status != "resolved" or plan.coordinator_uid is None:
+                raise RuntimeError(str(plan.error_message or "No Sonos speaker selection was made."))
+            selected_uids = list(plan.selected_uids)
+            coordinator_uid = plan.coordinator_uid
+
+        if not selected_uids or coordinator_uid is None:
             raise RuntimeError("No Sonos speaker selection was made.")
 
         try:
             result = SaveSonosSelection(
                 selected_group_repository=SettingsSelectedSonosGroupRepository(settings_service),
                 sonos_service=sonos_service,
-            ).execute(selected_uid)
+            ).execute(selected_uids, coordinator_uid=coordinator_uid)
         except ValueError as err:
             raise RuntimeError(str(err)) from err
         stdout_fn(render_sonos_selection_saved_output(result))

--- a/jukebox/admin/command_handlers.py
+++ b/jukebox/admin/command_handlers.py
@@ -6,7 +6,7 @@ from jukebox.settings.selected_sonos_group_repository import SettingsSelectedSon
 from jukebox.settings.service_protocols import SettingsService
 from jukebox.shared.dependency_messages import optional_extra_dependency_message
 from jukebox.sonos.discovery import DiscoveredSonosSpeaker
-from jukebox.sonos.selection import GetSonosSelectionStatus, PlanSonosSelection, SaveSonosSelection
+from jukebox.sonos.selection import GetSonosSelectionStatus, SaveSonosSelection
 from jukebox.sonos.service import SonosService
 
 from .cli_presentation import (
@@ -120,19 +120,13 @@ def execute_sonos_command(
         if settings_service is None:
             raise TypeError("settings_service is required for Sonos select commands")
 
-        plan = PlanSonosSelection(sonos_service=sonos_service).execute(
-            requested_uids=command.uids,
-            coordinator_uid=command.coordinator,
-        )
-        if plan.status in {"invalid_request", "none_available"}:
-            raise RuntimeError(str(plan.error_message))
-
-        selected_uids = list(plan.selected_uids)
-        coordinator_uid = plan.coordinator_uid
-        if plan.status == "needs_choice":
+        if command.uids is None:
+            available_speakers = sonos_service.list_available_speakers()
+            if not available_speakers:
+                raise RuntimeError("No visible Sonos speakers found.")
             if speaker_prompt_fn is None:
                 raise RuntimeError("Interactive Sonos speaker selection is not available in this context.")
-            prompt_result = speaker_prompt_fn(plan.speakers)
+            prompt_result = speaker_prompt_fn(available_speakers)
             if prompt_result is None:
                 return
             selected_uids = list(prompt_result)
@@ -143,23 +137,14 @@ def execute_sonos_command(
             else:
                 if coordinator_prompt_fn is None:
                     raise RuntimeError("Interactive Sonos coordinator selection is not available in this context.")
-                speakers_by_uid = {speaker.uid: speaker for speaker in plan.speakers}
+                speakers_by_uid = {speaker.uid: speaker for speaker in available_speakers}
                 selected_speakers = [speakers_by_uid[uid] for uid in selected_uids if uid in speakers_by_uid]
                 coordinator_uid = coordinator_prompt_fn(selected_speakers)
                 if coordinator_uid is None:
                     return
-
-            plan = PlanSonosSelection(sonos_service=sonos_service).execute(
-                requested_uids=selected_uids,
-                coordinator_uid=coordinator_uid,
-            )
-            if plan.status != "resolved" or plan.coordinator_uid is None:
-                raise RuntimeError(str(plan.error_message or "No Sonos speaker selection was made."))
-            selected_uids = list(plan.selected_uids)
-            coordinator_uid = plan.coordinator_uid
-
-        if not selected_uids or coordinator_uid is None:
-            raise RuntimeError("No Sonos speaker selection was made.")
+        else:
+            selected_uids = list(command.uids)
+            coordinator_uid = command.coordinator
 
         try:
             result = SaveSonosSelection(

--- a/jukebox/admin/commands.py
+++ b/jukebox/admin/commands.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     from typing_extensions import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 
 class ApiCommand(BaseModel):
@@ -26,6 +26,12 @@ class SonosSelectCommand(BaseModel):
     type: Literal["sonos_select"]
     uids: Optional[list[str]] = None
     coordinator: Optional[str] = None
+
+    @model_validator(mode="after")
+    def validate_coordinator_requires_uids(self):
+        if self.coordinator is not None and not self.uids:
+            raise ValueError("--coordinator requires --uids")
+        return self
 
 
 class SonosShowCommand(BaseModel):

--- a/jukebox/admin/commands.py
+++ b/jukebox/admin/commands.py
@@ -25,6 +25,7 @@ class SonosListCommand(BaseModel):
 class SonosSelectCommand(BaseModel):
     type: Literal["sonos_select"]
     uids: Optional[list[str]] = None
+    coordinator: Optional[str] = None
 
 
 class SonosShowCommand(BaseModel):

--- a/jukebox/settings/entities.py
+++ b/jukebox/settings/entities.py
@@ -35,7 +35,10 @@ class SelectedSonosGroupSettings(StrictModel):
         if not self.members:
             raise ValueError("selected_group must include at least one member")
 
-        member_uids = {member.uid for member in self.members}
+        member_uids = [member.uid for member in self.members]
+        if len(set(member_uids)) != len(member_uids):
+            raise ValueError("selected_group.members must not contain duplicate uids")
+
         if self.coordinator_uid not in member_uids:
             raise ValueError("selected_group.coordinator_uid must match a member uid")
 

--- a/jukebox/sonos/__init__.py
+++ b/jukebox/sonos/__init__.py
@@ -6,10 +6,8 @@ from .discovery import (
 )
 from .selection import (
     GetSonosSelectionStatus,
-    PlanSonosSelection,
     SaveSonosSelection,
     SonosSelectionAvailability,
-    SonosSelectionPlan,
     SonosSelectionResult,
     SonosSelectionStatus,
 )
@@ -19,12 +17,10 @@ __all__ = [
     "DefaultSonosService",
     "DiscoveredSonosSpeaker",
     "GetSonosSelectionStatus",
-    "PlanSonosSelection",
     "SaveSonosSelection",
     "SonosDiscoveryError",
     "SonosDiscoveryPort",
     "SonosSelectionAvailability",
-    "SonosSelectionPlan",
     "SonosSelectionResult",
     "SonosSelectionStatus",
     "SonosService",

--- a/jukebox/sonos/selection.py
+++ b/jukebox/sonos/selection.py
@@ -217,7 +217,7 @@ def _validate_selection_request(
     if unknown_uids:
         raise ValueError("Selected Sonos speakers are not currently discoverable: {}".format(", ".join(unknown_uids)))
 
-    resolved_coordinator_uid = coordinator_uid or requested_uids[0]
+    resolved_coordinator_uid = requested_uids[0] if coordinator_uid is None else coordinator_uid
     if resolved_coordinator_uid not in requested_uids:
         raise ValueError(
             "Selected Sonos coordinator must be one of the selected speakers: {}".format(resolved_coordinator_uid)

--- a/jukebox/sonos/selection.py
+++ b/jukebox/sonos/selection.py
@@ -160,6 +160,7 @@ class GetSonosSelectionStatus:
         members = []
         coordinator_available = False
         available_member_count = 0
+        available_household_ids = set()
 
         for saved_member in selected_group.members:
             speaker = available_speakers.get(saved_member.uid)
@@ -173,6 +174,7 @@ class GetSonosSelectionStatus:
                 continue
 
             available_member_count += 1
+            available_household_ids.add(speaker.household_id)
             if saved_member.uid == selected_group.coordinator_uid:
                 coordinator_available = True
             members.append(
@@ -183,7 +185,7 @@ class GetSonosSelectionStatus:
                 )
             )
 
-        if not coordinator_available:
+        if not coordinator_available or len(available_household_ids) > 1:
             availability = SonosSelectionAvailability(status="unavailable", members=members)
         elif available_member_count == len(selected_group.members):
             availability = SonosSelectionAvailability(status="available", members=members)

--- a/jukebox/sonos/selection.py
+++ b/jukebox/sonos/selection.py
@@ -156,11 +156,9 @@ class GetSonosSelectionStatus:
                 availability=SonosSelectionAvailability(status="not_selected"),
             )
 
-        available_speakers = {speaker.uid: speaker for speaker in self.sonos_service.list_available_speakers()}
+        inspection = self.sonos_service.inspect_selected_group(selected_group)
+        available_speakers = {speaker.uid: speaker for speaker in inspection.resolved_members}
         members = []
-        coordinator_available = False
-        available_member_count = 0
-        available_household_ids = set()
 
         for saved_member in selected_group.members:
             speaker = available_speakers.get(saved_member.uid)
@@ -173,10 +171,6 @@ class GetSonosSelectionStatus:
                 )
                 continue
 
-            available_member_count += 1
-            available_household_ids.add(speaker.household_id)
-            if saved_member.uid == selected_group.coordinator_uid:
-                coordinator_available = True
             members.append(
                 SonosSelectionMemberAvailability(
                     uid=saved_member.uid,
@@ -185,12 +179,12 @@ class GetSonosSelectionStatus:
                 )
             )
 
-        if not coordinator_available or len(available_household_ids) > 1:
+        if inspection.error_message is not None:
             availability = SonosSelectionAvailability(status="unavailable", members=members)
-        elif available_member_count == len(selected_group.members):
-            availability = SonosSelectionAvailability(status="available", members=members)
-        else:
+        elif inspection.missing_member_uids:
             availability = SonosSelectionAvailability(status="partial", members=members)
+        else:
+            availability = SonosSelectionAvailability(status="available", members=members)
 
         return SonosSelectionStatus(
             selected_group=selected_group,

--- a/jukebox/sonos/selection.py
+++ b/jukebox/sonos/selection.py
@@ -20,9 +20,15 @@ class StrictModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class SonosSelectionAvailability(StrictModel):
-    status: Literal["not_selected", "available", "unavailable"]
+class SonosSelectionMemberAvailability(StrictModel):
+    uid: str
+    status: Literal["available", "unavailable"]
     speaker: Optional[DiscoveredSonosSpeaker] = None
+
+
+class SonosSelectionAvailability(StrictModel):
+    status: Literal["not_selected", "available", "partial", "unavailable"]
+    members: list[SonosSelectionMemberAvailability] = []
 
 
 class SonosSelectionStatus(StrictModel):
@@ -37,7 +43,8 @@ class SonosSelectionStatus(StrictModel):
 
 
 class SonosSelectionResult(StrictModel):
-    speaker: DiscoveredSonosSpeaker
+    coordinator: DiscoveredSonosSpeaker
+    members: list[DiscoveredSonosSpeaker]
     selected_group: SelectedSonosGroupSettings
     settings_message: str
     restart_required: bool = False
@@ -56,31 +63,40 @@ class SelectedSonosGroupRepository(Protocol):
 
 class SonosSelectionPlan(StrictModel):
     status: Literal["resolved", "needs_choice", "invalid_request", "none_available"]
-    selected_uid: Optional[str] = None
+    selected_uids: list[str] = []
+    coordinator_uid: Optional[str] = None
     speakers: list[DiscoveredSonosSpeaker] = []
     error_message: Optional[str] = None
+
+    @property
+    def selected_uid(self) -> Optional[str]:
+        return self.coordinator_uid
 
 
 class PlanSonosSelection:
     def __init__(self, sonos_service: SonosService):
         self.sonos_service = sonos_service
 
-    def execute(self, requested_uids: Optional[list[str]] = None) -> SonosSelectionPlan:
+    def execute(
+        self,
+        requested_uids: Optional[list[str]] = None,
+        coordinator_uid: Optional[str] = None,
+    ) -> SonosSelectionPlan:
         available_speakers = self.sonos_service.list_available_speakers()
         if requested_uids is not None:
-            if len(requested_uids) != 1:
-                return SonosSelectionPlan(
-                    status="invalid_request",
-                    error_message="`uids` must contain exactly one UID in this phase.",
+            try:
+                validated_group = _validate_selection_request(
+                    available_speakers=available_speakers,
+                    requested_uids=requested_uids,
+                    coordinator_uid=coordinator_uid,
                 )
-
-            selected_uid = requested_uids[0]
-            if selected_uid not in {speaker.uid for speaker in available_speakers}:
-                return SonosSelectionPlan(
-                    status="invalid_request",
-                    error_message=f"Selected Sonos speaker is not currently discoverable: {selected_uid}",
-                )
-            return SonosSelectionPlan(status="resolved", selected_uid=selected_uid)
+            except ValueError as err:
+                return SonosSelectionPlan(status="invalid_request", error_message=str(err))
+            return SonosSelectionPlan(
+                status="resolved",
+                selected_uids=validated_group.selected_uids,
+                coordinator_uid=validated_group.coordinator_uid,
+            )
 
         if not available_speakers:
             return SonosSelectionPlan(
@@ -89,7 +105,11 @@ class PlanSonosSelection:
             )
 
         if len(available_speakers) == 1:
-            return SonosSelectionPlan(status="resolved", selected_uid=available_speakers[0].uid)
+            return SonosSelectionPlan(
+                status="resolved",
+                selected_uids=[available_speakers[0].uid],
+                coordinator_uid=available_speakers[0].uid,
+            )
 
         return SonosSelectionPlan(status="needs_choice", speakers=available_speakers)
 
@@ -99,19 +119,24 @@ class SaveSonosSelection:
         self.selected_group_repository = selected_group_repository
         self.sonos_service = sonos_service
 
-    def execute(self, uid: str) -> SonosSelectionResult:
-        speakers_by_uid = {speaker.uid: speaker for speaker in self.sonos_service.list_available_speakers()}
-        speaker = speakers_by_uid.get(uid)
-        if speaker is None:
-            raise ValueError(f"Selected Sonos speaker is not currently discoverable: {uid}")
-
-        selected_group = SelectedSonosGroupSettings(
-            coordinator_uid=uid,
-            members=[SelectedSonosSpeakerSettings(uid=uid)],
+    def execute(self, uids: list[str], coordinator_uid: Optional[str] = None) -> SonosSelectionResult:
+        available_speakers = self.sonos_service.list_available_speakers()
+        validated_group = _validate_selection_request(
+            available_speakers=available_speakers,
+            requested_uids=uids,
+            coordinator_uid=coordinator_uid,
         )
+        speakers_by_uid = {speaker.uid: speaker for speaker in available_speakers}
+        selected_group = SelectedSonosGroupSettings(
+            coordinator_uid=validated_group.coordinator_uid,
+            members=[SelectedSonosSpeakerSettings(uid=uid) for uid in validated_group.selected_uids],
+        )
+        members = [speakers_by_uid[uid] for uid in validated_group.selected_uids]
+        coordinator = speakers_by_uid[validated_group.coordinator_uid]
         settings_result = self.selected_group_repository.save_selected_group(selected_group)
         return SonosSelectionResult(
-            speaker=speaker,
+            coordinator=coordinator,
+            members=members,
             selected_group=selected_group,
             settings_message=settings_result.message,
             restart_required=settings_result.restart_required,
@@ -128,17 +153,81 @@ class GetSonosSelectionStatus:
         if selected_group is None:
             return SonosSelectionStatus(
                 selected_group=None,
-                availability=SonosSelectionAvailability(status="not_selected", speaker=None),
+                availability=SonosSelectionAvailability(status="not_selected"),
             )
 
         available_speakers = {speaker.uid: speaker for speaker in self.sonos_service.list_available_speakers()}
-        selected_speaker = available_speakers.get(selected_group.coordinator_uid)
-        if selected_speaker is None:
-            availability = SonosSelectionAvailability(status="unavailable", speaker=None)
+        members = []
+        coordinator_available = False
+        available_member_count = 0
+
+        for saved_member in selected_group.members:
+            speaker = available_speakers.get(saved_member.uid)
+            if speaker is None:
+                members.append(
+                    SonosSelectionMemberAvailability(
+                        uid=saved_member.uid,
+                        status="unavailable",
+                    )
+                )
+                continue
+
+            available_member_count += 1
+            if saved_member.uid == selected_group.coordinator_uid:
+                coordinator_available = True
+            members.append(
+                SonosSelectionMemberAvailability(
+                    uid=saved_member.uid,
+                    status="available",
+                    speaker=speaker,
+                )
+            )
+
+        if not coordinator_available:
+            availability = SonosSelectionAvailability(status="unavailable", members=members)
+        elif available_member_count == len(selected_group.members):
+            availability = SonosSelectionAvailability(status="available", members=members)
         else:
-            availability = SonosSelectionAvailability(status="available", speaker=selected_speaker)
+            availability = SonosSelectionAvailability(status="partial", members=members)
 
         return SonosSelectionStatus(
             selected_group=selected_group,
             availability=availability,
         )
+
+
+class _ValidatedSonosSelectionRequest(StrictModel):
+    selected_uids: list[str]
+    coordinator_uid: str
+
+
+def _validate_selection_request(
+    available_speakers: list[DiscoveredSonosSpeaker],
+    requested_uids: list[str],
+    coordinator_uid: Optional[str] = None,
+) -> _ValidatedSonosSelectionRequest:
+    if not requested_uids:
+        raise ValueError("`uids` must include at least one UID.")
+
+    if len(set(requested_uids)) != len(requested_uids):
+        raise ValueError("`uids` must not contain duplicate UIDs.")
+
+    speakers_by_uid = {speaker.uid: speaker for speaker in available_speakers}
+    unknown_uids = [uid for uid in requested_uids if uid not in speakers_by_uid]
+    if unknown_uids:
+        raise ValueError("Selected Sonos speakers are not currently discoverable: {}".format(", ".join(unknown_uids)))
+
+    resolved_coordinator_uid = coordinator_uid or requested_uids[0]
+    if resolved_coordinator_uid not in requested_uids:
+        raise ValueError(
+            "Selected Sonos coordinator must be one of the selected speakers: {}".format(resolved_coordinator_uid)
+        )
+
+    household_ids = {speakers_by_uid[uid].household_id for uid in requested_uids}
+    if len(household_ids) != 1:
+        raise ValueError("Selected Sonos speakers must belong to the same household.")
+
+    return _ValidatedSonosSelectionRequest(
+        selected_uids=list(requested_uids),
+        coordinator_uid=resolved_coordinator_uid,
+    )

--- a/jukebox/sonos/selection.py
+++ b/jukebox/sonos/selection.py
@@ -35,12 +35,6 @@ class SonosSelectionStatus(StrictModel):
     selected_group: Optional[SelectedSonosGroupSettings] = None
     availability: SonosSelectionAvailability
 
-    @property
-    def selected_uid(self) -> Optional[str]:
-        if self.selected_group is None:
-            return None
-        return self.selected_group.coordinator_uid
-
 
 class SonosSelectionResult(StrictModel):
     coordinator: DiscoveredSonosSpeaker
@@ -59,59 +53,6 @@ class SelectedSonosGroupRepository(Protocol):
     def get_selected_group(self) -> Optional[SelectedSonosGroupSettings]: ...
 
     def save_selected_group(self, selected_group: SelectedSonosGroupSettings) -> SaveSelectedSonosGroupResult: ...
-
-
-class SonosSelectionPlan(StrictModel):
-    status: Literal["resolved", "needs_choice", "invalid_request", "none_available"]
-    selected_uids: list[str] = []
-    coordinator_uid: Optional[str] = None
-    speakers: list[DiscoveredSonosSpeaker] = []
-    error_message: Optional[str] = None
-
-    @property
-    def selected_uid(self) -> Optional[str]:
-        return self.coordinator_uid
-
-
-class PlanSonosSelection:
-    def __init__(self, sonos_service: SonosService):
-        self.sonos_service = sonos_service
-
-    def execute(
-        self,
-        requested_uids: Optional[list[str]] = None,
-        coordinator_uid: Optional[str] = None,
-    ) -> SonosSelectionPlan:
-        available_speakers = self.sonos_service.list_available_speakers()
-        if requested_uids is not None:
-            try:
-                validated_group = _validate_selection_request(
-                    available_speakers=available_speakers,
-                    requested_uids=requested_uids,
-                    coordinator_uid=coordinator_uid,
-                )
-            except ValueError as err:
-                return SonosSelectionPlan(status="invalid_request", error_message=str(err))
-            return SonosSelectionPlan(
-                status="resolved",
-                selected_uids=validated_group.selected_uids,
-                coordinator_uid=validated_group.coordinator_uid,
-            )
-
-        if not available_speakers:
-            return SonosSelectionPlan(
-                status="none_available",
-                error_message="No visible Sonos speakers found.",
-            )
-
-        if len(available_speakers) == 1:
-            return SonosSelectionPlan(
-                status="resolved",
-                selected_uids=[available_speakers[0].uid],
-                coordinator_uid=available_speakers[0].uid,
-            )
-
-        return SonosSelectionPlan(status="needs_choice", speakers=available_speakers)
 
 
 class SaveSonosSelection:
@@ -215,9 +156,7 @@ def _validate_selection_request(
 
     resolved_coordinator_uid = requested_uids[0] if coordinator_uid is None else coordinator_uid
     if resolved_coordinator_uid not in requested_uids:
-        raise ValueError(
-            "Selected Sonos coordinator must be one of the selected speakers: {}".format(resolved_coordinator_uid)
-        )
+        raise ValueError(f"Selected Sonos coordinator must be one of the selected speakers: {resolved_coordinator_uid}")
 
     household_ids = {speakers_by_uid[uid].household_id for uid in requested_uids}
     if len(household_ids) != 1:

--- a/jukebox/sonos/service.py
+++ b/jukebox/sonos/service.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Callable, Optional, Protocol
+from typing import Optional, Protocol
 
 from jukebox.settings.entities import (
     ResolvedSonosGroupRuntime,
@@ -43,12 +43,9 @@ class DefaultSonosService:
         self,
         selected_group: SelectedSonosGroupSettings,
     ) -> InspectedSelectedSonosGroup:
-        snapshot = self.discovery.discover_runtime_snapshot()
         return _inspect_selected_group(
             selected_group=selected_group,
-            speakers=snapshot.speakers,
-            retry_hosts_by_uid=snapshot.retry_hosts_by_uid,
-            resolve_speaker_by_host=self.discovery.resolve_speaker_by_host,
+            speakers=self.discovery.discover_speakers(),
         )
 
     def resolve_selected_group(
@@ -85,36 +82,16 @@ class DefaultSonosService:
 def _inspect_selected_group(
     selected_group: SelectedSonosGroupSettings,
     speakers: list[DiscoveredSonosSpeaker],
-    retry_hosts_by_uid: dict[str, list[str]],
-    resolve_speaker_by_host: Callable[[str, str], DiscoveredSonosSpeaker],
 ) -> InspectedSelectedSonosGroup:
     available_speakers = {speaker.uid: speaker for speaker in speakers}
     resolved_members = []
     missing_member_uids = []
-    coordinator_resolution_error = None
 
     for saved_member in selected_group.members:
         resolved_speaker = available_speakers.get(saved_member.uid)
-        member_resolution_error = None
 
         if resolved_speaker is None:
-            host_errors = []
-            for host in retry_hosts_by_uid.get(saved_member.uid, []):
-                try:
-                    resolved_speaker = resolve_speaker_by_host(saved_member.uid, host)
-                    break
-                except ValueError as err:
-                    host_errors.append(f"{saved_member.uid} via {host}: {err}")
-
-            if resolved_speaker is None and host_errors:
-                member_resolution_error = "; ".join(host_errors)
-            elif resolved_speaker is None:
-                member_resolution_error = f"{saved_member.uid}: not found on network"
-
-        if resolved_speaker is None:
-            if saved_member.uid == selected_group.coordinator_uid:
-                coordinator_resolution_error = member_resolution_error
-            else:
+            if saved_member.uid != selected_group.coordinator_uid:
                 missing_member_uids.append(saved_member.uid)
             continue
 
@@ -125,15 +102,13 @@ def _inspect_selected_group(
         None,
     )
     if coordinator is None:
-        if coordinator_resolution_error is not None:
-            error_message = f"Unable to resolve saved Sonos coordinator: {coordinator_resolution_error}"
-        else:
-            error_message = "Saved Sonos coordinator did not resolve to one of the selected_group members"
         return InspectedSelectedSonosGroup(
             coordinator=None,
             resolved_members=resolved_members,
             missing_member_uids=missing_member_uids,
-            error_message=error_message,
+            error_message="Unable to resolve saved Sonos coordinator: {}: not found on network".format(
+                selected_group.coordinator_uid
+            ),
         )
 
     household_ids = {member.household_id for member in resolved_members}

--- a/jukebox/sonos/service.py
+++ b/jukebox/sonos/service.py
@@ -1,4 +1,5 @@
-from typing import Protocol
+from dataclasses import dataclass, field
+from typing import Callable, Optional, Protocol
 
 from jukebox.settings.entities import (
     ResolvedSonosGroupRuntime,
@@ -12,10 +13,23 @@ from .discovery import DiscoveredSonosSpeaker, SonosDiscoveryPort, sort_sonos_sp
 class SonosService(Protocol):
     def list_available_speakers(self) -> list[DiscoveredSonosSpeaker]: ...
 
+    def inspect_selected_group(
+        self,
+        selected_group: SelectedSonosGroupSettings,
+    ) -> "InspectedSelectedSonosGroup": ...
+
     def resolve_selected_group(
         self,
         selected_group: SelectedSonosGroupSettings,
     ) -> ResolvedSonosGroupRuntime: ...
+
+
+@dataclass(frozen=True)
+class InspectedSelectedSonosGroup:
+    coordinator: Optional[DiscoveredSonosSpeaker]
+    resolved_members: list[DiscoveredSonosSpeaker]
+    missing_member_uids: list[str] = field(default_factory=list)
+    error_message: Optional[str] = None
 
 
 class DefaultSonosService:
@@ -25,42 +39,37 @@ class DefaultSonosService:
     def list_available_speakers(self) -> list[DiscoveredSonosSpeaker]:
         return sort_sonos_speakers([speaker for speaker in self.discovery.discover_speakers() if speaker.is_visible])
 
+    def inspect_selected_group(
+        self,
+        selected_group: SelectedSonosGroupSettings,
+    ) -> InspectedSelectedSonosGroup:
+        snapshot = self.discovery.discover_runtime_snapshot()
+        return _inspect_selected_group(
+            selected_group=selected_group,
+            speakers=snapshot.speakers,
+            retry_hosts_by_uid=snapshot.retry_hosts_by_uid,
+            resolve_speaker_by_host=self.discovery.resolve_speaker_by_host,
+        )
+
     def resolve_selected_group(
         self,
         selected_group: SelectedSonosGroupSettings,
     ) -> ResolvedSonosGroupRuntime:
-        available_speakers = {speaker.uid: speaker for speaker in self.discovery.discover_speakers()}
-        resolved_members = []
-        missing_member_uids = []
+        inspection = self.inspect_selected_group(selected_group)
+        if inspection.error_message is not None:
+            raise ValueError(inspection.error_message)
 
-        for saved_member in selected_group.members:
-            resolved_speaker = available_speakers.get(saved_member.uid)
-            if resolved_speaker is None:
-                if saved_member.uid == selected_group.coordinator_uid:
-                    raise ValueError(
-                        f"Unable to resolve saved Sonos coordinator: {saved_member.uid}: not found on network"
-                    )
-                missing_member_uids.append(saved_member.uid)
-                continue
-
-            resolved_members.append(self._build_runtime_speaker(resolved_speaker))
-
-        coordinator = next(
-            (member for member in resolved_members if member.uid == selected_group.coordinator_uid),
-            None,
-        )
-        if coordinator is None:
+        if inspection.coordinator is None:
             raise ValueError("Saved Sonos coordinator did not resolve to one of the selected_group members")
 
-        household_ids = {member.household_id for member in resolved_members}
-        if len(household_ids) != 1:
-            raise ValueError("Resolved Sonos group members must belong to the same household")
+        coordinator = self._build_runtime_speaker(inspection.coordinator)
+        resolved_members = [self._build_runtime_speaker(member) for member in inspection.resolved_members]
 
         return ResolvedSonosGroupRuntime(
             household_id=coordinator.household_id,
             coordinator=coordinator,
             members=resolved_members,
-            missing_member_uids=missing_member_uids,
+            missing_member_uids=inspection.missing_member_uids,
         )
 
     @staticmethod
@@ -71,3 +80,73 @@ class DefaultSonosService:
             host=speaker.host,
             household_id=speaker.household_id,
         )
+
+
+def _inspect_selected_group(
+    selected_group: SelectedSonosGroupSettings,
+    speakers: list[DiscoveredSonosSpeaker],
+    retry_hosts_by_uid: dict[str, list[str]],
+    resolve_speaker_by_host: Callable[[str, str], DiscoveredSonosSpeaker],
+) -> InspectedSelectedSonosGroup:
+    available_speakers = {speaker.uid: speaker for speaker in speakers}
+    resolved_members = []
+    missing_member_uids = []
+    coordinator_resolution_error = None
+
+    for saved_member in selected_group.members:
+        resolved_speaker = available_speakers.get(saved_member.uid)
+        member_resolution_error = None
+
+        if resolved_speaker is None:
+            host_errors = []
+            for host in retry_hosts_by_uid.get(saved_member.uid, []):
+                try:
+                    resolved_speaker = resolve_speaker_by_host(saved_member.uid, host)
+                    break
+                except ValueError as err:
+                    host_errors.append(f"{saved_member.uid} via {host}: {err}")
+
+            if resolved_speaker is None and host_errors:
+                member_resolution_error = "; ".join(host_errors)
+            elif resolved_speaker is None:
+                member_resolution_error = f"{saved_member.uid}: not found on network"
+
+        if resolved_speaker is None:
+            if saved_member.uid == selected_group.coordinator_uid:
+                coordinator_resolution_error = member_resolution_error
+            else:
+                missing_member_uids.append(saved_member.uid)
+            continue
+
+        resolved_members.append(resolved_speaker)
+
+    coordinator = next(
+        (member for member in resolved_members if member.uid == selected_group.coordinator_uid),
+        None,
+    )
+    if coordinator is None:
+        if coordinator_resolution_error is not None:
+            error_message = f"Unable to resolve saved Sonos coordinator: {coordinator_resolution_error}"
+        else:
+            error_message = "Saved Sonos coordinator did not resolve to one of the selected_group members"
+        return InspectedSelectedSonosGroup(
+            coordinator=None,
+            resolved_members=resolved_members,
+            missing_member_uids=missing_member_uids,
+            error_message=error_message,
+        )
+
+    household_ids = {member.household_id for member in resolved_members}
+    if len(household_ids) != 1:
+        return InspectedSelectedSonosGroup(
+            coordinator=coordinator,
+            resolved_members=resolved_members,
+            missing_member_uids=missing_member_uids,
+            error_message="Resolved Sonos group members must belong to the same household",
+        )
+
+    return InspectedSelectedSonosGroup(
+        coordinator=coordinator,
+        resolved_members=resolved_members,
+        missing_member_uids=missing_member_uids,
+    )

--- a/jukebox/sonos/service.py
+++ b/jukebox/sonos/service.py
@@ -106,9 +106,7 @@ def _inspect_selected_group(
             coordinator=None,
             resolved_members=resolved_members,
             missing_member_uids=missing_member_uids,
-            error_message="Unable to resolve saved Sonos coordinator: {}: not found on network".format(
-                selected_group.coordinator_uid
-            ),
+            error_message=f"Unable to resolve saved Sonos coordinator: {selected_group.coordinator_uid}: not found on network",
         )
 
     household_ids = {member.household_id for member in resolved_members}

--- a/tests/discstore/adapters/inbound/test_api_controller.py
+++ b/tests/discstore/adapters/inbound/test_api_controller.py
@@ -21,6 +21,7 @@ if FASTAPI_INSTALLED:
     from discstore.domain.use_cases.get_current_tag_status import GetCurrentTagStatus
     from jukebox.settings.errors import InvalidSettingsError
     from jukebox.sonos.discovery import DiscoveredSonosSpeaker, SonosDiscoveryError
+    from jukebox.sonos.service import InspectedSelectedSonosGroup
 
 
 def build_controller(
@@ -37,6 +38,21 @@ def build_controller(
         get_current_tag_status or MagicMock(),
         settings_service or MagicMock(),
         sonos_service or MagicMock(),
+    )
+
+
+def build_inspected_group(
+    resolved_members,
+    coordinator_uid,
+    missing_member_uids=None,
+    error_message=None,
+):
+    coordinator = next((member for member in resolved_members if member.uid == coordinator_uid), None)
+    return InspectedSelectedSonosGroup(
+        coordinator=coordinator,
+        resolved_members=list(resolved_members),
+        missing_member_uids=list(missing_member_uids or []),
+        error_message=error_message,
     )
 
 
@@ -177,7 +193,7 @@ def test_get_sonos_selection_returns_not_selected_without_discovery():
             "members": [],
         },
     }
-    sonos_service.list_available_speakers.assert_not_called()
+    sonos_service.inspect_selected_group.assert_not_called()
 
 
 @pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
@@ -197,22 +213,25 @@ def test_get_sonos_selection_returns_available_saved_selection():
         },
     }
     sonos_service = MagicMock()
-    sonos_service.list_available_speakers.return_value = [
-        DiscoveredSonosSpeaker(
-            uid="speaker-1",
-            name="Kitchen",
-            host="192.168.1.30",
-            household_id="household-1",
-            is_visible=True,
-        ),
-        DiscoveredSonosSpeaker(
-            uid="speaker-2",
-            name="Living Room",
-            host="192.168.1.31",
-            household_id="household-1",
-            is_visible=True,
-        ),
-    ]
+    sonos_service.inspect_selected_group.return_value = build_inspected_group(
+        resolved_members=[
+            DiscoveredSonosSpeaker(
+                uid="speaker-1",
+                name="Kitchen",
+                host="192.168.1.30",
+                household_id="household-1",
+                is_visible=True,
+            ),
+            DiscoveredSonosSpeaker(
+                uid="speaker-2",
+                name="Living Room",
+                host="192.168.1.31",
+                household_id="household-1",
+                is_visible=True,
+            ),
+        ],
+        coordinator_uid="speaker-2",
+    )
     controller = build_controller(settings_service=settings_service, sonos_service=sonos_service)
     route = cast(
         APIRoute,
@@ -273,15 +292,19 @@ def test_get_sonos_selection_returns_partially_available_saved_selection():
         },
     }
     sonos_service = MagicMock()
-    sonos_service.list_available_speakers.return_value = [
-        DiscoveredSonosSpeaker(
-            uid="speaker-1",
-            name="Kitchen",
-            host="192.168.1.30",
-            household_id="household-1",
-            is_visible=True,
-        )
-    ]
+    sonos_service.inspect_selected_group.return_value = build_inspected_group(
+        resolved_members=[
+            DiscoveredSonosSpeaker(
+                uid="speaker-1",
+                name="Kitchen",
+                host="192.168.1.30",
+                household_id="household-1",
+                is_visible=True,
+            )
+        ],
+        coordinator_uid="speaker-1",
+        missing_member_uids=["speaker-2"],
+    )
     controller = build_controller(settings_service=settings_service, sonos_service=sonos_service)
     route = cast(
         APIRoute,
@@ -336,15 +359,19 @@ def test_get_sonos_selection_returns_unavailable_saved_selection_when_coordinato
         },
     }
     sonos_service = MagicMock()
-    sonos_service.list_available_speakers.return_value = [
-        DiscoveredSonosSpeaker(
-            uid="speaker-1",
-            name="Kitchen",
-            host="192.168.1.30",
-            household_id="household-1",
-            is_visible=True,
-        )
-    ]
+    sonos_service.inspect_selected_group.return_value = build_inspected_group(
+        resolved_members=[
+            DiscoveredSonosSpeaker(
+                uid="speaker-1",
+                name="Kitchen",
+                host="192.168.1.30",
+                household_id="household-1",
+                is_visible=True,
+            )
+        ],
+        coordinator_uid="speaker-2",
+        error_message="Unable to resolve saved Sonos coordinator: speaker-2: not found on network",
+    )
     controller = build_controller(settings_service=settings_service, sonos_service=sonos_service)
     route = cast(
         APIRoute,
@@ -399,7 +426,7 @@ def test_get_sonos_selection_returns_502_on_discovery_failure():
         },
     }
     sonos_service = MagicMock()
-    sonos_service.list_available_speakers.side_effect = SonosDiscoveryError(
+    sonos_service.inspect_selected_group.side_effect = SonosDiscoveryError(
         "Failed to discover Sonos speakers: network unavailable"
     )
     controller = build_controller(settings_service=settings_service, sonos_service=sonos_service)

--- a/tests/discstore/adapters/inbound/test_api_controller.py
+++ b/tests/discstore/adapters/inbound/test_api_controller.py
@@ -551,7 +551,7 @@ def test_put_sonos_selection_rejects_unknown_uid():
         route.endpoint(SonosSelectionInput(uids=["speaker-9"]))
 
     assert err.value.status_code == 400
-    assert err.value.detail == "Selected Sonos speaker is not currently discoverable: speaker-9"
+    assert err.value.detail == "Selected Sonos speakers are not currently discoverable: speaker-9"
     settings_service.patch_persisted_settings.assert_not_called()
 
 

--- a/tests/discstore/adapters/inbound/test_api_controller.py
+++ b/tests/discstore/adapters/inbound/test_api_controller.py
@@ -174,7 +174,7 @@ def test_get_sonos_selection_returns_not_selected_without_discovery():
         "selected_group": None,
         "availability": {
             "status": "not_selected",
-            "speaker": None,
+            "members": [],
         },
     }
     sonos_service.list_available_speakers.assert_not_called()
@@ -189,8 +189,84 @@ def test_get_sonos_selection_returns_available_saved_selection():
             "player": {
                 "sonos": {
                     "selected_group": {
+                        "coordinator_uid": "speaker-2",
+                        "members": [{"uid": "speaker-1"}, {"uid": "speaker-2"}],
+                    }
+                }
+            }
+        },
+    }
+    sonos_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = [
+        DiscoveredSonosSpeaker(
+            uid="speaker-1",
+            name="Kitchen",
+            host="192.168.1.30",
+            household_id="household-1",
+            is_visible=True,
+        ),
+        DiscoveredSonosSpeaker(
+            uid="speaker-2",
+            name="Living Room",
+            host="192.168.1.31",
+            household_id="household-1",
+            is_visible=True,
+        ),
+    ]
+    controller = build_controller(settings_service=settings_service, sonos_service=sonos_service)
+    route = cast(
+        APIRoute,
+        next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/v1/sonos/selection"),
+    )
+
+    response = route.endpoint()
+
+    assert response.model_dump() == {
+        "selected_group": {
+            "coordinator_uid": "speaker-2",
+            "members": [{"uid": "speaker-1"}, {"uid": "speaker-2"}],
+        },
+        "availability": {
+            "status": "available",
+            "members": [
+                {
+                    "uid": "speaker-1",
+                    "status": "available",
+                    "speaker": {
+                        "uid": "speaker-1",
+                        "name": "Kitchen",
+                        "host": "192.168.1.30",
+                        "household_id": "household-1",
+                        "is_visible": True,
+                    },
+                },
+                {
+                    "uid": "speaker-2",
+                    "status": "available",
+                    "speaker": {
+                        "uid": "speaker-2",
+                        "name": "Living Room",
+                        "host": "192.168.1.31",
+                        "household_id": "household-1",
+                        "is_visible": True,
+                    },
+                },
+            ],
+        },
+    }
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_get_sonos_selection_returns_partially_available_saved_selection():
+    settings_service = MagicMock()
+    settings_service.get_persisted_settings_view.return_value = {
+        "schema_version": 1,
+        "jukebox": {
+            "player": {
+                "sonos": {
+                    "selected_group": {
                         "coordinator_uid": "speaker-1",
-                        "members": [{"uid": "speaker-1"}],
+                        "members": [{"uid": "speaker-1"}, {"uid": "speaker-2"}],
                     }
                 }
             }
@@ -217,23 +293,34 @@ def test_get_sonos_selection_returns_available_saved_selection():
     assert response.model_dump() == {
         "selected_group": {
             "coordinator_uid": "speaker-1",
-            "members": [{"uid": "speaker-1"}],
+            "members": [{"uid": "speaker-1"}, {"uid": "speaker-2"}],
         },
         "availability": {
-            "status": "available",
-            "speaker": {
-                "uid": "speaker-1",
-                "name": "Kitchen",
-                "host": "192.168.1.30",
-                "household_id": "household-1",
-                "is_visible": True,
-            },
+            "status": "partial",
+            "members": [
+                {
+                    "uid": "speaker-1",
+                    "status": "available",
+                    "speaker": {
+                        "uid": "speaker-1",
+                        "name": "Kitchen",
+                        "host": "192.168.1.30",
+                        "household_id": "household-1",
+                        "is_visible": True,
+                    },
+                },
+                {
+                    "uid": "speaker-2",
+                    "status": "unavailable",
+                    "speaker": None,
+                },
+            ],
         },
     }
 
 
 @pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
-def test_get_sonos_selection_returns_unavailable_saved_selection():
+def test_get_sonos_selection_returns_unavailable_saved_selection_when_coordinator_is_missing():
     settings_service = MagicMock()
     settings_service.get_persisted_settings_view.return_value = {
         "schema_version": 1,
@@ -241,15 +328,23 @@ def test_get_sonos_selection_returns_unavailable_saved_selection():
             "player": {
                 "sonos": {
                     "selected_group": {
-                        "coordinator_uid": "speaker-1",
-                        "members": [{"uid": "speaker-1"}],
+                        "coordinator_uid": "speaker-2",
+                        "members": [{"uid": "speaker-1"}, {"uid": "speaker-2"}],
                     }
                 }
             }
         },
     }
     sonos_service = MagicMock()
-    sonos_service.list_available_speakers.return_value = []
+    sonos_service.list_available_speakers.return_value = [
+        DiscoveredSonosSpeaker(
+            uid="speaker-1",
+            name="Kitchen",
+            host="192.168.1.30",
+            household_id="household-1",
+            is_visible=True,
+        )
+    ]
     controller = build_controller(settings_service=settings_service, sonos_service=sonos_service)
     route = cast(
         APIRoute,
@@ -260,12 +355,29 @@ def test_get_sonos_selection_returns_unavailable_saved_selection():
 
     assert response.model_dump() == {
         "selected_group": {
-            "coordinator_uid": "speaker-1",
-            "members": [{"uid": "speaker-1"}],
+            "coordinator_uid": "speaker-2",
+            "members": [{"uid": "speaker-1"}, {"uid": "speaker-2"}],
         },
         "availability": {
             "status": "unavailable",
-            "speaker": None,
+            "members": [
+                {
+                    "uid": "speaker-1",
+                    "status": "available",
+                    "speaker": {
+                        "uid": "speaker-1",
+                        "name": "Kitchen",
+                        "host": "192.168.1.30",
+                        "household_id": "household-1",
+                        "is_visible": True,
+                    },
+                },
+                {
+                    "uid": "speaker-2",
+                    "status": "unavailable",
+                    "speaker": None,
+                },
+            ],
         },
     }
 
@@ -304,7 +416,7 @@ def test_get_sonos_selection_returns_502_on_discovery_failure():
 
 
 @pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
-def test_put_sonos_selection_persists_single_speaker_selection():
+def test_put_sonos_selection_persists_multi_speaker_selection():
     settings_service = MagicMock()
     settings_service.patch_persisted_settings.return_value = {
         "message": "Settings saved. Changes take effect after restart.",
@@ -318,7 +430,14 @@ def test_put_sonos_selection_persists_single_speaker_selection():
             host="192.168.1.30",
             household_id="household-1",
             is_visible=True,
-        )
+        ),
+        DiscoveredSonosSpeaker(
+            uid="speaker-2",
+            name="Living Room",
+            host="192.168.1.31",
+            household_id="household-1",
+            is_visible=True,
+        ),
     ]
     controller = build_controller(settings_service=settings_service, sonos_service=sonos_service)
     route = cast(
@@ -330,22 +449,39 @@ def test_put_sonos_selection_persists_single_speaker_selection():
         ),
     )
 
-    response = route.endpoint(SonosSelectionInput(uids=["speaker-1"]))
+    response = route.endpoint(SonosSelectionInput(uids=["speaker-1", "speaker-2"], coordinator_uid="speaker-2"))
 
     assert response.model_dump() == {
         "selected_group": {
-            "coordinator_uid": "speaker-1",
-            "members": [{"uid": "speaker-1"}],
+            "coordinator_uid": "speaker-2",
+            "members": [{"uid": "speaker-1"}, {"uid": "speaker-2"}],
         },
         "availability": {
             "status": "available",
-            "speaker": {
-                "uid": "speaker-1",
-                "name": "Kitchen",
-                "host": "192.168.1.30",
-                "household_id": "household-1",
-                "is_visible": True,
-            },
+            "members": [
+                {
+                    "uid": "speaker-1",
+                    "status": "available",
+                    "speaker": {
+                        "uid": "speaker-1",
+                        "name": "Kitchen",
+                        "host": "192.168.1.30",
+                        "household_id": "household-1",
+                        "is_visible": True,
+                    },
+                },
+                {
+                    "uid": "speaker-2",
+                    "status": "available",
+                    "speaker": {
+                        "uid": "speaker-2",
+                        "name": "Living Room",
+                        "host": "192.168.1.31",
+                        "household_id": "household-1",
+                        "is_visible": True,
+                    },
+                },
+            ],
         },
         "message": "Settings saved. Changes take effect after restart.",
         "restart_required": True,
@@ -357,8 +493,8 @@ def test_put_sonos_selection_persists_single_speaker_selection():
                     "type": "sonos",
                     "sonos": {
                         "selected_group": {
-                            "coordinator_uid": "speaker-1",
-                            "members": [{"uid": "speaker-1"}],
+                            "coordinator_uid": "speaker-2",
+                            "members": [{"uid": "speaker-1"}, {"uid": "speaker-2"}],
                         }
                     },
                 }
@@ -368,8 +504,14 @@ def test_put_sonos_selection_persists_single_speaker_selection():
 
 
 @pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
-@pytest.mark.parametrize("uids", [[], ["speaker-1", "speaker-2"]])
-def test_put_sonos_selection_rejects_non_single_uid_payloads(uids):
+@pytest.mark.parametrize(
+    ("payload_data", "detail"),
+    [
+        ({"uids": []}, "`uids` must include at least one UID."),
+        ({"uids": ["speaker-1", "speaker-1"]}, "`uids` must not contain duplicate UIDs."),
+    ],
+)
+def test_put_sonos_selection_rejects_invalid_uid_payloads(payload_data, detail):
     settings_service = MagicMock()
     sonos_service = MagicMock()
     controller = build_controller(settings_service=settings_service, sonos_service=sonos_service)
@@ -383,10 +525,10 @@ def test_put_sonos_selection_rejects_non_single_uid_payloads(uids):
     )
 
     with pytest.raises(HTTPException) as err:
-        route.endpoint(SonosSelectionInput(uids=uids))
+        route.endpoint(SonosSelectionInput(**payload_data))
 
     assert err.value.status_code == 400
-    assert err.value.detail == "`uids` must contain exactly one UID in this phase."
+    assert err.value.detail == detail
     settings_service.patch_persisted_settings.assert_not_called()
 
 

--- a/tests/discstore/adapters/inbound/test_api_controller.py
+++ b/tests/discstore/adapters/inbound/test_api_controller.py
@@ -505,15 +505,36 @@ def test_put_sonos_selection_persists_multi_speaker_selection():
 
 @pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
 @pytest.mark.parametrize(
-    ("payload_data", "detail"),
+    ("payload_data", "available_speakers", "detail"),
     [
-        ({"uids": []}, "`uids` must include at least one UID."),
-        ({"uids": ["speaker-1", "speaker-1"]}, "`uids` must not contain duplicate UIDs."),
+        ({"uids": []}, [], "`uids` must include at least one UID."),
+        ({"uids": ["speaker-1", "speaker-1"]}, [], "`uids` must not contain duplicate UIDs."),
+        (
+            {"uids": ["speaker-1", "speaker-2"], "coordinator_uid": ""},
+            [
+                DiscoveredSonosSpeaker(
+                    uid="speaker-1",
+                    name="Kitchen",
+                    host="192.168.1.30",
+                    household_id="household-1",
+                    is_visible=True,
+                ),
+                DiscoveredSonosSpeaker(
+                    uid="speaker-2",
+                    name="Living Room",
+                    host="192.168.1.31",
+                    household_id="household-1",
+                    is_visible=True,
+                ),
+            ],
+            "Selected Sonos coordinator must be one of the selected speakers: ",
+        ),
     ],
 )
-def test_put_sonos_selection_rejects_invalid_uid_payloads(payload_data, detail):
+def test_put_sonos_selection_rejects_invalid_uid_payloads(payload_data, available_speakers, detail):
     settings_service = MagicMock()
     sonos_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = available_speakers
     controller = build_controller(settings_service=settings_service, sonos_service=sonos_service)
     route = cast(
         APIRoute,

--- a/tests/discstore/adapters/inbound/test_api_controller.py
+++ b/tests/discstore/adapters/inbound/test_api_controller.py
@@ -1,6 +1,6 @@
 import importlib.util
 import sys
-from typing import cast
+from typing import Dict, List, Tuple, cast
 from unittest.mock import MagicMock, create_autospec
 
 import pytest
@@ -24,7 +24,10 @@ if FASTAPI_INSTALLED:
     from jukebox.sonos.service import InspectedSelectedSonosGroup
 
 
-INVALID_UID_PAYLOAD_CASES = [
+InvalidUidPayloadCase = Tuple[Dict[str, object], List[object], str]
+
+
+INVALID_UID_PAYLOAD_CASES: List[InvalidUidPayloadCase] = [
     ({"uids": []}, [], "`uids` must include at least one UID."),
     ({"uids": ["speaker-1", "speaker-1"]}, [], "`uids` must not contain duplicate UIDs."),
 ]

--- a/tests/discstore/adapters/inbound/test_api_controller.py
+++ b/tests/discstore/adapters/inbound/test_api_controller.py
@@ -24,6 +24,44 @@ if FASTAPI_INSTALLED:
     from jukebox.sonos.service import InspectedSelectedSonosGroup
 
 
+INVALID_UID_PAYLOAD_CASES = [
+    ({"uids": []}, [], "`uids` must include at least one UID."),
+    ({"uids": ["speaker-1", "speaker-1"]}, [], "`uids` must not contain duplicate UIDs."),
+]
+
+if FASTAPI_INSTALLED:
+    INVALID_UID_PAYLOAD_CASES.append(
+        (
+            {"uids": ["speaker-1", "speaker-2"], "coordinator_uid": ""},
+            [
+                DiscoveredSonosSpeaker(
+                    uid="speaker-1",
+                    name="Kitchen",
+                    host="192.168.1.30",
+                    household_id="household-1",
+                    is_visible=True,
+                ),
+                DiscoveredSonosSpeaker(
+                    uid="speaker-2",
+                    name="Living Room",
+                    host="192.168.1.31",
+                    household_id="household-1",
+                    is_visible=True,
+                ),
+            ],
+            "Selected Sonos coordinator must be one of the selected speakers: ",
+        )
+    )
+else:
+    INVALID_UID_PAYLOAD_CASES.append(
+        (
+            {"uids": ["speaker-1", "speaker-2"], "coordinator_uid": ""},
+            [],
+            "Selected Sonos coordinator must be one of the selected speakers: ",
+        )
+    )
+
+
 def build_controller(
     *,
     get_current_tag_status=None,
@@ -533,30 +571,7 @@ def test_put_sonos_selection_persists_multi_speaker_selection():
 @pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
 @pytest.mark.parametrize(
     ("payload_data", "available_speakers", "detail"),
-    [
-        ({"uids": []}, [], "`uids` must include at least one UID."),
-        ({"uids": ["speaker-1", "speaker-1"]}, [], "`uids` must not contain duplicate UIDs."),
-        (
-            {"uids": ["speaker-1", "speaker-2"], "coordinator_uid": ""},
-            [
-                DiscoveredSonosSpeaker(
-                    uid="speaker-1",
-                    name="Kitchen",
-                    host="192.168.1.30",
-                    household_id="household-1",
-                    is_visible=True,
-                ),
-                DiscoveredSonosSpeaker(
-                    uid="speaker-2",
-                    name="Living Room",
-                    host="192.168.1.31",
-                    household_id="household-1",
-                    is_visible=True,
-                ),
-            ],
-            "Selected Sonos coordinator must be one of the selected speakers: ",
-        ),
-    ],
+    INVALID_UID_PAYLOAD_CASES,
 )
 def test_put_sonos_selection_rejects_invalid_uid_payloads(payload_data, available_speakers, detail):
     settings_service = MagicMock()

--- a/tests/jukebox/admin/test_app.py
+++ b/tests/jukebox/admin/test_app.py
@@ -1,6 +1,7 @@
 from unittest.mock import ANY, MagicMock
 
 import pytest
+from pydantic import ValidationError
 from typer.testing import CliRunner
 
 from discstore.commands import (
@@ -190,6 +191,20 @@ def test_jukebox_admin_preserves_os_errors(app_mocks):
     assert result.exit_code == 1
     assert "[Errno 13] Permission denied: '/tmp/settings.json'" in result.output
     assert "Unexpected error. Re-run with `--verbose` for details." not in result.output
+
+
+def test_jukebox_admin_rejects_coordinator_without_uids(app_mocks):
+    result = runner.invoke(app, ["sonos", "select", "--coordinator", "speaker-2"])
+
+    assert result.exit_code == 1
+    assert "--coordinator requires --uids" in result.output
+    app_mocks.build_admin_services.assert_not_called()
+    app_mocks.execute_sonos_command.assert_not_called()
+
+
+def test_sonos_select_command_rejects_coordinator_without_uids():
+    with pytest.raises(ValidationError, match="--coordinator requires --uids"):
+        SonosSelectCommand(type="sonos_select", coordinator="speaker-2")
 
 
 @pytest.mark.parametrize(

--- a/tests/jukebox/admin/test_app.py
+++ b/tests/jukebox/admin/test_app.py
@@ -72,8 +72,8 @@ def app_mocks(mocker):
         ),
         (["sonos", "list"], SonosListCommand(type="sonos_list"), "execute_sonos_command"),
         (
-            ["sonos", "select", "--uids", "speaker-1"],
-            SonosSelectCommand(type="sonos_select", uids=["speaker-1"]),
+            ["sonos", "select", "--uids", "speaker-1,speaker-2", "--coordinator", "speaker-2"],
+            SonosSelectCommand(type="sonos_select", uids=["speaker-1", "speaker-2"], coordinator="speaker-2"),
             "execute_sonos_command",
         ),
         (["sonos", "show"], SonosShowCommand(type="sonos_show"), "execute_sonos_command"),
@@ -111,6 +111,7 @@ def test_jukebox_admin_routes_admin_commands_by_category(app_mocks, args, expect
             sonos_service=services.sonos,
             settings_service=services.settings,
             speaker_prompt_fn=ANY,
+            coordinator_prompt_fn=ANY,
         )
         app_mocks.execute_settings_command.assert_not_called()
         app_mocks.execute_server_command.assert_not_called()

--- a/tests/jukebox/admin/test_app.py
+++ b/tests/jukebox/admin/test_app.py
@@ -76,6 +76,11 @@ def app_mocks(mocker):
             SonosSelectCommand(type="sonos_select", uids=["speaker-1", "speaker-2"], coordinator="speaker-2"),
             "execute_sonos_command",
         ),
+        (
+            ["sonos", "select", "--uids", "speaker-1", "--uids", "speaker-2", "--coordinator", "speaker-2"],
+            SonosSelectCommand(type="sonos_select", uids=["speaker-1", "speaker-2"], coordinator="speaker-2"),
+            "execute_sonos_command",
+        ),
         (["sonos", "show"], SonosShowCommand(type="sonos_show"), "execute_sonos_command"),
         (["api", "--port", "9000"], ApiCommand(type="api", port=9000), "execute_server_command"),
         (["ui", "--port", "9100"], UiCommand(type="ui", port=9100), "execute_server_command"),

--- a/tests/jukebox/admin/test_cli_presentation.py
+++ b/tests/jukebox/admin/test_cli_presentation.py
@@ -420,7 +420,7 @@ def test_render_sonos_selection_status_output_for_available_selection():
     )
 
     assert "Selected Sonos Group" in rendered
-    assert "- Coordinator UID: speaker-1" in rendered
+    assert "- Coordinator: Kitchen [speaker-1]" in rendered
     assert "- Status: available" in rendered
     assert "speaker-1" in rendered
     assert "speaker-2" in rendered
@@ -462,8 +462,47 @@ def test_render_sonos_selection_status_output_for_partially_available_selection(
     )
 
     assert "- Status: partially available" in rendered
+    assert "- Coordinator: Kitchen [speaker-1]" in rendered
     assert "speaker-2" in rendered
     assert "unavailable" in rendered
+
+
+def test_render_sonos_selection_status_output_falls_back_to_coordinator_uid_when_unresolved():
+    rendered = render_sonos_selection_status_output(
+        SonosSelectionStatus(
+            selected_group=SelectedSonosGroupSettings(
+                coordinator_uid="speaker-1",
+                members=[
+                    SelectedSonosSpeakerSettings(uid="speaker-1"),
+                    SelectedSonosSpeakerSettings(uid="speaker-2"),
+                ],
+            ),
+            availability=SonosSelectionAvailability(
+                status="unavailable",
+                members=[
+                    SonosSelectionMemberAvailability(
+                        uid="speaker-1",
+                        status="unavailable",
+                        speaker=None,
+                    ),
+                    SonosSelectionMemberAvailability(
+                        uid="speaker-2",
+                        status="available",
+                        speaker=DiscoveredSonosSpeaker(
+                            uid="speaker-2",
+                            name="Living Room",
+                            host="192.168.1.31",
+                            household_id="household-1",
+                            is_visible=True,
+                        ),
+                    ),
+                ],
+            ),
+        )
+    )
+
+    assert "- Coordinator UID: speaker-1" in rendered
+    assert "- Status: unavailable" in rendered
 
 
 def test_render_settings_output_json_mode_preserves_payload_shape():

--- a/tests/jukebox/admin/test_cli_presentation.py
+++ b/tests/jukebox/admin/test_cli_presentation.py
@@ -16,7 +16,12 @@ from jukebox.settings.errors import (
 )
 from jukebox.settings.types import JsonObject
 from jukebox.sonos.discovery import DiscoveredSonosSpeaker
-from jukebox.sonos.selection import SonosSelectionAvailability, SonosSelectionResult, SonosSelectionStatus
+from jukebox.sonos.selection import (
+    SonosSelectionAvailability,
+    SonosSelectionMemberAvailability,
+    SonosSelectionResult,
+    SonosSelectionStatus,
+)
 
 
 def test_render_settings_output_persisted_groups_overrides_by_section():
@@ -323,23 +328,43 @@ def test_build_sonos_speaker_choice_label_includes_host_for_disambiguation():
 def test_render_sonos_selection_saved_output_is_human_readable():
     rendered = render_sonos_selection_saved_output(
         SonosSelectionResult(
-            speaker=DiscoveredSonosSpeaker(
+            coordinator=DiscoveredSonosSpeaker(
                 uid="speaker-1",
                 name="Kitchen",
                 host="192.168.1.30",
                 household_id="household-1",
                 is_visible=True,
             ),
+            members=[
+                DiscoveredSonosSpeaker(
+                    uid="speaker-1",
+                    name="Kitchen",
+                    host="192.168.1.30",
+                    household_id="household-1",
+                    is_visible=True,
+                ),
+                DiscoveredSonosSpeaker(
+                    uid="speaker-2",
+                    name="Living Room",
+                    host="192.168.1.31",
+                    household_id="household-1",
+                    is_visible=True,
+                ),
+            ],
             selected_group=SelectedSonosGroupSettings(
                 coordinator_uid="speaker-1",
-                members=[SelectedSonosSpeakerSettings(uid="speaker-1")],
+                members=[
+                    SelectedSonosSpeakerSettings(uid="speaker-1"),
+                    SelectedSonosSpeakerSettings(uid="speaker-2"),
+                ],
             ),
             settings_message="Settings saved. Changes take effect after restart.",
         )
     )
 
-    assert "Selected Sonos speaker: Kitchen" in rendered
-    assert "UID: speaker-1" in rendered
+    assert "Selected Sonos group saved." in rendered
+    assert "Coordinator: Kitchen [speaker-1]" in rendered
+    assert "Members: Kitchen [speaker-1], Living Room [speaker-2]" in rendered
     assert "Settings saved. Changes take effect after restart." in rendered
 
 
@@ -347,11 +372,11 @@ def test_render_sonos_selection_status_output_for_not_selected():
     rendered = render_sonos_selection_status_output(
         SonosSelectionStatus(
             selected_group=None,
-            availability=SonosSelectionAvailability(status="not_selected", speaker=None),
+            availability=SonosSelectionAvailability(status="not_selected", members=[]),
         )
     )
 
-    assert rendered == "Selected Sonos Speaker\n\n- Status: not selected"
+    assert rendered == "Selected Sonos Group\n\n- Status: not selected"
 
 
 def test_render_sonos_selection_status_output_for_available_selection():
@@ -359,25 +384,86 @@ def test_render_sonos_selection_status_output_for_available_selection():
         SonosSelectionStatus(
             selected_group=SelectedSonosGroupSettings(
                 coordinator_uid="speaker-1",
-                members=[SelectedSonosSpeakerSettings(uid="speaker-1")],
+                members=[
+                    SelectedSonosSpeakerSettings(uid="speaker-1"),
+                    SelectedSonosSpeakerSettings(uid="speaker-2"),
+                ],
             ),
             availability=SonosSelectionAvailability(
                 status="available",
-                speaker=DiscoveredSonosSpeaker(
-                    uid="speaker-1",
-                    name="Kitchen",
-                    host="192.168.1.30",
-                    household_id="household-1",
-                    is_visible=True,
-                ),
+                members=[
+                    SonosSelectionMemberAvailability(
+                        uid="speaker-1",
+                        status="available",
+                        speaker=DiscoveredSonosSpeaker(
+                            uid="speaker-1",
+                            name="Kitchen",
+                            host="192.168.1.30",
+                            household_id="household-1",
+                            is_visible=True,
+                        ),
+                    ),
+                    SonosSelectionMemberAvailability(
+                        uid="speaker-2",
+                        status="available",
+                        speaker=DiscoveredSonosSpeaker(
+                            uid="speaker-2",
+                            name="Living Room",
+                            host="192.168.1.31",
+                            household_id="household-1",
+                            is_visible=True,
+                        ),
+                    ),
+                ],
             ),
         )
     )
 
-    assert "Selected Sonos Speaker" in rendered
-    assert "- UID: speaker-1" in rendered
+    assert "Selected Sonos Group" in rendered
+    assert "- Coordinator UID: speaker-1" in rendered
     assert "- Status: available" in rendered
-    assert "- Household: household-1" in rendered
+    assert "speaker-1" in rendered
+    assert "speaker-2" in rendered
+    assert "household-1" in rendered
+
+
+def test_render_sonos_selection_status_output_for_partially_available_selection():
+    rendered = render_sonos_selection_status_output(
+        SonosSelectionStatus(
+            selected_group=SelectedSonosGroupSettings(
+                coordinator_uid="speaker-1",
+                members=[
+                    SelectedSonosSpeakerSettings(uid="speaker-1"),
+                    SelectedSonosSpeakerSettings(uid="speaker-2"),
+                ],
+            ),
+            availability=SonosSelectionAvailability(
+                status="partial",
+                members=[
+                    SonosSelectionMemberAvailability(
+                        uid="speaker-1",
+                        status="available",
+                        speaker=DiscoveredSonosSpeaker(
+                            uid="speaker-1",
+                            name="Kitchen",
+                            host="192.168.1.30",
+                            household_id="household-1",
+                            is_visible=True,
+                        ),
+                    ),
+                    SonosSelectionMemberAvailability(
+                        uid="speaker-2",
+                        status="unavailable",
+                        speaker=None,
+                    ),
+                ],
+            ),
+        )
+    )
+
+    assert "- Status: partially available" in rendered
+    assert "speaker-2" in rendered
+    assert "unavailable" in rendered
 
 
 def test_render_settings_output_json_mode_preserves_payload_shape():

--- a/tests/jukebox/admin/test_command_handlers.py
+++ b/tests/jukebox/admin/test_command_handlers.py
@@ -22,10 +22,26 @@ from jukebox.admin.services import AdminServices
 from jukebox.settings.entities import ResolvedAdminRuntimeConfig
 from jukebox.shared.dependency_messages import optional_extra_dependency_message
 from jukebox.sonos.discovery import DiscoveredSonosSpeaker, SonosDiscoveryError
+from jukebox.sonos.service import InspectedSelectedSonosGroup
 
 
 def build_services():
     return AdminServices(settings=MagicMock(), sonos=MagicMock())
+
+
+def build_inspected_group(
+    resolved_members,
+    coordinator_uid,
+    missing_member_uids=None,
+    error_message=None,
+):
+    coordinator = next((member for member in resolved_members if member.uid == coordinator_uid), None)
+    return InspectedSelectedSonosGroup(
+        coordinator=coordinator,
+        resolved_members=list(resolved_members),
+        missing_member_uids=list(missing_member_uids or []),
+        error_message=error_message,
+    )
 
 
 def test_execute_settings_command_renders_human_readable_persisted_settings():
@@ -653,22 +669,25 @@ def test_execute_sonos_command_show_renders_saved_selection_status():
             }
         },
     }
-    sonos_service.list_available_speakers.return_value = [
-        DiscoveredSonosSpeaker(
-            uid="speaker-1",
-            name="Kitchen",
-            host="192.168.1.30",
-            household_id="household-1",
-            is_visible=True,
-        ),
-        DiscoveredSonosSpeaker(
-            uid="speaker-2",
-            name="Living Room",
-            host="192.168.1.31",
-            household_id="household-1",
-            is_visible=True,
-        ),
-    ]
+    sonos_service.inspect_selected_group.return_value = build_inspected_group(
+        resolved_members=[
+            DiscoveredSonosSpeaker(
+                uid="speaker-1",
+                name="Kitchen",
+                host="192.168.1.30",
+                household_id="household-1",
+                is_visible=True,
+            ),
+            DiscoveredSonosSpeaker(
+                uid="speaker-2",
+                name="Living Room",
+                host="192.168.1.31",
+                household_id="household-1",
+                is_visible=True,
+            ),
+        ],
+        coordinator_uid="speaker-1",
+    )
 
     execute_sonos_command(
         command=SonosShowCommand(type="sonos_show"),

--- a/tests/jukebox/admin/test_command_handlers.py
+++ b/tests/jukebox/admin/test_command_handlers.py
@@ -453,13 +453,15 @@ def test_execute_sonos_command_selects_requested_uid_and_renders_success():
 
     settings_service.patch_persisted_settings.assert_called_once()
     rendered_output = stdout_fn.call_args.args[0]
-    assert "Selected Sonos speaker: Kitchen" in rendered_output
-    assert "UID: speaker-1" in rendered_output
+    assert "Selected Sonos group saved." in rendered_output
+    assert "Coordinator: Kitchen [speaker-1]" in rendered_output
+    assert "Members: Kitchen [speaker-1]" in rendered_output
 
 
 def test_execute_sonos_command_selects_single_discovered_speaker_without_prompt():
     stdout_fn = MagicMock()
     prompt_fn = MagicMock()
+    coordinator_prompt_fn = MagicMock()
     sonos_service = MagicMock()
     settings_service = MagicMock()
     settings_service.patch_persisted_settings.return_value = {"message": "Settings saved."}
@@ -478,16 +480,19 @@ def test_execute_sonos_command_selects_single_discovered_speaker_without_prompt(
         sonos_service=sonos_service,
         settings_service=settings_service,
         speaker_prompt_fn=prompt_fn,
+        coordinator_prompt_fn=coordinator_prompt_fn,
         stdout_fn=stdout_fn,
     )
 
     prompt_fn.assert_not_called()
+    coordinator_prompt_fn.assert_not_called()
     settings_service.patch_persisted_settings.assert_called_once()
 
 
-def test_execute_sonos_command_uses_prompt_for_multiple_speakers():
+def test_execute_sonos_command_uses_prompts_for_multi_speaker_selection():
     stdout_fn = MagicMock()
-    prompt_fn = MagicMock(return_value="speaker-2")
+    prompt_fn = MagicMock(return_value=["speaker-1", "speaker-2"])
+    coordinator_prompt_fn = MagicMock(return_value="speaker-2")
     sonos_service = MagicMock()
     settings_service = MagicMock()
     settings_service.patch_persisted_settings.return_value = {"message": "Settings saved."}
@@ -513,10 +518,12 @@ def test_execute_sonos_command_uses_prompt_for_multiple_speakers():
         sonos_service=sonos_service,
         settings_service=settings_service,
         speaker_prompt_fn=prompt_fn,
+        coordinator_prompt_fn=coordinator_prompt_fn,
         stdout_fn=stdout_fn,
     )
 
     prompt_fn.assert_called_once_with(sonos_service.list_available_speakers.return_value)
+    coordinator_prompt_fn.assert_called_once_with(sonos_service.list_available_speakers.return_value)
     settings_service.patch_persisted_settings.assert_called_once()
     assert "speaker-2" in stdout_fn.call_args.args[0]
 
@@ -524,6 +531,7 @@ def test_execute_sonos_command_uses_prompt_for_multiple_speakers():
 def test_execute_sonos_command_cancel_does_not_write_settings():
     stdout_fn = MagicMock()
     prompt_fn = MagicMock(return_value=None)
+    coordinator_prompt_fn = MagicMock()
     sonos_service = MagicMock()
     settings_service = MagicMock()
     sonos_service.list_available_speakers.return_value = [
@@ -548,6 +556,79 @@ def test_execute_sonos_command_cancel_does_not_write_settings():
         sonos_service=sonos_service,
         settings_service=settings_service,
         speaker_prompt_fn=prompt_fn,
+        coordinator_prompt_fn=coordinator_prompt_fn,
+        stdout_fn=stdout_fn,
+    )
+
+    settings_service.patch_persisted_settings.assert_not_called()
+    coordinator_prompt_fn.assert_not_called()
+    stdout_fn.assert_not_called()
+
+
+def test_execute_sonos_command_rejects_empty_interactive_member_selection():
+    prompt_fn = MagicMock(return_value=[])
+    coordinator_prompt_fn = MagicMock()
+    sonos_service = MagicMock()
+    settings_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = [
+        DiscoveredSonosSpeaker(
+            uid="speaker-1",
+            name="Kitchen",
+            host="192.168.1.30",
+            household_id="household-1",
+            is_visible=True,
+        ),
+        DiscoveredSonosSpeaker(
+            uid="speaker-2",
+            name="Living Room",
+            host="192.168.1.31",
+            household_id="household-1",
+            is_visible=True,
+        ),
+    ]
+
+    with pytest.raises(RuntimeError, match="At least one Sonos speaker must be selected"):
+        execute_sonos_command(
+            command=SonosSelectCommand(type="sonos_select"),
+            sonos_service=sonos_service,
+            settings_service=settings_service,
+            speaker_prompt_fn=prompt_fn,
+            coordinator_prompt_fn=coordinator_prompt_fn,
+        )
+
+    settings_service.patch_persisted_settings.assert_not_called()
+    coordinator_prompt_fn.assert_not_called()
+
+
+def test_execute_sonos_command_cancelled_coordinator_prompt_does_not_write_settings():
+    stdout_fn = MagicMock()
+    prompt_fn = MagicMock(return_value=["speaker-1", "speaker-2"])
+    coordinator_prompt_fn = MagicMock(return_value=None)
+    sonos_service = MagicMock()
+    settings_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = [
+        DiscoveredSonosSpeaker(
+            uid="speaker-1",
+            name="Kitchen",
+            host="192.168.1.30",
+            household_id="household-1",
+            is_visible=True,
+        ),
+        DiscoveredSonosSpeaker(
+            uid="speaker-2",
+            name="Living Room",
+            host="192.168.1.31",
+            household_id="household-1",
+            is_visible=True,
+        ),
+    ]
+
+    execute_sonos_command(
+        command=SonosSelectCommand(type="sonos_select"),
+        sonos_service=sonos_service,
+        settings_service=settings_service,
+        speaker_prompt_fn=prompt_fn,
+        coordinator_prompt_fn=coordinator_prompt_fn,
         stdout_fn=stdout_fn,
     )
 
@@ -566,7 +647,7 @@ def test_execute_sonos_command_show_renders_saved_selection_status():
                 "sonos": {
                     "selected_group": {
                         "coordinator_uid": "speaker-1",
-                        "members": [{"uid": "speaker-1"}],
+                        "members": [{"uid": "speaker-1"}, {"uid": "speaker-2"}],
                     }
                 }
             }
@@ -579,7 +660,14 @@ def test_execute_sonos_command_show_renders_saved_selection_status():
             host="192.168.1.30",
             household_id="household-1",
             is_visible=True,
-        )
+        ),
+        DiscoveredSonosSpeaker(
+            uid="speaker-2",
+            name="Living Room",
+            host="192.168.1.31",
+            household_id="household-1",
+            is_visible=True,
+        ),
     ]
 
     execute_sonos_command(
@@ -590,19 +678,20 @@ def test_execute_sonos_command_show_renders_saved_selection_status():
     )
 
     rendered_output = stdout_fn.call_args.args[0]
-    assert "Selected Sonos Speaker" in rendered_output
+    assert "Selected Sonos Group" in rendered_output
     assert "- Status: available" in rendered_output
-    assert "- Host: 192.168.1.30" in rendered_output
+    assert "speaker-1" in rendered_output
+    assert "speaker-2" in rendered_output
 
 
-def test_execute_sonos_command_rejects_multiple_scripted_uids():
+def test_execute_sonos_command_rejects_duplicate_scripted_uids():
     sonos_service = MagicMock()
     settings_service = MagicMock()
     sonos_service.list_available_speakers.return_value = []
 
-    with pytest.raises(RuntimeError, match="exactly one UID"):
+    with pytest.raises(RuntimeError, match="must not contain duplicate UIDs"):
         execute_sonos_command(
-            command=SonosSelectCommand(type="sonos_select", uids=["speaker-1", "speaker-2"]),
+            command=SonosSelectCommand(type="sonos_select", uids=["speaker-1", "speaker-1"]),
             sonos_service=sonos_service,
             settings_service=settings_service,
         )

--- a/tests/jukebox/admin/test_command_handlers.py
+++ b/tests/jukebox/admin/test_command_handlers.py
@@ -512,7 +512,7 @@ def test_execute_sonos_command_uses_prompts_for_multi_speaker_selection():
     sonos_service = MagicMock()
     settings_service = MagicMock()
     settings_service.patch_persisted_settings.return_value = {"message": "Settings saved."}
-    sonos_service.list_available_speakers.return_value = [
+    available_speakers = [
         DiscoveredSonosSpeaker(
             uid="speaker-1",
             name="Kitchen",
@@ -527,7 +527,16 @@ def test_execute_sonos_command_uses_prompts_for_multi_speaker_selection():
             household_id="household-1",
             is_visible=True,
         ),
+        DiscoveredSonosSpeaker(
+            uid="speaker-3",
+            name="Bedroom",
+            host="192.168.1.32",
+            household_id="household-1",
+            is_visible=True,
+        ),
     ]
+    sonos_service.list_available_speakers.return_value = available_speakers
+    selected_speakers = available_speakers[:2]
 
     execute_sonos_command(
         command=SonosSelectCommand(type="sonos_select"),
@@ -538,8 +547,8 @@ def test_execute_sonos_command_uses_prompts_for_multi_speaker_selection():
         stdout_fn=stdout_fn,
     )
 
-    prompt_fn.assert_called_once_with(sonos_service.list_available_speakers.return_value)
-    coordinator_prompt_fn.assert_called_once_with(sonos_service.list_available_speakers.return_value)
+    prompt_fn.assert_called_once_with(available_speakers)
+    coordinator_prompt_fn.assert_called_once_with(selected_speakers)
     settings_service.patch_persisted_settings.assert_called_once()
     assert "speaker-2" in stdout_fn.call_args.args[0]
 

--- a/tests/jukebox/admin/test_command_handlers.py
+++ b/tests/jukebox/admin/test_command_handlers.py
@@ -474,9 +474,9 @@ def test_execute_sonos_command_selects_requested_uid_and_renders_success():
     assert "Members: Kitchen [speaker-1]" in rendered_output
 
 
-def test_execute_sonos_command_selects_single_discovered_speaker_without_prompt():
+def test_execute_sonos_command_prompts_for_single_discovered_speaker():
     stdout_fn = MagicMock()
-    prompt_fn = MagicMock()
+    prompt_fn = MagicMock(return_value=["speaker-1"])
     coordinator_prompt_fn = MagicMock()
     sonos_service = MagicMock()
     settings_service = MagicMock()
@@ -500,9 +500,30 @@ def test_execute_sonos_command_selects_single_discovered_speaker_without_prompt(
         stdout_fn=stdout_fn,
     )
 
-    prompt_fn.assert_not_called()
+    prompt_fn.assert_called_once_with(sonos_service.list_available_speakers.return_value)
     coordinator_prompt_fn.assert_not_called()
     settings_service.patch_persisted_settings.assert_called_once()
+
+
+def test_execute_sonos_command_reports_no_visible_speakers_before_prompting():
+    prompt_fn = MagicMock()
+    coordinator_prompt_fn = MagicMock()
+    sonos_service = MagicMock()
+    settings_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = []
+
+    with pytest.raises(RuntimeError, match="No visible Sonos speakers found."):
+        execute_sonos_command(
+            command=SonosSelectCommand(type="sonos_select"),
+            sonos_service=sonos_service,
+            settings_service=settings_service,
+            speaker_prompt_fn=prompt_fn,
+            coordinator_prompt_fn=coordinator_prompt_fn,
+        )
+
+    prompt_fn.assert_not_called()
+    coordinator_prompt_fn.assert_not_called()
+    settings_service.patch_persisted_settings.assert_not_called()
 
 
 def test_execute_sonos_command_uses_prompts_for_multi_speaker_selection():

--- a/tests/jukebox/settings/_helpers.py
+++ b/tests/jukebox/settings/_helpers.py
@@ -7,6 +7,8 @@ from jukebox.settings.entities import (
 from jukebox.settings.resolve import SettingsService
 from jukebox.settings.runtime_resolver import JukeboxRuntimeResolver
 from jukebox.settings.types import JsonObject, JsonValue
+from jukebox.sonos.discovery import DiscoveredSonosSpeaker
+from jukebox.sonos.service import InspectedSelectedSonosGroup
 
 
 def lookup_json_value(root: JsonObject, *path: str) -> JsonValue:
@@ -49,9 +51,11 @@ class StubSonosService:
     def __init__(
         self,
         resolved_group: Optional[ResolvedSonosGroupRuntime] = None,
+        inspected_group: Optional[InspectedSelectedSonosGroup] = None,
         error: Optional[Exception] = None,
     ):
         self.resolved_group = resolved_group
+        self.inspected_group = inspected_group
         self.error = error
         self.calls = []
 
@@ -61,6 +65,30 @@ class StubSonosService:
             raise self.error
         assert self.resolved_group is not None
         return self.resolved_group
+
+    def inspect_selected_group(self, selected_group):
+        self.calls.append(selected_group)
+        if self.error is not None:
+            raise self.error
+        if self.inspected_group is not None:
+            return self.inspected_group
+        assert self.resolved_group is not None
+        members = [
+            DiscoveredSonosSpeaker(
+                uid=member.uid,
+                name=member.name,
+                host=member.host,
+                household_id=member.household_id,
+                is_visible=True,
+            )
+            for member in self.resolved_group.members
+        ]
+        coordinator = next((member for member in members if member.uid == self.resolved_group.coordinator.uid), None)
+        return InspectedSelectedSonosGroup(
+            coordinator=coordinator,
+            resolved_members=members,
+            missing_member_uids=list(self.resolved_group.missing_member_uids),
+        )
 
     def list_available_speakers(self):
         return []

--- a/tests/jukebox/settings/test_settings_service_mutation_validation.py
+++ b/tests/jukebox/settings/test_settings_service_mutation_validation.py
@@ -79,6 +79,26 @@ def test_settings_service_set_rejects_invalid_selected_group_without_writing(tmp
     }
 
 
+def test_settings_service_set_rejects_duplicate_selected_group_members_without_writing(tmp_path):
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(
+        json.dumps({"schema_version": 1, "admin": {"api": {"port": 8100}}}),
+        encoding="utf-8",
+    )
+    service = SettingsService(repository=FileSettingsRepository(str(settings_path)))
+
+    with pytest.raises(InvalidSettingsError, match="selected_group.members must not contain duplicate uids"):
+        service.set_persisted_value(
+            "jukebox.player.sonos.selected_group",
+            '{"coordinator_uid":"speaker-1","members":[{"uid":"speaker-1"},{"uid":"speaker-1"}]}',
+        )
+
+    assert json.loads(settings_path.read_text(encoding="utf-8")) == {
+        "schema_version": 1,
+        "admin": {"api": {"port": 8100}},
+    }
+
+
 def test_settings_service_set_rejects_non_json_selected_group_without_writing(tmp_path):
     settings_path = tmp_path / "settings.json"
     settings_path.write_text(

--- a/tests/jukebox/settings/test_sonos_runtime.py
+++ b/tests/jukebox/settings/test_sonos_runtime.py
@@ -66,6 +66,31 @@ def test_default_sonos_service_marks_unreachable_non_coordinator_missing():
     assert resolved_group.missing_member_uids == ["speaker-2"]
 
 
+def test_default_sonos_service_inspect_selected_group_matches_runtime_for_mixed_households():
+    service = DefaultSonosService(
+        StubDiscovery(
+            [
+                build_discovered_speaker("speaker-1", "Kitchen", "192.168.1.30", "household-1"),
+                build_discovered_speaker("speaker-2", "Living Room", "192.168.1.40", "household-2"),
+            ]
+        )
+    )
+    selected_group = SelectedSonosGroupSettings(
+        coordinator_uid="speaker-2",
+        members=[
+            SelectedSonosSpeakerSettings(uid="speaker-1"),
+            SelectedSonosSpeakerSettings(uid="speaker-2"),
+        ],
+    )
+
+    inspection = service.inspect_selected_group(selected_group)
+
+    assert inspection.error_message == "Resolved Sonos group members must belong to the same household"
+
+    with pytest.raises(ValueError, match="same household"):
+        service.resolve_selected_group(selected_group)
+
+
 def test_default_sonos_service_rejects_unreachable_coordinator():
     service = DefaultSonosService(
         StubDiscovery([build_discovered_speaker("speaker-1", "Kitchen", "192.168.1.30", "household-1")])

--- a/tests/jukebox/sonos/test_selection.py
+++ b/tests/jukebox/sonos/test_selection.py
@@ -151,6 +151,22 @@ def test_plan_sonos_selection_rejects_explicit_coordinator_outside_selected_grou
     assert plan.error_message == "Selected Sonos coordinator must be one of the selected speakers: speaker-2"
 
 
+def test_plan_sonos_selection_rejects_blank_coordinator_uid():
+    sonos_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = [
+        build_speaker(uid="speaker-1"),
+        build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31"),
+    ]
+
+    plan = PlanSonosSelection(sonos_service=sonos_service).execute(
+        requested_uids=["speaker-1", "speaker-2"],
+        coordinator_uid="",
+    )
+
+    assert plan.status == "invalid_request"
+    assert plan.error_message == "Selected Sonos coordinator must be one of the selected speakers: "
+
+
 def test_plan_sonos_selection_rejects_mixed_household_input():
     sonos_service = MagicMock()
     sonos_service.list_available_speakers.return_value = [

--- a/tests/jukebox/sonos/test_selection.py
+++ b/tests/jukebox/sonos/test_selection.py
@@ -22,38 +22,71 @@ def build_speaker(uid="speaker-1", name="Kitchen", host="192.168.1.30", househol
     )
 
 
-def test_plan_sonos_selection_resolves_single_requested_uid():
+def test_plan_sonos_selection_resolves_requested_group_and_defaults_coordinator():
     sonos_service = MagicMock()
-    sonos_service.list_available_speakers.return_value = [build_speaker()]
+    sonos_service.list_available_speakers.return_value = [
+        build_speaker(uid="speaker-1"),
+        build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31"),
+    ]
 
-    plan = PlanSonosSelection(sonos_service=sonos_service).execute(requested_uids=["speaker-1"])
+    plan = PlanSonosSelection(sonos_service=sonos_service).execute(
+        requested_uids=["speaker-1", "speaker-2"],
+    )
 
     assert plan.status == "resolved"
-    assert plan.selected_uid == "speaker-1"
+    assert plan.selected_uids == ["speaker-1", "speaker-2"]
+    assert plan.coordinator_uid == "speaker-1"
 
 
-def test_save_sonos_selection_persists_one_member_selected_group_and_player_type():
+def test_plan_sonos_selection_resolves_requested_group_with_explicit_coordinator():
+    sonos_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = [
+        build_speaker(uid="speaker-1"),
+        build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31"),
+    ]
+
+    plan = PlanSonosSelection(sonos_service=sonos_service).execute(
+        requested_uids=["speaker-1", "speaker-2"],
+        coordinator_uid="speaker-2",
+    )
+
+    assert plan.status == "resolved"
+    assert plan.selected_uids == ["speaker-1", "speaker-2"]
+    assert plan.coordinator_uid == "speaker-2"
+
+
+def test_save_sonos_selection_persists_multi_member_selected_group_and_player_type():
     selected_group_repository = MagicMock()
     selected_group_repository.save_selected_group.return_value = SaveSelectedSonosGroupResult(
         message="Settings saved. Changes take effect after restart."
     )
     sonos_service = MagicMock()
-    sonos_service.list_available_speakers.return_value = [build_speaker()]
+    sonos_service.list_available_speakers.return_value = [
+        build_speaker(uid="speaker-1"),
+        build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31"),
+    ]
 
     result = SaveSonosSelection(
         selected_group_repository=selected_group_repository,
         sonos_service=sonos_service,
-    ).execute("speaker-1")
+    ).execute(["speaker-1", "speaker-2"], coordinator_uid="speaker-2")
 
-    assert result.speaker.uid == "speaker-1"
+    assert result.coordinator.uid == "speaker-2"
+    assert [member.uid for member in result.members] == ["speaker-1", "speaker-2"]
     assert result.selected_group == SelectedSonosGroupSettings(
-        coordinator_uid="speaker-1",
-        members=[SelectedSonosSpeakerSettings(uid="speaker-1")],
+        coordinator_uid="speaker-2",
+        members=[
+            SelectedSonosSpeakerSettings(uid="speaker-1"),
+            SelectedSonosSpeakerSettings(uid="speaker-2"),
+        ],
     )
     selected_group_repository.save_selected_group.assert_called_once_with(
         SelectedSonosGroupSettings(
-            coordinator_uid="speaker-1",
-            members=[SelectedSonosSpeakerSettings(uid="speaker-1")],
+            coordinator_uid="speaker-2",
+            members=[
+                SelectedSonosSpeakerSettings(uid="speaker-1"),
+                SelectedSonosSpeakerSettings(uid="speaker-2"),
+            ],
         )
     )
 
@@ -65,7 +98,7 @@ def test_plan_sonos_selection_rejects_unknown_uid():
     plan = PlanSonosSelection(sonos_service=sonos_service).execute(requested_uids=["speaker-9"])
 
     assert plan.status == "invalid_request"
-    assert plan.error_message == "Selected Sonos speaker is not currently discoverable: speaker-9"
+    assert plan.error_message == "Selected Sonos speakers are not currently discoverable: speaker-9"
 
 
 def test_save_sonos_selection_rejects_unknown_uid_without_writing():
@@ -77,18 +110,60 @@ def test_save_sonos_selection_rejects_unknown_uid_without_writing():
         SaveSonosSelection(
             selected_group_repository=selected_group_repository,
             sonos_service=sonos_service,
-        ).execute("speaker-9")
+        ).execute(["speaker-9"])
 
     selected_group_repository.save_selected_group.assert_not_called()
 
 
-def test_plan_sonos_selection_rejects_non_single_uid_input():
+def test_plan_sonos_selection_rejects_empty_uid_input():
     sonos_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = [build_speaker()]
 
-    plan = PlanSonosSelection(sonos_service=sonos_service).execute(requested_uids=["speaker-1", "speaker-2"])
+    plan = PlanSonosSelection(sonos_service=sonos_service).execute(requested_uids=[])
 
     assert plan.status == "invalid_request"
-    assert "exactly one UID" in str(plan.error_message)
+    assert plan.error_message == "`uids` must include at least one UID."
+
+
+def test_plan_sonos_selection_rejects_duplicate_uids():
+    sonos_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = [build_speaker()]
+
+    plan = PlanSonosSelection(sonos_service=sonos_service).execute(requested_uids=["speaker-1", "speaker-1"])
+
+    assert plan.status == "invalid_request"
+    assert plan.error_message == "`uids` must not contain duplicate UIDs."
+
+
+def test_plan_sonos_selection_rejects_explicit_coordinator_outside_selected_group():
+    sonos_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = [
+        build_speaker(uid="speaker-1"),
+        build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31"),
+    ]
+
+    plan = PlanSonosSelection(sonos_service=sonos_service).execute(
+        requested_uids=["speaker-1"],
+        coordinator_uid="speaker-2",
+    )
+
+    assert plan.status == "invalid_request"
+    assert plan.error_message == "Selected Sonos coordinator must be one of the selected speakers: speaker-2"
+
+
+def test_plan_sonos_selection_rejects_mixed_household_input():
+    sonos_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = [
+        build_speaker(uid="speaker-1", household_id="household-1"),
+        build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31", household_id="household-2"),
+    ]
+
+    plan = PlanSonosSelection(sonos_service=sonos_service).execute(
+        requested_uids=["speaker-1", "speaker-2"],
+    )
+
+    assert plan.status == "invalid_request"
+    assert plan.error_message == "Selected Sonos speakers must belong to the same household."
 
 
 def test_plan_sonos_selection_auto_selects_only_visible_speaker():
@@ -98,7 +173,8 @@ def test_plan_sonos_selection_auto_selects_only_visible_speaker():
     plan = PlanSonosSelection(sonos_service=sonos_service).execute()
 
     assert plan.status == "resolved"
-    assert plan.selected_uid == "speaker-1"
+    assert plan.selected_uids == ["speaker-1"]
+    assert plan.coordinator_uid == "speaker-1"
 
 
 def test_plan_sonos_selection_requires_choice_when_multiple_speakers_available():
@@ -137,38 +213,48 @@ def test_get_sonos_selection_status_reports_not_selected_without_discovery():
 
     assert status.selected_group is None
     assert status.availability.status == "not_selected"
-    assert status.availability.speaker is None
+    assert status.availability.members == []
     sonos_service.list_available_speakers.assert_not_called()
 
 
-def test_get_sonos_selection_status_reports_available_selection():
+def test_get_sonos_selection_status_reports_available_multi_speaker_selection():
     selected_group_repository = MagicMock()
     selected_group_repository.get_selected_group.return_value = SelectedSonosGroupSettings(
-        coordinator_uid="speaker-1",
-        members=[SelectedSonosSpeakerSettings(uid="speaker-1")],
+        coordinator_uid="speaker-2",
+        members=[
+            SelectedSonosSpeakerSettings(uid="speaker-1"),
+            SelectedSonosSpeakerSettings(uid="speaker-2"),
+        ],
     )
     sonos_service = MagicMock()
-    sonos_service.list_available_speakers.return_value = [build_speaker()]
+    sonos_service.list_available_speakers.return_value = [
+        build_speaker(uid="speaker-1"),
+        build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31"),
+    ]
 
     status = GetSonosSelectionStatus(
         selected_group_repository=selected_group_repository,
         sonos_service=sonos_service,
     ).execute()
 
-    assert status.selected_uid == "speaker-1"
+    assert status.selected_uid == "speaker-2"
     assert status.availability.status == "available"
-    assert status.availability.speaker is not None
-    assert status.availability.speaker.host == "192.168.1.30"
+    assert [member.status for member in status.availability.members] == ["available", "available"]
+    assert status.availability.members[1].speaker is not None
+    assert status.availability.members[1].speaker.host == "192.168.1.31"
 
 
-def test_get_sonos_selection_status_reports_unavailable_selection():
+def test_get_sonos_selection_status_reports_partially_available_selection():
     selected_group_repository = MagicMock()
     selected_group_repository.get_selected_group.return_value = SelectedSonosGroupSettings(
         coordinator_uid="speaker-1",
-        members=[SelectedSonosSpeakerSettings(uid="speaker-1")],
+        members=[
+            SelectedSonosSpeakerSettings(uid="speaker-1"),
+            SelectedSonosSpeakerSettings(uid="speaker-2"),
+        ],
     )
     sonos_service = MagicMock()
-    sonos_service.list_available_speakers.return_value = [build_speaker(uid="speaker-2", host="192.168.1.31")]
+    sonos_service.list_available_speakers.return_value = [build_speaker(uid="speaker-1")]
 
     status = GetSonosSelectionStatus(
         selected_group_repository=selected_group_repository,
@@ -176,5 +262,27 @@ def test_get_sonos_selection_status_reports_unavailable_selection():
     ).execute()
 
     assert status.selected_uid == "speaker-1"
+    assert status.availability.status == "partial"
+    assert [member.status for member in status.availability.members] == ["available", "unavailable"]
+
+
+def test_get_sonos_selection_status_reports_unavailable_selection_when_coordinator_is_missing():
+    selected_group_repository = MagicMock()
+    selected_group_repository.get_selected_group.return_value = SelectedSonosGroupSettings(
+        coordinator_uid="speaker-2",
+        members=[
+            SelectedSonosSpeakerSettings(uid="speaker-1"),
+            SelectedSonosSpeakerSettings(uid="speaker-2"),
+        ],
+    )
+    sonos_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = [build_speaker(uid="speaker-1", host="192.168.1.31")]
+
+    status = GetSonosSelectionStatus(
+        selected_group_repository=selected_group_repository,
+        sonos_service=sonos_service,
+    ).execute()
+
+    assert status.selected_uid == "speaker-2"
     assert status.availability.status == "unavailable"
-    assert status.availability.speaker is None
+    assert [member.status for member in status.availability.members] == ["available", "unavailable"]

--- a/tests/jukebox/sonos/test_selection.py
+++ b/tests/jukebox/sonos/test_selection.py
@@ -302,3 +302,54 @@ def test_get_sonos_selection_status_reports_unavailable_selection_when_coordinat
     assert status.selected_uid == "speaker-2"
     assert status.availability.status == "unavailable"
     assert [member.status for member in status.availability.members] == ["available", "unavailable"]
+
+
+def test_get_sonos_selection_status_reports_unavailable_selection_for_mixed_households():
+    selected_group_repository = MagicMock()
+    selected_group_repository.get_selected_group.return_value = SelectedSonosGroupSettings(
+        coordinator_uid="speaker-1",
+        members=[
+            SelectedSonosSpeakerSettings(uid="speaker-1"),
+            SelectedSonosSpeakerSettings(uid="speaker-2"),
+        ],
+    )
+    sonos_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = [
+        build_speaker(uid="speaker-1", household_id="household-1"),
+        build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31", household_id="household-2"),
+    ]
+
+    status = GetSonosSelectionStatus(
+        selected_group_repository=selected_group_repository,
+        sonos_service=sonos_service,
+    ).execute()
+
+    assert status.selected_uid == "speaker-1"
+    assert status.availability.status == "unavailable"
+    assert [member.status for member in status.availability.members] == ["available", "available"]
+
+
+def test_get_sonos_selection_status_reports_unavailable_when_partial_group_spans_households():
+    selected_group_repository = MagicMock()
+    selected_group_repository.get_selected_group.return_value = SelectedSonosGroupSettings(
+        coordinator_uid="speaker-1",
+        members=[
+            SelectedSonosSpeakerSettings(uid="speaker-1"),
+            SelectedSonosSpeakerSettings(uid="speaker-2"),
+            SelectedSonosSpeakerSettings(uid="speaker-3"),
+        ],
+    )
+    sonos_service = MagicMock()
+    sonos_service.list_available_speakers.return_value = [
+        build_speaker(uid="speaker-1", household_id="household-1"),
+        build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31", household_id="household-2"),
+    ]
+
+    status = GetSonosSelectionStatus(
+        selected_group_repository=selected_group_repository,
+        sonos_service=sonos_service,
+    ).execute()
+
+    assert status.selected_uid == "speaker-1"
+    assert status.availability.status == "unavailable"
+    assert [member.status for member in status.availability.members] == ["available", "available", "unavailable"]

--- a/tests/jukebox/sonos/test_selection.py
+++ b/tests/jukebox/sonos/test_selection.py
@@ -10,6 +10,7 @@ from jukebox.sonos.selection import (
     SaveSelectedSonosGroupResult,
     SaveSonosSelection,
 )
+from jukebox.sonos.service import InspectedSelectedSonosGroup
 
 
 def build_speaker(uid="speaker-1", name="Kitchen", host="192.168.1.30", household_id="household-1"):
@@ -19,6 +20,21 @@ def build_speaker(uid="speaker-1", name="Kitchen", host="192.168.1.30", househol
         host=host,
         household_id=household_id,
         is_visible=True,
+    )
+
+
+def build_inspected_group(
+    resolved_members,
+    coordinator_uid,
+    missing_member_uids=None,
+    error_message=None,
+):
+    coordinator = next((member for member in resolved_members if member.uid == coordinator_uid), None)
+    return InspectedSelectedSonosGroup(
+        coordinator=coordinator,
+        resolved_members=list(resolved_members),
+        missing_member_uids=list(missing_member_uids or []),
+        error_message=error_message,
     )
 
 
@@ -230,7 +246,7 @@ def test_get_sonos_selection_status_reports_not_selected_without_discovery():
     assert status.selected_group is None
     assert status.availability.status == "not_selected"
     assert status.availability.members == []
-    sonos_service.list_available_speakers.assert_not_called()
+    sonos_service.inspect_selected_group.assert_not_called()
 
 
 def test_get_sonos_selection_status_reports_available_multi_speaker_selection():
@@ -243,10 +259,13 @@ def test_get_sonos_selection_status_reports_available_multi_speaker_selection():
         ],
     )
     sonos_service = MagicMock()
-    sonos_service.list_available_speakers.return_value = [
-        build_speaker(uid="speaker-1"),
-        build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31"),
-    ]
+    sonos_service.inspect_selected_group.return_value = build_inspected_group(
+        resolved_members=[
+            build_speaker(uid="speaker-1"),
+            build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31"),
+        ],
+        coordinator_uid="speaker-2",
+    )
 
     status = GetSonosSelectionStatus(
         selected_group_repository=selected_group_repository,
@@ -270,7 +289,11 @@ def test_get_sonos_selection_status_reports_partially_available_selection():
         ],
     )
     sonos_service = MagicMock()
-    sonos_service.list_available_speakers.return_value = [build_speaker(uid="speaker-1")]
+    sonos_service.inspect_selected_group.return_value = build_inspected_group(
+        resolved_members=[build_speaker(uid="speaker-1")],
+        coordinator_uid="speaker-1",
+        missing_member_uids=["speaker-2"],
+    )
 
     status = GetSonosSelectionStatus(
         selected_group_repository=selected_group_repository,
@@ -292,7 +315,11 @@ def test_get_sonos_selection_status_reports_unavailable_selection_when_coordinat
         ],
     )
     sonos_service = MagicMock()
-    sonos_service.list_available_speakers.return_value = [build_speaker(uid="speaker-1", host="192.168.1.31")]
+    sonos_service.inspect_selected_group.return_value = build_inspected_group(
+        resolved_members=[build_speaker(uid="speaker-1", host="192.168.1.31")],
+        coordinator_uid="speaker-2",
+        error_message="Unable to resolve saved Sonos coordinator: speaker-2: not found on network",
+    )
 
     status = GetSonosSelectionStatus(
         selected_group_repository=selected_group_repository,
@@ -314,10 +341,14 @@ def test_get_sonos_selection_status_reports_unavailable_selection_for_mixed_hous
         ],
     )
     sonos_service = MagicMock()
-    sonos_service.list_available_speakers.return_value = [
-        build_speaker(uid="speaker-1", household_id="household-1"),
-        build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31", household_id="household-2"),
-    ]
+    sonos_service.inspect_selected_group.return_value = build_inspected_group(
+        resolved_members=[
+            build_speaker(uid="speaker-1", household_id="household-1"),
+            build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31", household_id="household-2"),
+        ],
+        coordinator_uid="speaker-1",
+        error_message="Resolved Sonos group members must belong to the same household",
+    )
 
     status = GetSonosSelectionStatus(
         selected_group_repository=selected_group_repository,
@@ -340,10 +371,15 @@ def test_get_sonos_selection_status_reports_unavailable_when_partial_group_spans
         ],
     )
     sonos_service = MagicMock()
-    sonos_service.list_available_speakers.return_value = [
-        build_speaker(uid="speaker-1", household_id="household-1"),
-        build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31", household_id="household-2"),
-    ]
+    sonos_service.inspect_selected_group.return_value = build_inspected_group(
+        resolved_members=[
+            build_speaker(uid="speaker-1", household_id="household-1"),
+            build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31", household_id="household-2"),
+        ],
+        coordinator_uid="speaker-1",
+        missing_member_uids=["speaker-3"],
+        error_message="Resolved Sonos group members must belong to the same household",
+    )
 
     status = GetSonosSelectionStatus(
         selected_group_repository=selected_group_repository,

--- a/tests/jukebox/sonos/test_selection.py
+++ b/tests/jukebox/sonos/test_selection.py
@@ -6,7 +6,6 @@ from jukebox.settings.entities import SelectedSonosGroupSettings, SelectedSonosS
 from jukebox.sonos.discovery import DiscoveredSonosSpeaker
 from jukebox.sonos.selection import (
     GetSonosSelectionStatus,
-    PlanSonosSelection,
     SaveSelectedSonosGroupResult,
     SaveSonosSelection,
 )
@@ -38,37 +37,33 @@ def build_inspected_group(
     )
 
 
-def test_plan_sonos_selection_resolves_requested_group_and_defaults_coordinator():
+def test_save_sonos_selection_defaults_coordinator_to_first_selected_uid():
+    selected_group_repository = MagicMock()
+    selected_group_repository.save_selected_group.return_value = SaveSelectedSonosGroupResult(
+        message="Settings saved. Changes take effect after restart."
+    )
     sonos_service = MagicMock()
     sonos_service.list_available_speakers.return_value = [
         build_speaker(uid="speaker-1"),
         build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31"),
     ]
 
-    plan = PlanSonosSelection(sonos_service=sonos_service).execute(
-        requested_uids=["speaker-1", "speaker-2"],
+    result = SaveSonosSelection(
+        selected_group_repository=selected_group_repository,
+        sonos_service=sonos_service,
+    ).execute(["speaker-1", "speaker-2"])
+
+    assert result.coordinator.uid == "speaker-1"
+    assert [member.uid for member in result.members] == ["speaker-1", "speaker-2"]
+    selected_group_repository.save_selected_group.assert_called_once_with(
+        SelectedSonosGroupSettings(
+            coordinator_uid="speaker-1",
+            members=[
+                SelectedSonosSpeakerSettings(uid="speaker-1"),
+                SelectedSonosSpeakerSettings(uid="speaker-2"),
+            ],
+        )
     )
-
-    assert plan.status == "resolved"
-    assert plan.selected_uids == ["speaker-1", "speaker-2"]
-    assert plan.coordinator_uid == "speaker-1"
-
-
-def test_plan_sonos_selection_resolves_requested_group_with_explicit_coordinator():
-    sonos_service = MagicMock()
-    sonos_service.list_available_speakers.return_value = [
-        build_speaker(uid="speaker-1"),
-        build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31"),
-    ]
-
-    plan = PlanSonosSelection(sonos_service=sonos_service).execute(
-        requested_uids=["speaker-1", "speaker-2"],
-        coordinator_uid="speaker-2",
-    )
-
-    assert plan.status == "resolved"
-    assert plan.selected_uids == ["speaker-1", "speaker-2"]
-    assert plan.coordinator_uid == "speaker-2"
 
 
 def test_save_sonos_selection_persists_multi_member_selected_group_and_player_type():
@@ -107,16 +102,6 @@ def test_save_sonos_selection_persists_multi_member_selected_group_and_player_ty
     )
 
 
-def test_plan_sonos_selection_rejects_unknown_uid():
-    sonos_service = MagicMock()
-    sonos_service.list_available_speakers.return_value = [build_speaker()]
-
-    plan = PlanSonosSelection(sonos_service=sonos_service).execute(requested_uids=["speaker-9"])
-
-    assert plan.status == "invalid_request"
-    assert plan.error_message == "Selected Sonos speakers are not currently discoverable: speaker-9"
-
-
 def test_save_sonos_selection_rejects_unknown_uid_without_writing():
     selected_group_repository = MagicMock()
     sonos_service = MagicMock()
@@ -131,106 +116,83 @@ def test_save_sonos_selection_rejects_unknown_uid_without_writing():
     selected_group_repository.save_selected_group.assert_not_called()
 
 
-def test_plan_sonos_selection_rejects_empty_uid_input():
+def test_save_sonos_selection_rejects_empty_uid_input():
+    selected_group_repository = MagicMock()
     sonos_service = MagicMock()
     sonos_service.list_available_speakers.return_value = [build_speaker()]
 
-    plan = PlanSonosSelection(sonos_service=sonos_service).execute(requested_uids=[])
+    with pytest.raises(ValueError, match="`uids` must include at least one UID."):
+        SaveSonosSelection(
+            selected_group_repository=selected_group_repository,
+            sonos_service=sonos_service,
+        ).execute([])
 
-    assert plan.status == "invalid_request"
-    assert plan.error_message == "`uids` must include at least one UID."
+    selected_group_repository.save_selected_group.assert_not_called()
 
 
-def test_plan_sonos_selection_rejects_duplicate_uids():
+def test_save_sonos_selection_rejects_duplicate_uids():
+    selected_group_repository = MagicMock()
     sonos_service = MagicMock()
     sonos_service.list_available_speakers.return_value = [build_speaker()]
 
-    plan = PlanSonosSelection(sonos_service=sonos_service).execute(requested_uids=["speaker-1", "speaker-1"])
+    with pytest.raises(ValueError, match="`uids` must not contain duplicate UIDs."):
+        SaveSonosSelection(
+            selected_group_repository=selected_group_repository,
+            sonos_service=sonos_service,
+        ).execute(["speaker-1", "speaker-1"])
 
-    assert plan.status == "invalid_request"
-    assert plan.error_message == "`uids` must not contain duplicate UIDs."
+    selected_group_repository.save_selected_group.assert_not_called()
 
 
-def test_plan_sonos_selection_rejects_explicit_coordinator_outside_selected_group():
+def test_save_sonos_selection_rejects_explicit_coordinator_outside_selected_group():
+    selected_group_repository = MagicMock()
     sonos_service = MagicMock()
     sonos_service.list_available_speakers.return_value = [
         build_speaker(uid="speaker-1"),
         build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31"),
     ]
 
-    plan = PlanSonosSelection(sonos_service=sonos_service).execute(
-        requested_uids=["speaker-1"],
-        coordinator_uid="speaker-2",
-    )
+    with pytest.raises(ValueError, match="Selected Sonos coordinator must be one of the selected speakers: speaker-2"):
+        SaveSonosSelection(
+            selected_group_repository=selected_group_repository,
+            sonos_service=sonos_service,
+        ).execute(["speaker-1"], coordinator_uid="speaker-2")
 
-    assert plan.status == "invalid_request"
-    assert plan.error_message == "Selected Sonos coordinator must be one of the selected speakers: speaker-2"
+    selected_group_repository.save_selected_group.assert_not_called()
 
 
-def test_plan_sonos_selection_rejects_blank_coordinator_uid():
+def test_save_sonos_selection_rejects_blank_coordinator_uid():
+    selected_group_repository = MagicMock()
     sonos_service = MagicMock()
     sonos_service.list_available_speakers.return_value = [
         build_speaker(uid="speaker-1"),
         build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31"),
     ]
 
-    plan = PlanSonosSelection(sonos_service=sonos_service).execute(
-        requested_uids=["speaker-1", "speaker-2"],
-        coordinator_uid="",
-    )
+    with pytest.raises(ValueError, match="Selected Sonos coordinator must be one of the selected speakers: "):
+        SaveSonosSelection(
+            selected_group_repository=selected_group_repository,
+            sonos_service=sonos_service,
+        ).execute(["speaker-1", "speaker-2"], coordinator_uid="")
 
-    assert plan.status == "invalid_request"
-    assert plan.error_message == "Selected Sonos coordinator must be one of the selected speakers: "
+    selected_group_repository.save_selected_group.assert_not_called()
 
 
-def test_plan_sonos_selection_rejects_mixed_household_input():
+def test_save_sonos_selection_rejects_mixed_household_input():
+    selected_group_repository = MagicMock()
     sonos_service = MagicMock()
     sonos_service.list_available_speakers.return_value = [
         build_speaker(uid="speaker-1", household_id="household-1"),
         build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31", household_id="household-2"),
     ]
 
-    plan = PlanSonosSelection(sonos_service=sonos_service).execute(
-        requested_uids=["speaker-1", "speaker-2"],
-    )
+    with pytest.raises(ValueError, match="Selected Sonos speakers must belong to the same household."):
+        SaveSonosSelection(
+            selected_group_repository=selected_group_repository,
+            sonos_service=sonos_service,
+        ).execute(["speaker-1", "speaker-2"])
 
-    assert plan.status == "invalid_request"
-    assert plan.error_message == "Selected Sonos speakers must belong to the same household."
-
-
-def test_plan_sonos_selection_auto_selects_only_visible_speaker():
-    sonos_service = MagicMock()
-    sonos_service.list_available_speakers.return_value = [build_speaker()]
-
-    plan = PlanSonosSelection(sonos_service=sonos_service).execute()
-
-    assert plan.status == "resolved"
-    assert plan.selected_uids == ["speaker-1"]
-    assert plan.coordinator_uid == "speaker-1"
-
-
-def test_plan_sonos_selection_requires_choice_when_multiple_speakers_available():
-    sonos_service = MagicMock()
-    available_speakers = [
-        build_speaker(uid="speaker-1"),
-        build_speaker(uid="speaker-2", host="192.168.1.31"),
-    ]
-    sonos_service.list_available_speakers.return_value = available_speakers
-
-    plan = PlanSonosSelection(sonos_service=sonos_service).execute()
-
-    assert plan.status == "needs_choice"
-    assert plan.speakers == available_speakers
-
-
-def test_plan_sonos_selection_reports_none_available_when_no_speakers_found():
-    sonos_service = MagicMock()
-    sonos_service.list_available_speakers.return_value = []
-
-    plan = PlanSonosSelection(sonos_service=sonos_service).execute()
-
-    assert plan.status == "none_available"
-    assert plan.error_message == "No visible Sonos speakers found."
+    selected_group_repository.save_selected_group.assert_not_called()
 
 
 def test_get_sonos_selection_status_reports_not_selected_without_discovery():
@@ -272,7 +234,8 @@ def test_get_sonos_selection_status_reports_available_multi_speaker_selection():
         sonos_service=sonos_service,
     ).execute()
 
-    assert status.selected_uid == "speaker-2"
+    assert status.selected_group is not None
+    assert status.selected_group.coordinator_uid == "speaker-2"
     assert status.availability.status == "available"
     assert [member.status for member in status.availability.members] == ["available", "available"]
     assert status.availability.members[1].speaker is not None
@@ -300,7 +263,8 @@ def test_get_sonos_selection_status_reports_partially_available_selection():
         sonos_service=sonos_service,
     ).execute()
 
-    assert status.selected_uid == "speaker-1"
+    assert status.selected_group is not None
+    assert status.selected_group.coordinator_uid == "speaker-1"
     assert status.availability.status == "partial"
     assert [member.status for member in status.availability.members] == ["available", "unavailable"]
 
@@ -326,7 +290,8 @@ def test_get_sonos_selection_status_reports_unavailable_selection_when_coordinat
         sonos_service=sonos_service,
     ).execute()
 
-    assert status.selected_uid == "speaker-2"
+    assert status.selected_group is not None
+    assert status.selected_group.coordinator_uid == "speaker-2"
     assert status.availability.status == "unavailable"
     assert [member.status for member in status.availability.members] == ["available", "unavailable"]
 
@@ -355,7 +320,8 @@ def test_get_sonos_selection_status_reports_unavailable_selection_for_mixed_hous
         sonos_service=sonos_service,
     ).execute()
 
-    assert status.selected_uid == "speaker-1"
+    assert status.selected_group is not None
+    assert status.selected_group.coordinator_uid == "speaker-1"
     assert status.availability.status == "unavailable"
     assert [member.status for member in status.availability.members] == ["available", "available"]
 
@@ -386,6 +352,7 @@ def test_get_sonos_selection_status_reports_unavailable_when_partial_group_spans
         sonos_service=sonos_service,
     ).execute()
 
-    assert status.selected_uid == "speaker-1"
+    assert status.selected_group is not None
+    assert status.selected_group.coordinator_uid == "speaker-1"
     assert status.availability.status == "unavailable"
     assert [member.status for member in status.availability.members] == ["available", "available", "unavailable"]


### PR DESCRIPTION
Closes #178.

## Summary

This PR extends Sonos speaker selection from a single saved speaker to a saved Sonos group with an explicit coordinator.

It updates the selection flow across the admin CLI, settings persistence, Sonos selection logic, and the discstore API so we can:

- persist multiple selected Sonos speaker UIDs
- choose and persist a coordinator for the selected group
- validate that all selected speakers are discoverable and belong to the same household
- reject empty selections, duplicate UIDs, and coordinators outside the selected group
- report per-member availability, including a new `partial` availability state when some group members are missing but the coordinator is still available

## User-Facing Changes

### Admin CLI

- `jukebox-admin sonos select` now accepts comma-separated `--uids`
- `jukebox-admin sonos select` now accepts `--coordinator`
- interactive selection now supports choosing multiple speakers, then choosing a coordinator when more than one speaker is selected
- `jukebox-admin sonos show` now renders the selected Sonos group, including coordinator and member availability

### API

- `PUT /api/v1/sonos/selection` now accepts:
  - `uids: list[str]`
  - `coordinator_uid: Optional[str]`
- Sonos selection responses now return availability per selected member instead of a single speaker
- availability can now be `not_selected`, `available`, `partial`, or `unavailable`

## Implementation Notes

- `SelectedSonosGroupSettings` now enforces unique member UIDs
- Sonos selection planning and saving now operate on groups instead of a single speaker
- saved selection status distinguishes:
  - `available`: all members available
  - `partial`: coordinator available, but one or more members missing
  - `unavailable`: coordinator missing