### PR TITLE
Clean up disc API routes

### DIFF
--- a/discstore/adapters/inbound/api_controller.py
+++ b/discstore/adapters/inbound/api_controller.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, cast
+from typing import Any, Dict, Optional, cast
 
 from pydantic import BaseModel, RootModel
 
@@ -11,10 +11,11 @@ except ModuleNotFoundError as e:
         optional_extra_dependency_message("The `api_controller` module", "api", "discstore api")
     ) from e
 
-from discstore.domain.entities import CurrentTagStatus, Disc
+from discstore.domain.entities import CurrentTagStatus, Disc, DiscMetadata, DiscOption
 from discstore.domain.use_cases.add_disc import AddDisc
 from discstore.domain.use_cases.edit_disc import EditDisc
 from discstore.domain.use_cases.get_current_tag_status import GetCurrentTagStatus
+from discstore.domain.use_cases.get_disc import GetDisc
 from discstore.domain.use_cases.list_discs import ListDiscs
 from discstore.domain.use_cases.remove_disc import RemoveDisc
 from jukebox.settings.errors import SettingsError
@@ -22,12 +23,30 @@ from jukebox.settings.service_protocols import SettingsService
 from jukebox.settings.types import JsonObject
 
 
-class DiscInput(Disc):
+class DiscCreateInput(Disc):
     pass
 
 
 class DiscOutput(Disc):
     pass
+
+
+class DiscMetadataPatchInput(BaseModel):
+    artist: Optional[str] = None
+    album: Optional[str] = None
+    track: Optional[str] = None
+    playlist: Optional[str] = None
+
+
+class DiscOptionPatchInput(BaseModel):
+    shuffle: Optional[bool] = None
+    is_test: Optional[bool] = None
+
+
+class DiscPatchInput(BaseModel):
+    uri: Optional[str] = None
+    metadata: Optional[DiscMetadataPatchInput] = None
+    option: Optional[DiscOptionPatchInput] = None
 
 
 class CurrentTagStatusOutput(CurrentTagStatus):
@@ -49,6 +68,7 @@ class APIController:
         list_discs: ListDiscs,
         remove_disc: RemoveDisc,
         edit_disc: EditDisc,
+        get_disc: GetDisc,
         get_current_tag_status: GetCurrentTagStatus,
         settings_service: SettingsService,
     ):
@@ -56,6 +76,7 @@ class APIController:
         self.list_discs = list_discs
         self.remove_disc = remove_disc
         self.edit_disc = edit_disc
+        self.get_disc = get_disc
         self.get_current_tag_status = get_current_tag_status
         self.settings_service = settings_service
         self.app = FastAPI(
@@ -70,6 +91,16 @@ class APIController:
         @self.app.get("/api/v1/discs", response_model=Dict[str, DiscOutput])
         def list_discs():
             return self.list_discs.execute()
+
+        @self.app.get("/api/v1/discs/{tag_id}", response_model=DiscOutput)
+        def get_disc(tag_id: str):
+            try:
+                disc = self.get_disc.execute(tag_id)
+                return DiscOutput(**disc.model_dump())
+            except ValueError as value_err:
+                raise HTTPException(status_code=404, detail=str(value_err))
+            except Exception as err:
+                raise HTTPException(status_code=500, detail=f"Server error: {str(err)}")
 
         @self.app.get(
             "/api/v1/current-tag",
@@ -115,19 +146,35 @@ class APIController:
             except Exception as err:
                 raise HTTPException(status_code=500, detail=f"Server error: {str(err)}")
 
-        @self.app.post("/api/v1/disc", status_code=201)
-        def add_or_edit_disc(tag_id: str, disc: DiscInput):
+        @self.app.post("/api/v1/discs/{tag_id}", status_code=201)
+        def create_disc(tag_id: str, disc: DiscCreateInput):
             try:
                 self.add_disc.execute(tag_id, Disc(**disc.model_dump()))
                 return {"message": "Disc added"}
-            except ValueError:
-                new_disc = Disc(**disc.model_dump())
-                self.edit_disc.execute(tag_id, new_disc.uri, new_disc.metadata, new_disc.option)
-                return {"message": "Disc edited"}
+            except ValueError as value_err:
+                raise HTTPException(status_code=409, detail=str(value_err))
             except Exception as err:
                 raise HTTPException(status_code=500, detail=f"Server error: {str(err)}")
 
-        @self.app.delete("/api/v1/disc", status_code=200)
+        @self.app.patch("/api/v1/discs/{tag_id}", status_code=200)
+        def update_disc(tag_id: str, disc: DiscPatchInput):
+            metadata = None
+            if disc.metadata is not None:
+                metadata = DiscMetadata(**disc.metadata.model_dump(exclude_unset=True))
+
+            option = None
+            if disc.option is not None:
+                option = DiscOption(**disc.option.model_dump(exclude_unset=True))
+
+            try:
+                self.edit_disc.execute(tag_id=tag_id, uri=disc.uri, metadata=metadata, option=option)
+                return {"message": "Disc updated"}
+            except ValueError as value_err:
+                raise HTTPException(status_code=404, detail=str(value_err))
+            except Exception as err:
+                raise HTTPException(status_code=500, detail=f"Server error: {str(err)}")
+
+        @self.app.delete("/api/v1/discs/{tag_id}", status_code=200)
         def remove_disc(tag_id: str):
             try:
                 self.remove_disc.execute(tag_id)

--- a/discstore/adapters/inbound/ui_controller.py
+++ b/discstore/adapters/inbound/ui_controller.py
@@ -59,7 +59,9 @@ class UIController(APIController):
         settings_service: ReadOnlySettingsService,
     ):
         self.get_disc = get_disc
-        super().__init__(add_disc, list_discs, remove_disc, edit_disc, get_current_tag_status, settings_service)
+        super().__init__(
+            add_disc, list_discs, remove_disc, edit_disc, get_disc, get_current_tag_status, settings_service
+        )
 
     def register_routes(self):
         super().register_routes()

--- a/jukebox/admin/di_container.py
+++ b/jukebox/admin/di_container.py
@@ -51,6 +51,7 @@ def build_admin_api_app(library_path: str, settings_service: SettingsService):
         ListDiscs(repository),
         RemoveDisc(repository),
         EditDisc(repository),
+        GetDisc(repository),
         GetCurrentTagStatus(current_tag_repository, repository),
         settings_service,
     )

--- a/tests/discstore/adapters/inbound/test_api_controller.py
+++ b/tests/discstore/adapters/inbound/test_api_controller.py
@@ -11,10 +11,47 @@ if FASTAPI_INSTALLED:
     from fastapi import HTTPException
     from fastapi.routing import APIRoute
 
-    from discstore.adapters.inbound.api_controller import APIController, SettingsPatchInput, SettingsResetInput
-    from discstore.domain.entities import CurrentTagStatus
+    from discstore.adapters.inbound.api_controller import (
+        APIController,
+        DiscCreateInput,
+        DiscPatchInput,
+        SettingsPatchInput,
+        SettingsResetInput,
+    )
+    from discstore.domain.entities import CurrentTagStatus, Disc, DiscMetadata, DiscOption
     from discstore.domain.use_cases.get_current_tag_status import GetCurrentTagStatus
     from jukebox.settings.errors import InvalidSettingsError
+
+
+def build_controller(
+    add_disc=None,
+    list_discs=None,
+    remove_disc=None,
+    edit_disc=None,
+    get_disc=None,
+    get_current_tag_status=None,
+    settings_service=None,
+):
+    return APIController(
+        add_disc or MagicMock(),
+        list_discs or MagicMock(),
+        remove_disc or MagicMock(),
+        edit_disc or MagicMock(),
+        get_disc or MagicMock(),
+        get_current_tag_status or MagicMock(),
+        settings_service or MagicMock(),
+    )
+
+
+def get_route(controller, path, method="GET"):
+    return cast(
+        APIRoute,
+        next(
+            route
+            for route in controller.app.routes
+            if getattr(route, "path", None) == path and method in getattr(route, "methods", set())
+        ),
+    )
 
 
 def test_dependencies_import_failure(mocker):
@@ -35,7 +72,7 @@ def test_dependencies_import_failure(mocker):
 def test_get_current_tag_returns_current_tag_payload(known_in_library):
     get_current_tag_status = create_autospec(GetCurrentTagStatus, instance=True, spec_set=True)
     get_current_tag_status.execute.return_value = CurrentTagStatus(tag_id="tag-123", known_in_library=known_in_library)
-    controller = APIController(MagicMock(), MagicMock(), MagicMock(), MagicMock(), get_current_tag_status, MagicMock())
+    controller = build_controller(get_current_tag_status=get_current_tag_status)
     route = cast(
         APIRoute,
         next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/v1/current-tag"),
@@ -53,7 +90,7 @@ def test_get_current_tag_returns_current_tag_payload(known_in_library):
 def test_get_current_tag_returns_no_content_when_absent():
     get_current_tag_status = create_autospec(GetCurrentTagStatus, instance=True, spec_set=True)
     get_current_tag_status.execute.return_value = None
-    controller = APIController(MagicMock(), MagicMock(), MagicMock(), MagicMock(), get_current_tag_status, MagicMock())
+    controller = build_controller(get_current_tag_status=get_current_tag_status)
     route = cast(
         APIRoute,
         next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/v1/current-tag"),
@@ -68,10 +105,198 @@ def test_get_current_tag_returns_no_content_when_absent():
 
 
 @pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_disc_routes_use_explicit_crud_paths():
+    controller = build_controller()
+
+    route_index = {
+        (getattr(route, "path", None), tuple(sorted(getattr(route, "methods", []))))
+        for route in controller.app.routes
+        if hasattr(route, "path")
+    }
+
+    assert ("/api/v1/discs", ("GET",)) in route_index
+    assert ("/api/v1/discs/{tag_id}", ("GET",)) in route_index
+    assert ("/api/v1/discs/{tag_id}", ("POST",)) in route_index
+    assert ("/api/v1/discs/{tag_id}", ("PATCH",)) in route_index
+    assert ("/api/v1/discs/{tag_id}", ("DELETE",)) in route_index
+    assert not any(path == "/api/v1/disc" for path, _ in route_index)
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_list_discs_returns_disc_mapping():
+    list_discs = MagicMock()
+    list_discs.execute.return_value = {
+        "tag-123": Disc(
+            uri="/music/song.mp3",
+            metadata=DiscMetadata(artist="Artist", album="Album", track="Track"),
+            option=DiscOption(shuffle=True),
+        )
+    }
+    controller = build_controller(list_discs=list_discs)
+
+    response = get_route(controller, "/api/v1/discs").endpoint()
+
+    assert response == {
+        "tag-123": Disc(
+            uri="/music/song.mp3",
+            metadata=DiscMetadata(artist="Artist", album="Album", track="Track"),
+            option=DiscOption(shuffle=True),
+        )
+    }
+    list_discs.execute.assert_called_once_with()
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_get_disc_returns_disc_payload():
+    get_disc = MagicMock()
+    get_disc.execute.return_value = Disc(
+        uri="/music/song.mp3",
+        metadata=DiscMetadata(artist="Artist", album="Album", track="Track"),
+        option=DiscOption(shuffle=True),
+    )
+    controller = build_controller(get_disc=get_disc)
+    route = get_route(controller, "/api/v1/discs/{tag_id}")
+
+    response = route.endpoint("tag-123")
+
+    assert route.response_model is not None
+    assert route.response_model.__name__ == "DiscOutput"
+    assert response.model_dump() == {
+        "uri": "/music/song.mp3",
+        "metadata": {"artist": "Artist", "album": "Album", "track": "Track", "playlist": None},
+        "option": {"shuffle": True, "is_test": False},
+    }
+    get_disc.execute.assert_called_once_with("tag-123")
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_get_disc_returns_404_when_missing():
+    get_disc = MagicMock()
+    get_disc.execute.side_effect = ValueError("Tag not found: tag_id='missing-tag'")
+    controller = build_controller(get_disc=get_disc)
+
+    with pytest.raises(HTTPException) as err:
+        get_route(controller, "/api/v1/discs/{tag_id}").endpoint("missing-tag")
+
+    assert err.value.status_code == 404
+    assert err.value.detail == "Tag not found: tag_id='missing-tag'"
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_create_disc_returns_201_and_calls_add_use_case():
+    add_disc = MagicMock()
+    controller = build_controller(add_disc=add_disc)
+    route = get_route(controller, "/api/v1/discs/{tag_id}", method="POST")
+
+    response = route.endpoint(
+        "tag-123",
+        DiscCreateInput(
+            uri="/music/song.mp3",
+            metadata=DiscMetadata(artist="Artist", album="Album", track="Track"),
+            option=DiscOption(shuffle=True),
+        ),
+    )
+
+    assert route.status_code == 201
+    assert response == {"message": "Disc added"}
+    add_disc.execute.assert_called_once_with(
+        "tag-123",
+        Disc(
+            uri="/music/song.mp3",
+            metadata=DiscMetadata(artist="Artist", album="Album", track="Track"),
+            option=DiscOption(shuffle=True),
+        ),
+    )
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_create_disc_returns_409_when_tag_already_exists():
+    add_disc = MagicMock()
+    add_disc.execute.side_effect = ValueError("Already existing tag: tag_id='tag-123'")
+    controller = build_controller(add_disc=add_disc)
+
+    with pytest.raises(HTTPException) as err:
+        get_route(controller, "/api/v1/discs/{tag_id}", method="POST").endpoint(
+            "tag-123",
+            DiscCreateInput(uri="/music/song.mp3", metadata=DiscMetadata()),
+        )
+
+    assert err.value.status_code == 409
+    assert err.value.detail == "Already existing tag: tag_id='tag-123'"
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_patch_disc_returns_200_and_calls_edit_use_case():
+    edit_disc = MagicMock()
+    controller = build_controller(edit_disc=edit_disc)
+    route = get_route(controller, "/api/v1/discs/{tag_id}", method="PATCH")
+
+    response = route.endpoint(
+        "tag-123",
+        DiscPatchInput(
+            uri="/music/updated.mp3",
+            metadata={"artist": "Updated Artist"},
+            option={"shuffle": True},
+        ),
+    )
+
+    assert route.status_code == 200
+    assert response == {"message": "Disc updated"}
+    edit_disc.execute.assert_called_once_with(
+        tag_id="tag-123",
+        uri="/music/updated.mp3",
+        metadata=DiscMetadata(artist="Updated Artist"),
+        option=DiscOption(shuffle=True),
+    )
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_patch_disc_returns_404_when_target_is_missing():
+    edit_disc = MagicMock()
+    edit_disc.execute.side_effect = ValueError("Tag does not exist: tag_id='missing-tag'")
+    controller = build_controller(edit_disc=edit_disc)
+
+    with pytest.raises(HTTPException) as err:
+        get_route(controller, "/api/v1/discs/{tag_id}", method="PATCH").endpoint(
+            "missing-tag",
+            DiscPatchInput(metadata={"artist": "Updated Artist"}),
+        )
+
+    assert err.value.status_code == 404
+    assert err.value.detail == "Tag does not exist: tag_id='missing-tag'"
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_delete_disc_returns_200_and_calls_remove_use_case():
+    remove_disc = MagicMock()
+    controller = build_controller(remove_disc=remove_disc)
+    route = get_route(controller, "/api/v1/discs/{tag_id}", method="DELETE")
+
+    response = route.endpoint("tag-123")
+
+    assert route.status_code == 200
+    assert response == {"message": "Disc removed"}
+    remove_disc.execute.assert_called_once_with("tag-123")
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_delete_disc_returns_404_when_target_is_missing():
+    remove_disc = MagicMock()
+    remove_disc.execute.side_effect = ValueError("Tag does not exist: tag_id='missing-tag'")
+    controller = build_controller(remove_disc=remove_disc)
+
+    with pytest.raises(HTTPException) as err:
+        get_route(controller, "/api/v1/discs/{tag_id}", method="DELETE").endpoint("missing-tag")
+
+    assert err.value.status_code == 404
+    assert err.value.detail == "Tag does not exist: tag_id='missing-tag'"
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
 def test_get_settings_returns_sparse_settings_payload():
     settings_service = MagicMock()
     settings_service.get_persisted_settings_view.return_value = {"schema_version": 1}
-    controller = APIController(MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock(), settings_service)
+    controller = build_controller(settings_service=settings_service)
     route = cast(
         APIRoute,
         next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/v1/settings"),
@@ -87,7 +312,7 @@ def test_get_settings_returns_sparse_settings_payload():
 def test_get_effective_settings_returns_effective_settings_payload():
     settings_service = MagicMock()
     settings_service.get_effective_settings_view.return_value = {"settings": {}, "provenance": {}, "derived": {}}
-    controller = APIController(MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock(), settings_service)
+    controller = build_controller(settings_service=settings_service)
     route = cast(
         APIRoute,
         next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/v1/settings/effective"),
@@ -105,7 +330,7 @@ def test_patch_settings_updates_persisted_settings():
     settings_service.patch_persisted_settings.return_value = {
         "persisted": {"schema_version": 1, "admin": {"api": {"port": 9000}}}
     }
-    controller = APIController(MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock(), settings_service)
+    controller = build_controller(settings_service=settings_service)
     route = cast(
         APIRoute,
         next(
@@ -127,7 +352,7 @@ def test_patch_settings_updates_playback_timing_settings():
     settings_service.patch_persisted_settings.return_value = {
         "persisted": {"schema_version": 1, "jukebox": {"runtime": {"loop_interval_seconds": 0.2}}}
     }
-    controller = APIController(MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock(), settings_service)
+    controller = build_controller(settings_service=settings_service)
     route = cast(
         APIRoute,
         next(
@@ -159,7 +384,7 @@ def test_patch_settings_updates_reader_settings():
             },
         }
     }
-    controller = APIController(MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock(), settings_service)
+    controller = build_controller(settings_service=settings_service)
     route = cast(
         APIRoute,
         next(
@@ -208,7 +433,7 @@ def test_patch_settings_updates_player_settings():
             },
         }
     }
-    controller = APIController(MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock(), settings_service)
+    controller = build_controller(settings_service=settings_service)
     route = cast(
         APIRoute,
         next(
@@ -273,7 +498,7 @@ def test_patch_settings_updates_player_settings():
 def test_patch_settings_returns_400_for_invalid_settings_write():
     settings_service = MagicMock()
     settings_service.patch_persisted_settings.side_effect = InvalidSettingsError("Unsupported settings path")
-    controller = APIController(MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock(), settings_service)
+    controller = build_controller(settings_service=settings_service)
     route = cast(
         APIRoute,
         next(
@@ -292,7 +517,7 @@ def test_patch_settings_returns_400_for_invalid_settings_write():
 
 @pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
 def test_patch_settings_route_generates_openapi_schema():
-    controller = APIController(MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock())
+    controller = build_controller()
 
     schema = controller.app.openapi()
 
@@ -305,7 +530,7 @@ def test_reset_settings_removes_persisted_override():
     settings_service.reset_persisted_value.return_value = {
         "persisted": {"schema_version": 1, "admin": {"ui": {"port": 9200}}}
     }
-    controller = APIController(MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock(), settings_service)
+    controller = build_controller(settings_service=settings_service)
     route = cast(
         APIRoute,
         next(
@@ -327,7 +552,7 @@ def test_reset_settings_removes_playback_timing_override():
     settings_service.reset_persisted_value.return_value = {
         "persisted": {"schema_version": 1, "jukebox": {"playback": {"pause_duration_seconds": 600}}}
     }
-    controller = APIController(MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock(), settings_service)
+    controller = build_controller(settings_service=settings_service)
     route = cast(
         APIRoute,
         next(
@@ -349,7 +574,7 @@ def test_reset_settings_removes_selected_group_override():
     settings_service.reset_persisted_value.return_value = {
         "persisted": {"schema_version": 1, "jukebox": {"player": {"type": "sonos"}}}
     }
-    controller = APIController(MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock(), settings_service)
+    controller = build_controller(settings_service=settings_service)
     route = cast(
         APIRoute,
         next(
@@ -371,7 +596,7 @@ def test_reset_settings_removes_reader_override():
     settings_service.reset_persisted_value.return_value = {
         "persisted": {"schema_version": 1, "jukebox": {"reader": {"type": "nfc"}}}
     }
-    controller = APIController(MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock(), settings_service)
+    controller = build_controller(settings_service=settings_service)
     route = cast(
         APIRoute,
         next(
@@ -391,7 +616,7 @@ def test_reset_settings_removes_reader_override():
 def test_reset_settings_accepts_section_path():
     settings_service = MagicMock()
     settings_service.reset_persisted_value.return_value = {"persisted": {"schema_version": 1}}
-    controller = APIController(MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock(), settings_service)
+    controller = build_controller(settings_service=settings_service)
     route = cast(
         APIRoute,
         next(
@@ -411,7 +636,7 @@ def test_reset_settings_accepts_section_path():
 def test_reset_settings_returns_400_for_invalid_reset_path():
     settings_service = MagicMock()
     settings_service.reset_persisted_value.side_effect = InvalidSettingsError("Unsupported settings path")
-    controller = APIController(MagicMock(), MagicMock(), MagicMock(), MagicMock(), MagicMock(), settings_service)
+    controller = build_controller(settings_service=settings_service)
     route = cast(
         APIRoute,
         next(

--- a/tests/discstore/adapters/inbound/test_ui_controller.py
+++ b/tests/discstore/adapters/inbound/test_ui_controller.py
@@ -88,9 +88,11 @@ def test_ui_controller_registers_fastui_routes_and_page_structure():
     assert ("/api/ui/discs/{tag_id}/delete", ("GET",)) in route_index
     assert ("/api/ui/discs/{tag_id}/delete", ("POST",)) in route_index
     assert ("/api/v1/discs", ("GET",)) in route_index
+    assert ("/api/v1/discs/{tag_id}", ("GET",)) in route_index
+    assert ("/api/v1/discs/{tag_id}", ("POST",)) in route_index
+    assert ("/api/v1/discs/{tag_id}", ("PATCH",)) in route_index
+    assert ("/api/v1/discs/{tag_id}", ("DELETE",)) in route_index
     assert ("/api/v1/current-tag", ("GET",)) in route_index
-    assert ("/api/v1/disc", ("POST",)) in route_index
-    assert ("/api/v1/disc", ("DELETE",)) in route_index
 
     route = next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/ui/")
     page = route.endpoint()[0]

--- a/tests/jukebox/admin/test_di_container.py
+++ b/tests/jukebox/admin/test_di_container.py
@@ -86,6 +86,7 @@ def test_build_admin_api_app_wiring(mocker, bootstrap_mocks):
         bootstrap_mocks.list_disc_instance,
         bootstrap_mocks.remove_disc_instance,
         bootstrap_mocks.edit_disc_instance,
+        bootstrap_mocks.get_disc_instance,
         bootstrap_mocks.get_current_tag_status_instance,
         settings_service,
     )


### PR DESCRIPTION
## Summary

Closes #197.

This updates the disc API to use explicit CRUD semantics instead of the old upsert-style `POST /api/v1/disc` behavior.

## What changed

- removed the legacy `/api/v1/disc` upsert/delete endpoints
- added explicit disc routes under `/api/v1/discs/{tag_id}` for `GET`, `POST`, `PATCH`, and `DELETE`
- added a dedicated patch request model for partial disc updates
- wired `GetDisc` into the admin API container for single-disc fetches
- updated API, UI route, and DI tests to cover the new contract and status codes

## Behavior

- `POST /api/v1/discs/{tag_id}` now returns `409` if the tag already exists
- `GET`, `PATCH`, and `DELETE /api/v1/discs/{tag_id}` now return `404` if the tag is missing
- partial updates no longer depend on create-failure fallback behavior
