### PR TITLE
Clean up disc API routes

### DIFF
--- a/discstore/adapters/inbound/api/__init__.py
+++ b/discstore/adapters/inbound/api/__init__.py
@@ -1,0 +1,21 @@
+from discstore.adapters.inbound.api.current_tag_router import build_current_tag_router
+from discstore.adapters.inbound.api.discs_router import build_discs_router
+from discstore.adapters.inbound.api.models import (
+    CurrentTagStatusOutput,
+    DiscInput,
+    DiscOutput,
+    SettingsPatchInput,
+    SettingsResetInput,
+)
+from discstore.adapters.inbound.api.settings_router import build_settings_router
+
+__all__ = [
+    "CurrentTagStatusOutput",
+    "DiscInput",
+    "DiscOutput",
+    "SettingsPatchInput",
+    "SettingsResetInput",
+    "build_current_tag_router",
+    "build_discs_router",
+    "build_settings_router",
+]

--- a/discstore/adapters/inbound/api/__init__.py
+++ b/discstore/adapters/inbound/api/__init__.py
@@ -4,6 +4,7 @@ from discstore.adapters.inbound.api.models import (
     CurrentTagStatusOutput,
     DiscInput,
     DiscOutput,
+    DiscPatchInput,
     SettingsPatchInput,
     SettingsResetInput,
 )
@@ -13,6 +14,7 @@ __all__ = [
     "CurrentTagStatusOutput",
     "DiscInput",
     "DiscOutput",
+    "DiscPatchInput",
     "SettingsPatchInput",
     "SettingsResetInput",
     "build_current_tag_router",

--- a/discstore/adapters/inbound/api/discs_router.py
+++ b/discstore/adapters/inbound/api/discs_router.py
@@ -1,11 +1,12 @@
 from typing import Dict
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Response, status
 
-from discstore.adapters.inbound.api.models import DiscInput, DiscOutput
-from discstore.domain.entities import Disc
+from discstore.adapters.inbound.api.models import DiscInput, DiscOutput, DiscPatchInput
+from discstore.domain.entities import Disc, DiscMetadata, DiscOption
 from discstore.domain.use_cases.add_disc import AddDisc
 from discstore.domain.use_cases.edit_disc import EditDisc
+from discstore.domain.use_cases.get_disc import GetDisc
 from discstore.domain.use_cases.list_discs import ListDiscs
 from discstore.domain.use_cases.remove_disc import RemoveDisc
 
@@ -15,6 +16,7 @@ def build_discs_router(
     list_discs: ListDiscs,
     remove_disc: RemoveDisc,
     edit_disc: EditDisc,
+    get_disc: GetDisc,
 ) -> APIRouter:
     router = APIRouter(prefix="/api/v1", tags=["discs"])
 
@@ -22,24 +24,49 @@ def build_discs_router(
     def list_discs_route() -> Dict[str, Disc]:
         return list_discs.execute()
 
-    @router.post("/disc", status_code=201, summary="Create or update a disc")
-    def add_or_edit_disc(tag_id: str, disc: DiscInput) -> Dict[str, str]:
+    @router.get("/discs/{tag_id}", response_model=DiscOutput, summary="Get a disc")
+    def get_disc_route(tag_id: str) -> Disc:
         try:
-            self_disc = Disc(**disc.model_dump())
-            add_disc.execute(tag_id, self_disc)
-            return {"message": "Disc added"}
-        except ValueError:
-            new_disc = Disc(**disc.model_dump())
-            edit_disc.execute(tag_id, new_disc.uri, new_disc.metadata, new_disc.option)
-            return {"message": "Disc edited"}
+            return get_disc.execute(tag_id)
+        except ValueError as value_err:
+            raise HTTPException(status_code=404, detail=str(value_err))
         except Exception as err:
             raise HTTPException(status_code=500, detail=f"Server error: {str(err)}")
 
-    @router.delete("/disc", status_code=200, summary="Delete a disc")
-    def remove_disc_route(tag_id: str) -> Dict[str, str]:
+    @router.post("/discs/{tag_id}", response_model=DiscOutput, status_code=201, summary="Create a disc")
+    def create_disc_route(tag_id: str, disc: DiscInput) -> Disc:
+        try:
+            new_disc = Disc(**disc.model_dump())
+            add_disc.execute(tag_id, new_disc)
+            return new_disc
+        except ValueError as value_err:
+            raise HTTPException(status_code=409, detail=str(value_err))
+        except Exception as err:
+            raise HTTPException(status_code=500, detail=f"Server error: {str(err)}")
+
+    @router.patch("/discs/{tag_id}", response_model=DiscOutput, summary="Update a disc")
+    def update_disc_route(tag_id: str, disc_patch: DiscPatchInput) -> Disc:
+        try:
+            metadata = None
+            if disc_patch.metadata is not None:
+                metadata = DiscMetadata(**disc_patch.metadata.model_dump(exclude_unset=True, exclude_none=True))
+
+            option = None
+            if disc_patch.option is not None:
+                option = DiscOption(**disc_patch.option.model_dump(exclude_unset=True, exclude_none=True))
+
+            edit_disc.execute(tag_id, disc_patch.uri, metadata, option)
+            return get_disc.execute(tag_id)
+        except ValueError as value_err:
+            raise HTTPException(status_code=404, detail=str(value_err))
+        except Exception as err:
+            raise HTTPException(status_code=500, detail=f"Server error: {str(err)}")
+
+    @router.delete("/discs/{tag_id}", status_code=204, summary="Delete a disc")
+    def remove_disc_route(tag_id: str) -> Response:
         try:
             remove_disc.execute(tag_id)
-            return {"message": "Disc removed"}
+            return Response(status_code=status.HTTP_204_NO_CONTENT)
         except ValueError as value_err:
             raise HTTPException(status_code=404, detail=str(value_err))
         except Exception as err:

--- a/discstore/adapters/inbound/api/discs_router.py
+++ b/discstore/adapters/inbound/api/discs_router.py
@@ -37,8 +37,7 @@ def build_discs_router(
     def create_disc_route(tag_id: str, disc: DiscInput) -> Disc:
         try:
             new_disc = Disc(**disc.model_dump())
-            add_disc.execute(tag_id, new_disc)
-            return new_disc
+            return add_disc.execute(tag_id, new_disc)
         except ValueError as value_err:
             raise HTTPException(status_code=409, detail=str(value_err))
         except Exception as err:
@@ -55,8 +54,7 @@ def build_discs_router(
             if disc_patch.option is not None:
                 option = DiscOption(**disc_patch.option.model_dump(exclude_unset=True, exclude_none=True))
 
-            edit_disc.execute(tag_id, disc_patch.uri, metadata, option)
-            return get_disc.execute(tag_id)
+            return edit_disc.execute(tag_id, disc_patch.uri, metadata, option)
         except ValueError as value_err:
             raise HTTPException(status_code=404, detail=str(value_err))
         except Exception as err:

--- a/discstore/adapters/inbound/api/models.py
+++ b/discstore/adapters/inbound/api/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from pydantic import BaseModel, RootModel
 
@@ -11,6 +11,24 @@ class DiscInput(Disc):
 
 class DiscOutput(Disc):
     pass
+
+
+class DiscPatchMetadataInput(BaseModel):
+    artist: Optional[str] = None
+    album: Optional[str] = None
+    track: Optional[str] = None
+    playlist: Optional[str] = None
+
+
+class DiscPatchOptionInput(BaseModel):
+    shuffle: Optional[bool] = None
+    is_test: Optional[bool] = None
+
+
+class DiscPatchInput(BaseModel):
+    uri: Optional[str] = None
+    metadata: Optional[DiscPatchMetadataInput] = None
+    option: Optional[DiscPatchOptionInput] = None
 
 
 class CurrentTagStatusOutput(CurrentTagStatus):

--- a/discstore/adapters/inbound/api_controller.py
+++ b/discstore/adapters/inbound/api_controller.py
@@ -12,8 +12,8 @@ try:
     from discstore.adapters.inbound.api.models import (
         CurrentTagStatusOutput,
         DiscInput,
-        DiscPatchInput,
         DiscOutput,
+        DiscPatchInput,
         SettingsPatchInput,
         SettingsResetInput,
     )

--- a/discstore/adapters/inbound/api_controller.py
+++ b/discstore/adapters/inbound/api_controller.py
@@ -12,6 +12,7 @@ try:
     from discstore.adapters.inbound.api.models import (
         CurrentTagStatusOutput,
         DiscInput,
+        DiscPatchInput,
         DiscOutput,
         SettingsPatchInput,
         SettingsResetInput,
@@ -26,6 +27,7 @@ except ModuleNotFoundError as e:
 from discstore.domain.use_cases.add_disc import AddDisc
 from discstore.domain.use_cases.edit_disc import EditDisc
 from discstore.domain.use_cases.get_current_tag_status import GetCurrentTagStatus
+from discstore.domain.use_cases.get_disc import GetDisc
 from discstore.domain.use_cases.list_discs import ListDiscs
 from discstore.domain.use_cases.remove_disc import RemoveDisc
 from jukebox.settings.entities import SelectedSonosGroupSettings
@@ -40,6 +42,7 @@ __all__ = [
     "CurrentTagStatusOutput",
     "DiscInput",
     "DiscOutput",
+    "DiscPatchInput",
     "SettingsPatchInput",
     "SettingsResetInput",
     "SonosSelectionInput",
@@ -89,6 +92,7 @@ class APIController:
         list_discs: ListDiscs,
         remove_disc: RemoveDisc,
         edit_disc: EditDisc,
+        get_disc: GetDisc,
         get_current_tag_status: GetCurrentTagStatus,
         settings_service: SettingsService,
         sonos_service: SonosService,
@@ -97,6 +101,7 @@ class APIController:
         self.list_discs = list_discs
         self.remove_disc = remove_disc
         self.edit_disc = edit_disc
+        self.get_disc = get_disc
         self.get_current_tag_status = get_current_tag_status
         self.settings_service = settings_service
         self.sonos_service = sonos_service
@@ -115,6 +120,7 @@ class APIController:
                 list_discs=self.list_discs,
                 remove_disc=self.remove_disc,
                 edit_disc=self.edit_disc,
+                get_disc=self.get_disc,
             )
         )
         self.app.include_router(build_current_tag_router(self.get_current_tag_status))

--- a/discstore/adapters/inbound/ui_controller.py
+++ b/discstore/adapters/inbound/ui_controller.py
@@ -83,6 +83,7 @@ class UIController(APIController):
             list_discs,
             remove_disc,
             edit_disc,
+            get_disc,
             get_current_tag_status,
             settings_service,
             sonos_service,

--- a/discstore/domain/use_cases/add_disc.py
+++ b/discstore/domain/use_cases/add_disc.py
@@ -6,5 +6,6 @@ class AddDisc:
     def __init__(self, repository: LibraryRepository):
         self.repository = repository
 
-    def execute(self, tag_id: str, disc: Disc) -> None:
+    def execute(self, tag_id: str, disc: Disc) -> Disc:
         self.repository.add_disc(tag_id, disc)
+        return disc

--- a/discstore/domain/use_cases/edit_disc.py
+++ b/discstore/domain/use_cases/edit_disc.py
@@ -14,7 +14,7 @@ class EditDisc:
         uri: Optional[str] = None,
         metadata: Optional[DiscMetadata] = None,
         option: Optional[DiscOption] = None,
-    ) -> None:
+    ) -> Disc:
         current_disc = self.repository.get_disc(tag_id)
         if current_disc is None:
             raise ValueError(f"Tag does not exist: tag_id='{tag_id}'")
@@ -37,3 +37,4 @@ class EditDisc:
 
         updated_disc = Disc(uri=new_uri, metadata=new_metadata, option=new_option)
         self.repository.update_disc(tag_id, updated_disc)
+        return updated_disc

--- a/jukebox/admin/di_container.py
+++ b/jukebox/admin/di_container.py
@@ -68,6 +68,7 @@ def build_admin_api_app(library_path: str, services: AdminServices):
         ListDiscs(repository),
         RemoveDisc(repository),
         EditDisc(repository),
+        GetDisc(repository),
         GetCurrentTagStatus(current_tag_repository, repository),
         services.settings,
         services.sonos,

--- a/tests/discstore/adapters/inbound/test_api_controller.py
+++ b/tests/discstore/adapters/inbound/test_api_controller.py
@@ -225,6 +225,11 @@ def test_get_disc_returns_404_when_missing():
 @pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
 def test_create_disc_returns_created_disc_payload():
     add_disc = MagicMock()
+    add_disc.execute.return_value = Disc(
+        uri="/music/song.mp3",
+        metadata=DiscMetadata(artist="Artist", album="Album", track="Track"),
+        option=DiscOption(shuffle=True),
+    )
     controller = build_controller(add_disc=add_disc)
     route = get_route(controller, "/api/v1/discs/{tag_id}", "POST")
     request = DiscInput(
@@ -259,13 +264,12 @@ def test_create_disc_returns_409_when_tag_exists():
 @pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
 def test_patch_disc_partially_updates_existing_disc():
     edit_disc = MagicMock()
-    get_disc = MagicMock()
-    get_disc.execute.return_value = Disc(
+    edit_disc.execute.return_value = Disc(
         uri="/music/song.mp3",
         metadata=DiscMetadata(artist="Artist", album="Album", track="Updated Track"),
         option=DiscOption(shuffle=False),
     )
-    controller = build_controller(edit_disc=edit_disc, get_disc=get_disc)
+    controller = build_controller(edit_disc=edit_disc)
     route = get_route(controller, "/api/v1/discs/{tag_id}", "PATCH")
 
     response = route.endpoint(
@@ -284,7 +288,6 @@ def test_patch_disc_partially_updates_existing_disc():
         DiscMetadata(track="Updated Track"),
         DiscOption(shuffle=False),
     )
-    get_disc.execute.assert_called_once_with("tag-123")
 
 
 @pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")

--- a/tests/discstore/adapters/inbound/test_api_controller.py
+++ b/tests/discstore/adapters/inbound/test_api_controller.py
@@ -11,12 +11,16 @@ if FASTAPI_INSTALLED:
     from fastapi import HTTPException
     from fastapi.routing import APIRoute
 
-    from discstore.adapters.inbound.api_controller import (
-        APIController,
+    from discstore.adapters.inbound.api.models import (
         DiscInput,
         DiscPatchInput,
+        DiscPatchMetadataInput,
+        DiscPatchOptionInput,
         SettingsPatchInput,
         SettingsResetInput,
+    )
+    from discstore.adapters.inbound.api_controller import (
+        APIController,
         SonosSelectionInput,
     )
     from discstore.domain.entities import CurrentTagStatus, Disc, DiscMetadata, DiscOption
@@ -274,7 +278,10 @@ def test_patch_disc_partially_updates_existing_disc():
 
     response = route.endpoint(
         "tag-123",
-        DiscPatchInput(metadata={"track": "Updated Track"}, option={"shuffle": False}),
+        DiscPatchInput(
+            metadata=DiscPatchMetadataInput(track="Updated Track"),
+            option=DiscPatchOptionInput(shuffle=False),
+        ),
     )
 
     assert response.model_dump() == {

--- a/tests/discstore/adapters/inbound/test_api_controller.py
+++ b/tests/discstore/adapters/inbound/test_api_controller.py
@@ -13,11 +13,13 @@ if FASTAPI_INSTALLED:
 
     from discstore.adapters.inbound.api_controller import (
         APIController,
+        DiscInput,
+        DiscPatchInput,
         SettingsPatchInput,
         SettingsResetInput,
         SonosSelectionInput,
     )
-    from discstore.domain.entities import CurrentTagStatus
+    from discstore.domain.entities import CurrentTagStatus, Disc, DiscMetadata, DiscOption
     from discstore.domain.use_cases.get_current_tag_status import GetCurrentTagStatus
     from jukebox.settings.errors import InvalidSettingsError
     from jukebox.sonos.discovery import DiscoveredSonosSpeaker, SonosDiscoveryError
@@ -67,18 +69,35 @@ else:
 
 def build_controller(
     *,
+    get_disc=None,
     get_current_tag_status=None,
     settings_service=None,
     sonos_service=None,
+    add_disc=None,
+    list_discs=None,
+    remove_disc=None,
+    edit_disc=None,
 ):
     return APIController(
-        MagicMock(),
-        MagicMock(),
-        MagicMock(),
-        MagicMock(),
-        get_current_tag_status or MagicMock(),
-        settings_service or MagicMock(),
-        sonos_service or MagicMock(),
+        add_disc if add_disc is not None else MagicMock(),
+        list_discs if list_discs is not None else MagicMock(),
+        remove_disc if remove_disc is not None else MagicMock(),
+        edit_disc if edit_disc is not None else MagicMock(),
+        get_disc if get_disc is not None else MagicMock(),
+        get_current_tag_status if get_current_tag_status is not None else MagicMock(),
+        settings_service if settings_service is not None else MagicMock(),
+        sonos_service if sonos_service is not None else MagicMock(),
+    )
+
+
+def get_route(controller, path, method):
+    return cast(
+        APIRoute,
+        next(
+            route
+            for route in controller.app.routes
+            if getattr(route, "path", None) == path and method in getattr(route, "methods", set())
+        ),
     )
 
 
@@ -145,6 +164,168 @@ def test_get_current_tag_returns_no_content_when_absent():
     assert response.status_code == 204
     assert response.body == b""
     get_current_tag_status.execute.assert_called_once_with()
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_disc_routes_register_explicit_crud_paths():
+    controller = build_controller()
+
+    route_index = {
+        (getattr(route, "path", None), tuple(sorted(getattr(route, "methods", []))))
+        for route in controller.app.routes
+        if hasattr(route, "path")
+    }
+
+    assert ("/api/v1/discs", ("GET",)) in route_index
+    assert ("/api/v1/discs/{tag_id}", ("GET",)) in route_index
+    assert ("/api/v1/discs/{tag_id}", ("POST",)) in route_index
+    assert ("/api/v1/discs/{tag_id}", ("PATCH",)) in route_index
+    assert ("/api/v1/discs/{tag_id}", ("DELETE",)) in route_index
+    assert ("/api/v1/disc", ("POST",)) not in route_index
+    assert ("/api/v1/disc", ("DELETE",)) not in route_index
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_get_disc_returns_disc_payload():
+    get_disc = MagicMock()
+    get_disc.execute.return_value = Disc(
+        uri="/music/song.mp3",
+        metadata=DiscMetadata(artist="Artist", album="Album", track="Track"),
+        option=DiscOption(shuffle=True),
+    )
+    controller = build_controller(get_disc=get_disc)
+    route = get_route(controller, "/api/v1/discs/{tag_id}", "GET")
+
+    response = route.endpoint("tag-123")
+
+    assert route.response_model is not None
+    assert route.response_model.__name__ == "DiscOutput"
+    assert response.model_dump() == {
+        "uri": "/music/song.mp3",
+        "metadata": {"artist": "Artist", "album": "Album", "track": "Track", "playlist": None},
+        "option": {"shuffle": True, "is_test": False},
+    }
+    get_disc.execute.assert_called_once_with("tag-123")
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_get_disc_returns_404_when_missing():
+    get_disc = MagicMock()
+    get_disc.execute.side_effect = ValueError("Tag not found: tag_id='missing'")
+    controller = build_controller(get_disc=get_disc)
+    route = get_route(controller, "/api/v1/discs/{tag_id}", "GET")
+
+    with pytest.raises(HTTPException) as err:
+        route.endpoint("missing")
+
+    assert err.value.status_code == 404
+    assert err.value.detail == "Tag not found: tag_id='missing'"
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_create_disc_returns_created_disc_payload():
+    add_disc = MagicMock()
+    controller = build_controller(add_disc=add_disc)
+    route = get_route(controller, "/api/v1/discs/{tag_id}", "POST")
+    request = DiscInput(
+        uri="/music/song.mp3",
+        metadata=DiscMetadata(artist="Artist", album="Album", track="Track"),
+        option=DiscOption(shuffle=True),
+    )
+
+    response = route.endpoint("tag-123", request)
+
+    assert response.model_dump() == request.model_dump()
+    add_disc.execute.assert_called_once_with("tag-123", Disc(**request.model_dump()))
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_create_disc_returns_409_when_tag_exists():
+    add_disc = MagicMock()
+    add_disc.execute.side_effect = ValueError("Already existing tag: tag_id='tag-123'")
+    controller = build_controller(add_disc=add_disc)
+    route = get_route(controller, "/api/v1/discs/{tag_id}", "POST")
+
+    with pytest.raises(HTTPException) as err:
+        route.endpoint(
+            "tag-123",
+            DiscInput(uri="/music/song.mp3", metadata=DiscMetadata(artist="Artist"), option=DiscOption()),
+        )
+
+    assert err.value.status_code == 409
+    assert err.value.detail == "Already existing tag: tag_id='tag-123'"
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_patch_disc_partially_updates_existing_disc():
+    edit_disc = MagicMock()
+    get_disc = MagicMock()
+    get_disc.execute.return_value = Disc(
+        uri="/music/song.mp3",
+        metadata=DiscMetadata(artist="Artist", album="Album", track="Updated Track"),
+        option=DiscOption(shuffle=False),
+    )
+    controller = build_controller(edit_disc=edit_disc, get_disc=get_disc)
+    route = get_route(controller, "/api/v1/discs/{tag_id}", "PATCH")
+
+    response = route.endpoint(
+        "tag-123",
+        DiscPatchInput(metadata={"track": "Updated Track"}, option={"shuffle": False}),
+    )
+
+    assert response.model_dump() == {
+        "uri": "/music/song.mp3",
+        "metadata": {"artist": "Artist", "album": "Album", "track": "Updated Track", "playlist": None},
+        "option": {"shuffle": False, "is_test": False},
+    }
+    edit_disc.execute.assert_called_once_with(
+        "tag-123",
+        None,
+        DiscMetadata(track="Updated Track"),
+        DiscOption(shuffle=False),
+    )
+    get_disc.execute.assert_called_once_with("tag-123")
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_patch_disc_returns_404_when_missing():
+    edit_disc = MagicMock()
+    edit_disc.execute.side_effect = ValueError("Tag does not exist: tag_id='missing'")
+    controller = build_controller(edit_disc=edit_disc)
+    route = get_route(controller, "/api/v1/discs/{tag_id}", "PATCH")
+
+    with pytest.raises(HTTPException) as err:
+        route.endpoint("missing", DiscPatchInput(uri="/music/new-song.mp3"))
+
+    assert err.value.status_code == 404
+    assert err.value.detail == "Tag does not exist: tag_id='missing'"
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_delete_disc_returns_no_content():
+    remove_disc = MagicMock()
+    controller = build_controller(remove_disc=remove_disc)
+    route = get_route(controller, "/api/v1/discs/{tag_id}", "DELETE")
+
+    response = route.endpoint("tag-123")
+
+    assert response.status_code == 204
+    assert response.body == b""
+    remove_disc.execute.assert_called_once_with("tag-123")
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_delete_disc_returns_404_when_missing():
+    remove_disc = MagicMock()
+    remove_disc.execute.side_effect = ValueError("Tag does not exist: tag_id='missing'")
+    controller = build_controller(remove_disc=remove_disc)
+    route = get_route(controller, "/api/v1/discs/{tag_id}", "DELETE")
+
+    with pytest.raises(HTTPException) as err:
+        route.endpoint("missing")
+
+    assert err.value.status_code == 404
+    assert err.value.detail == "Tag does not exist: tag_id='missing'"
 
 
 @pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")

--- a/tests/discstore/adapters/inbound/test_ui_controller.py
+++ b/tests/discstore/adapters/inbound/test_ui_controller.py
@@ -157,9 +157,11 @@ def test_ui_controller_registers_fastui_routes_and_page_structure():
     assert ("/api/ui/settings/{setting_path}", ("POST",)) in route_index
     assert ("/api/ui/settings/{setting_path}/reset", ("POST",)) in route_index
     assert ("/api/v1/discs", ("GET",)) in route_index
+    assert ("/api/v1/discs/{tag_id}", ("GET",)) in route_index
+    assert ("/api/v1/discs/{tag_id}", ("POST",)) in route_index
+    assert ("/api/v1/discs/{tag_id}", ("PATCH",)) in route_index
+    assert ("/api/v1/discs/{tag_id}", ("DELETE",)) in route_index
     assert ("/api/v1/current-tag", ("GET",)) in route_index
-    assert ("/api/v1/disc", ("POST",)) in route_index
-    assert ("/api/v1/disc", ("DELETE",)) in route_index
 
     route = next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/ui/")
     page = route.endpoint()[0]

--- a/tests/discstore/domain/use_cases/test_add_disc.py
+++ b/tests/discstore/domain/use_cases/test_add_disc.py
@@ -14,9 +14,10 @@ def test_add_disc_adds_disc(repo):
     use_case = AddDisc(repo)
 
     new_disc = Disc(uri="/new.mp3", metadata=DiscMetadata())
-    use_case.execute("non-existing-tag", new_disc)
+    created_disc = use_case.execute("non-existing-tag", new_disc)
 
     assert repo.add_calls == [("non-existing-tag", new_disc)]
+    assert created_disc == new_disc
     assert len(repo.library.discs) == 2
     assert "existing-tag" in repo.library.discs
     assert repo.library.discs["existing-tag"] != new_disc

--- a/tests/discstore/domain/use_cases/test_edit_disc.py
+++ b/tests/discstore/domain/use_cases/test_edit_disc.py
@@ -15,7 +15,7 @@ def test_edit_only_uri():
     repo = MockRepo(Library(discs={"tag:123": original_disc}))
 
     edit_disc = EditDisc(repo)
-    edit_disc.execute(tag_id="tag:123", uri="uri:new")
+    updated_disc = edit_disc.execute(tag_id="tag:123", uri="uri:new")
 
     assert repo.get_calls == ["tag:123"]
     assert repo.update_calls == [
@@ -29,6 +29,11 @@ def test_edit_only_uri():
         )
     ]
     updated_disc = repo.library.discs["tag:123"]
+    assert updated_disc == Disc(
+        uri="uri:new",
+        metadata=DiscMetadata(artist="Artist", album="Album", track="Track"),
+        option=DiscOption(shuffle=True),
+    )
     assert updated_disc.uri == "uri:new"
     assert updated_disc.metadata.artist == "Artist"
     assert updated_disc.metadata.album == "Album"
@@ -45,7 +50,7 @@ def test_edit_only_track_name():
     repo = MockRepo(Library(discs={"tag:456": original_disc}))
 
     edit_disc = EditDisc(repo)
-    edit_disc.execute(tag_id="tag:456", metadata=DiscMetadata(track="New Track"))
+    updated_disc = edit_disc.execute(tag_id="tag:456", metadata=DiscMetadata(track="New Track"))
 
     assert repo.get_calls == ["tag:456"]
     assert repo.update_calls == [
@@ -59,6 +64,11 @@ def test_edit_only_track_name():
         )
     ]
     updated_disc = repo.library.discs["tag:456"]
+    assert updated_disc == Disc(
+        uri="uri:123",
+        metadata=DiscMetadata(artist="Artist", album="Album", track="New Track"),
+        option=DiscOption(),
+    )
     assert updated_disc.uri == "uri:123"
     assert updated_disc.metadata.artist == "Artist"
     assert updated_disc.metadata.album == "Album"
@@ -70,7 +80,7 @@ def test_edit_only_artist():
     repo = MockRepo(Library(discs={"tag:789": original_disc}))
 
     edit_disc = EditDisc(repo)
-    edit_disc.execute(tag_id="tag:789", metadata=DiscMetadata(artist="New Artist"))
+    updated_disc = edit_disc.execute(tag_id="tag:789", metadata=DiscMetadata(artist="New Artist"))
 
     assert repo.get_calls == ["tag:789"]
     assert repo.update_calls == [
@@ -84,6 +94,11 @@ def test_edit_only_artist():
         )
     ]
     updated_disc = repo.library.discs["tag:789"]
+    assert updated_disc == Disc(
+        uri="uri:789",
+        metadata=DiscMetadata(artist="New Artist", album="Album"),
+        option=DiscOption(),
+    )
     assert updated_disc.metadata.artist == "New Artist"
     assert updated_disc.metadata.album == "Album"
     assert updated_disc.metadata.track is None
@@ -98,7 +113,7 @@ def test_edit_multiple_metadata_fields():
     repo = MockRepo(Library(discs={"tag:abc": original_disc}))
 
     edit_disc = EditDisc(repo)
-    edit_disc.execute(tag_id="tag:abc", metadata=DiscMetadata(artist="New Artist", track="New Track"))
+    updated_disc = edit_disc.execute(tag_id="tag:abc", metadata=DiscMetadata(artist="New Artist", track="New Track"))
 
     assert repo.get_calls == ["tag:abc"]
     assert repo.update_calls == [
@@ -112,6 +127,11 @@ def test_edit_multiple_metadata_fields():
         )
     ]
     updated_disc = repo.library.discs["tag:abc"]
+    assert updated_disc == Disc(
+        uri="uri:abc",
+        metadata=DiscMetadata(artist="New Artist", album="Old Album", track="New Track"),
+        option=DiscOption(),
+    )
     assert updated_disc.metadata.artist == "New Artist"
     assert updated_disc.metadata.track == "New Track"
 
@@ -121,7 +141,9 @@ def test_edit_uri_and_metadata():
     repo = MockRepo(Library(discs={"tag:xyz": original_disc}))
 
     edit_disc = EditDisc(repo)
-    edit_disc.execute(tag_id="tag:xyz", uri="uri:new", metadata=DiscMetadata(artist="New Artist", album="New Album"))
+    updated_disc = edit_disc.execute(
+        tag_id="tag:xyz", uri="uri:new", metadata=DiscMetadata(artist="New Artist", album="New Album")
+    )
 
     assert repo.get_calls == ["tag:xyz"]
     assert repo.update_calls == [
@@ -135,6 +157,11 @@ def test_edit_uri_and_metadata():
         )
     ]
     updated_disc = repo.library.discs["tag:xyz"]
+    assert updated_disc == Disc(
+        uri="uri:new",
+        metadata=DiscMetadata(artist="New Artist", album="New Album"),
+        option=DiscOption(),
+    )
     assert updated_disc.uri == "uri:new"
     assert updated_disc.metadata.artist == "New Artist"
     assert updated_disc.metadata.album == "New Album"
@@ -145,7 +172,7 @@ def test_edit_options():
     repo = MockRepo(Library(discs={"tag:opt": original_disc}))
 
     edit_disc = EditDisc(repo)
-    edit_disc.execute(tag_id="tag:opt", option=DiscOption(shuffle=True))
+    updated_disc = edit_disc.execute(tag_id="tag:opt", option=DiscOption(shuffle=True))
 
     assert repo.get_calls == ["tag:opt"]
     assert repo.update_calls == [
@@ -159,6 +186,11 @@ def test_edit_options():
         )
     ]
     updated_disc = repo.library.discs["tag:opt"]
+    assert updated_disc == Disc(
+        uri="uri:123",
+        metadata=DiscMetadata(playlist="My Playlist"),
+        option=DiscOption(shuffle=True),
+    )
     assert updated_disc.uri == "uri:123"
     assert updated_disc.metadata.playlist == "My Playlist"
     assert updated_disc.option.shuffle is True
@@ -180,10 +212,11 @@ def test_edit_with_no_changes():
     repo = MockRepo(Library(discs={"tag:noop": original_disc}))
 
     edit_disc = EditDisc(repo)
-    edit_disc.execute(tag_id="tag:noop", uri=None, metadata=None, option=None)
+    updated_disc = edit_disc.execute(tag_id="tag:noop", uri=None, metadata=None, option=None)
 
     assert repo.get_calls == ["tag:noop"]
     assert repo.update_calls == [("tag:noop", original_disc)]
+    assert updated_disc == original_disc
     updated_disc = repo.library.discs["tag:noop"]
     assert updated_disc.uri == "uri:123"
     assert updated_disc.metadata.artist == "Artist"

--- a/tests/jukebox/admin/test_di_container.py
+++ b/tests/jukebox/admin/test_di_container.py
@@ -108,6 +108,7 @@ def test_build_admin_api_app_wiring(mocker, bootstrap_mocks):
         bootstrap_mocks.list_disc_instance,
         bootstrap_mocks.remove_disc_instance,
         bootstrap_mocks.edit_disc_instance,
+        bootstrap_mocks.get_disc_instance,
         bootstrap_mocks.get_current_tag_status_instance,
         services.settings,
         services.sonos,


### PR DESCRIPTION
## Summary

Closes #197.

This updates the disc API to use explicit CRUD semantics instead of the old upsert-style `POST /api/v1/disc` behavior.

## What changed

- removed the legacy `/api/v1/disc` upsert/delete endpoints
- added explicit disc routes under `/api/v1/discs/{tag_id}` for `GET`, `POST`, `PATCH`, and `DELETE`
- added a dedicated patch request model for partial disc updates
- wired `GetDisc` into the admin API container for single-disc fetches
- updated API, UI route, and DI tests to cover the new contract and status codes

## Behavior

- `POST /api/v1/discs/{tag_id}` now returns `409` if the tag already exists
- `GET`, `PATCH`, and `DELETE /api/v1/discs/{tag_id}` now return `404` if the tag is missing
- partial updates no longer depend on create-failure fallback behavior
