### PR TITLE
Current Tag API Routes

### DIFF
--- a/discstore/adapters/inbound/api/__init__.py
+++ b/discstore/adapters/inbound/api/__init__.py
@@ -1,6 +1,7 @@
 from discstore.adapters.inbound.api.current_tag_router import build_current_tag_router
 from discstore.adapters.inbound.api.discs_router import build_discs_router
 from discstore.adapters.inbound.api.models import (
+    CurrentTagDiscOutput,
     CurrentTagStatusOutput,
     DiscInput,
     DiscOutput,
@@ -11,6 +12,7 @@ from discstore.adapters.inbound.api.models import (
 from discstore.adapters.inbound.api.settings_router import build_settings_router
 
 __all__ = [
+    "CurrentTagDiscOutput",
     "CurrentTagStatusOutput",
     "DiscInput",
     "DiscOutput",

--- a/discstore/adapters/inbound/api/current_tag_router.py
+++ b/discstore/adapters/inbound/api/current_tag_router.py
@@ -1,13 +1,49 @@
-from typing import Any
+from typing import Any, Optional
 
-from fastapi import APIRouter, Response
+from fastapi import APIRouter, HTTPException, Response, status
 
-from discstore.adapters.inbound.api.models import CurrentTagStatusOutput
+from discstore.adapters.inbound.api.models import (
+    CurrentTagDiscOutput,
+    CurrentTagStatusOutput,
+    DiscInput,
+    DiscOutput,
+    DiscPatchInput,
+)
+from discstore.domain.entities import CurrentTagStatus, Disc, DiscMetadata, DiscOption
+from discstore.domain.use_cases.add_disc import AddDisc
+from discstore.domain.use_cases.edit_disc import EditDisc
 from discstore.domain.use_cases.get_current_tag_status import GetCurrentTagStatus
+from discstore.domain.use_cases.get_disc import GetDisc
+from discstore.domain.use_cases.remove_disc import RemoveDisc
 
 
-def build_current_tag_router(get_current_tag_status: GetCurrentTagStatus) -> APIRouter:
+def build_current_tag_router(
+    get_current_tag_status: GetCurrentTagStatus,
+    add_disc: AddDisc,
+    edit_disc: EditDisc,
+    get_disc: GetDisc,
+    remove_disc: RemoveDisc,
+) -> APIRouter:
     router = APIRouter(prefix="/api/v1", tags=["current-tag"])
+
+    def read_current_tag_status() -> Optional[CurrentTagStatus]:
+        return get_current_tag_status.execute()
+
+    def ensure_expected_tag_id_matches(
+        expected_tag_id: Optional[str], current_tag_status: Optional[CurrentTagStatus]
+    ) -> None:
+        if expected_tag_id is None:
+            return
+
+        actual_tag_id = None if current_tag_status is None else current_tag_status.tag_id
+        if actual_tag_id != expected_tag_id:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Current tag changed: expected_tag_id='{expected_tag_id}', actual_tag_id={repr(actual_tag_id)}",
+            )
+
+    def build_current_tag_disc_output(tag_id: str, disc: Disc) -> CurrentTagDiscOutput:
+        return CurrentTagDiscOutput(tag_id=tag_id, disc=DiscOutput(**disc.model_dump()))
 
     @router.get(
         "/current-tag",
@@ -16,10 +52,110 @@ def build_current_tag_router(get_current_tag_status: GetCurrentTagStatus) -> API
         summary="Get the current NFC tag status",
     )
     def get_current_tag() -> Any:
-        current_tag_status = get_current_tag_status.execute()
+        current_tag_status = read_current_tag_status()
         if current_tag_status is None:
             return Response(status_code=204)
 
         return CurrentTagStatusOutput(**current_tag_status.model_dump())
+
+    @router.get(
+        "/current-tag/disc",
+        response_model=CurrentTagDiscOutput,
+        responses={204: {"description": "No current tag"}, 404: {"description": "Current tag disc not found"}},
+        summary="Get the current tag disc",
+    )
+    def get_current_tag_disc() -> Any:
+        current_tag_status = read_current_tag_status()
+        if current_tag_status is None:
+            return Response(status_code=204)
+
+        if not current_tag_status.known_in_library:
+            raise HTTPException(status_code=404, detail=f"Tag does not exist: tag_id='{current_tag_status.tag_id}'")
+
+        return build_current_tag_disc_output(current_tag_status.tag_id, get_disc.execute(current_tag_status.tag_id))
+
+    @router.post(
+        "/current-tag/disc",
+        response_model=CurrentTagDiscOutput,
+        status_code=201,
+        responses={204: {"description": "No current tag"}, 409: {"description": "Current tag changed or disc exists"}},
+        summary="Create a disc for the current tag",
+    )
+    def create_current_tag_disc(
+        disc: DiscInput,
+        expected_tag_id: Optional[str] = None,
+    ) -> Any:
+        current_tag_status = read_current_tag_status()
+        ensure_expected_tag_id_matches(expected_tag_id, current_tag_status)
+        if current_tag_status is None:
+            return Response(status_code=204)
+
+        try:
+            new_disc = Disc(**disc.model_dump())
+            add_disc.execute(current_tag_status.tag_id, new_disc)
+            return build_current_tag_disc_output(current_tag_status.tag_id, new_disc)
+        except ValueError as value_err:
+            raise HTTPException(status_code=409, detail=str(value_err))
+        except Exception as err:
+            raise HTTPException(status_code=500, detail=f"Server error: {str(err)}")
+
+    @router.patch(
+        "/current-tag/disc",
+        response_model=CurrentTagDiscOutput,
+        responses={
+            204: {"description": "No current tag"},
+            404: {"description": "Current tag disc not found"},
+            409: {"description": "Current tag changed"},
+        },
+        summary="Update the current tag disc",
+    )
+    def update_current_tag_disc(
+        disc_patch: DiscPatchInput,
+        expected_tag_id: Optional[str] = None,
+    ) -> Any:
+        current_tag_status = read_current_tag_status()
+        ensure_expected_tag_id_matches(expected_tag_id, current_tag_status)
+        if current_tag_status is None:
+            return Response(status_code=204)
+
+        try:
+            metadata = None
+            if disc_patch.metadata is not None:
+                metadata = DiscMetadata(**disc_patch.metadata.model_dump(exclude_unset=True, exclude_none=True))
+
+            option = None
+            if disc_patch.option is not None:
+                option = DiscOption(**disc_patch.option.model_dump(exclude_unset=True, exclude_none=True))
+
+            edit_disc.execute(current_tag_status.tag_id, disc_patch.uri, metadata, option)
+            return build_current_tag_disc_output(current_tag_status.tag_id, get_disc.execute(current_tag_status.tag_id))
+        except ValueError as value_err:
+            raise HTTPException(status_code=404, detail=str(value_err))
+        except Exception as err:
+            raise HTTPException(status_code=500, detail=f"Server error: {str(err)}")
+
+    @router.delete(
+        "/current-tag/disc",
+        status_code=204,
+        responses={
+            204: {"description": "No current tag or disc deleted"},
+            404: {"description": "Current tag disc not found"},
+            409: {"description": "Current tag changed"},
+        },
+        summary="Delete the current tag disc",
+    )
+    def delete_current_tag_disc(expected_tag_id: Optional[str] = None) -> Response:
+        current_tag_status = read_current_tag_status()
+        ensure_expected_tag_id_matches(expected_tag_id, current_tag_status)
+        if current_tag_status is None:
+            return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+        try:
+            remove_disc.execute(current_tag_status.tag_id)
+            return Response(status_code=status.HTTP_204_NO_CONTENT)
+        except ValueError as value_err:
+            raise HTTPException(status_code=404, detail=str(value_err))
+        except Exception as err:
+            raise HTTPException(status_code=500, detail=f"Server error: {str(err)}")
 
     return router

--- a/discstore/adapters/inbound/api/models.py
+++ b/discstore/adapters/inbound/api/models.py
@@ -30,7 +30,6 @@ class DiscPatchInput(BaseModel):
     metadata: Optional[DiscPatchMetadataInput] = None
     option: Optional[DiscPatchOptionInput] = None
 
-
 class CurrentTagStatusOutput(CurrentTagStatus):
     pass
 

--- a/discstore/adapters/inbound/api/models.py
+++ b/discstore/adapters/inbound/api/models.py
@@ -34,6 +34,11 @@ class CurrentTagStatusOutput(CurrentTagStatus):
     pass
 
 
+class CurrentTagDiscOutput(BaseModel):
+    tag_id: str
+    disc: DiscOutput
+
+
 class SettingsResetInput(BaseModel):
     path: str
 

--- a/discstore/adapters/inbound/api/models.py
+++ b/discstore/adapters/inbound/api/models.py
@@ -30,6 +30,7 @@ class DiscPatchInput(BaseModel):
     metadata: Optional[DiscPatchMetadataInput] = None
     option: Optional[DiscPatchOptionInput] = None
 
+
 class CurrentTagStatusOutput(CurrentTagStatus):
     pass
 

--- a/discstore/adapters/inbound/api_controller.py
+++ b/discstore/adapters/inbound/api_controller.py
@@ -10,6 +10,7 @@ try:
     from discstore.adapters.inbound.api.current_tag_router import build_current_tag_router
     from discstore.adapters.inbound.api.discs_router import build_discs_router
     from discstore.adapters.inbound.api.models import (
+        CurrentTagDiscOutput,
         CurrentTagStatusOutput,
         DiscInput,
         DiscOutput,
@@ -39,6 +40,7 @@ from jukebox.sonos.service import SonosService
 
 __all__ = [
     "APIController",
+    "CurrentTagDiscOutput",
     "CurrentTagStatusOutput",
     "DiscInput",
     "DiscOutput",
@@ -123,7 +125,15 @@ class APIController:
                 get_disc=self.get_disc,
             )
         )
-        self.app.include_router(build_current_tag_router(self.get_current_tag_status))
+        self.app.include_router(
+            build_current_tag_router(
+                get_current_tag_status=self.get_current_tag_status,
+                add_disc=self.add_disc,
+                edit_disc=self.edit_disc,
+                get_disc=self.get_disc,
+                remove_disc=self.remove_disc,
+            )
+        )
         self.app.include_router(build_settings_router(self.settings_service))
 
         @self.app.get("/api/v1/sonos/speakers", response_model=list[SonosSpeakerOutput])

--- a/tests/discstore/adapters/inbound/test_api_controller.py
+++ b/tests/discstore/adapters/inbound/test_api_controller.py
@@ -187,6 +187,234 @@ def test_disc_routes_register_explicit_crud_paths():
     assert ("/api/v1/discs/{tag_id}", ("DELETE",)) in route_index
     assert ("/api/v1/disc", ("POST",)) not in route_index
     assert ("/api/v1/disc", ("DELETE",)) not in route_index
+    assert ("/api/v1/current-tag/disc", ("GET",)) in route_index
+    assert ("/api/v1/current-tag/disc", ("POST",)) in route_index
+    assert ("/api/v1/current-tag/disc", ("PATCH",)) in route_index
+    assert ("/api/v1/current-tag/disc", ("DELETE",)) in route_index
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_get_current_tag_disc_returns_tag_and_disc_payload():
+    get_current_tag_status = create_autospec(GetCurrentTagStatus, instance=True, spec_set=True)
+    get_current_tag_status.execute.return_value = CurrentTagStatus(tag_id="tag-123", known_in_library=True)
+    get_disc = MagicMock()
+    get_disc.execute.return_value = Disc(
+        uri="/music/song.mp3",
+        metadata=DiscMetadata(artist="Artist", album="Album", track="Track"),
+        option=DiscOption(shuffle=True),
+    )
+    controller = build_controller(get_current_tag_status=get_current_tag_status, get_disc=get_disc)
+    route = get_route(controller, "/api/v1/current-tag/disc", "GET")
+
+    response = route.endpoint()
+
+    assert route.response_model is not None
+    assert route.response_model.__name__ == "CurrentTagDiscOutput"
+    assert response.model_dump() == {
+        "tag_id": "tag-123",
+        "disc": {
+            "uri": "/music/song.mp3",
+            "metadata": {"artist": "Artist", "album": "Album", "track": "Track", "playlist": None},
+            "option": {"shuffle": True, "is_test": False},
+        },
+    }
+    get_disc.execute.assert_called_once_with("tag-123")
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_get_current_tag_disc_returns_no_content_when_absent():
+    get_current_tag_status = create_autospec(GetCurrentTagStatus, instance=True, spec_set=True)
+    get_current_tag_status.execute.return_value = None
+    controller = build_controller(get_current_tag_status=get_current_tag_status)
+    route = get_route(controller, "/api/v1/current-tag/disc", "GET")
+
+    response = route.endpoint()
+
+    assert response.status_code == 204
+    assert response.body == b""
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_get_current_tag_disc_returns_404_when_current_tag_is_unknown():
+    get_current_tag_status = create_autospec(GetCurrentTagStatus, instance=True, spec_set=True)
+    get_current_tag_status.execute.return_value = CurrentTagStatus(tag_id="tag-123", known_in_library=False)
+    controller = build_controller(get_current_tag_status=get_current_tag_status)
+    route = get_route(controller, "/api/v1/current-tag/disc", "GET")
+
+    with pytest.raises(HTTPException) as err:
+        route.endpoint()
+
+    assert err.value.status_code == 404
+    assert err.value.detail == "Tag does not exist: tag_id='tag-123'"
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_create_current_tag_disc_returns_created_disc_payload():
+    get_current_tag_status = create_autospec(GetCurrentTagStatus, instance=True, spec_set=True)
+    get_current_tag_status.execute.return_value = CurrentTagStatus(tag_id="tag-123", known_in_library=False)
+    add_disc = MagicMock()
+    controller = build_controller(get_current_tag_status=get_current_tag_status, add_disc=add_disc)
+    route = get_route(controller, "/api/v1/current-tag/disc", "POST")
+    request = DiscInput(
+        uri="/music/song.mp3",
+        metadata=DiscMetadata(artist="Artist", album="Album", track="Track"),
+        option=DiscOption(shuffle=True),
+    )
+
+    response = route.endpoint(request)
+
+    assert response.model_dump() == {
+        "tag_id": "tag-123",
+        "disc": request.model_dump(),
+    }
+    add_disc.execute.assert_called_once_with("tag-123", Disc(**request.model_dump()))
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_create_current_tag_disc_returns_no_content_when_absent():
+    get_current_tag_status = create_autospec(GetCurrentTagStatus, instance=True, spec_set=True)
+    get_current_tag_status.execute.return_value = None
+    add_disc = MagicMock()
+    controller = build_controller(get_current_tag_status=get_current_tag_status, add_disc=add_disc)
+    route = get_route(controller, "/api/v1/current-tag/disc", "POST")
+
+    response = route.endpoint(DiscInput(uri="/music/song.mp3", metadata=DiscMetadata(), option=DiscOption()))
+
+    assert response.status_code == 204
+    assert response.body == b""
+    add_disc.execute.assert_not_called()
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_create_current_tag_disc_returns_409_when_tag_exists():
+    get_current_tag_status = create_autospec(GetCurrentTagStatus, instance=True, spec_set=True)
+    get_current_tag_status.execute.return_value = CurrentTagStatus(tag_id="tag-123", known_in_library=True)
+    add_disc = MagicMock()
+    add_disc.execute.side_effect = ValueError("Already existing tag: tag_id='tag-123'")
+    controller = build_controller(get_current_tag_status=get_current_tag_status, add_disc=add_disc)
+    route = get_route(controller, "/api/v1/current-tag/disc", "POST")
+
+    with pytest.raises(HTTPException) as err:
+        route.endpoint(DiscInput(uri="/music/song.mp3", metadata=DiscMetadata(artist="Artist"), option=DiscOption()))
+
+    assert err.value.status_code == 409
+    assert err.value.detail == "Already existing tag: tag_id='tag-123'"
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_patch_current_tag_disc_partially_updates_existing_disc():
+    get_current_tag_status = create_autospec(GetCurrentTagStatus, instance=True, spec_set=True)
+    get_current_tag_status.execute.return_value = CurrentTagStatus(tag_id="tag-123", known_in_library=True)
+    edit_disc = MagicMock()
+    get_disc = MagicMock()
+    get_disc.execute.return_value = Disc(
+        uri="/music/song.mp3",
+        metadata=DiscMetadata(artist="Artist", album="Album", track="Updated Track"),
+        option=DiscOption(shuffle=False),
+    )
+    controller = build_controller(get_current_tag_status=get_current_tag_status, edit_disc=edit_disc, get_disc=get_disc)
+    route = get_route(controller, "/api/v1/current-tag/disc", "PATCH")
+
+    response = route.endpoint(DiscPatchInput(metadata={"track": "Updated Track"}, option={"shuffle": False}))
+
+    assert response.model_dump() == {
+        "tag_id": "tag-123",
+        "disc": {
+            "uri": "/music/song.mp3",
+            "metadata": {"artist": "Artist", "album": "Album", "track": "Updated Track", "playlist": None},
+            "option": {"shuffle": False, "is_test": False},
+        },
+    }
+    edit_disc.execute.assert_called_once_with(
+        "tag-123",
+        None,
+        DiscMetadata(track="Updated Track"),
+        DiscOption(shuffle=False),
+    )
+    get_disc.execute.assert_called_once_with("tag-123")
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_patch_current_tag_disc_returns_no_content_when_absent():
+    get_current_tag_status = create_autospec(GetCurrentTagStatus, instance=True, spec_set=True)
+    get_current_tag_status.execute.return_value = None
+    edit_disc = MagicMock()
+    controller = build_controller(get_current_tag_status=get_current_tag_status, edit_disc=edit_disc)
+    route = get_route(controller, "/api/v1/current-tag/disc", "PATCH")
+
+    response = route.endpoint(DiscPatchInput(uri="/music/new-song.mp3"))
+
+    assert response.status_code == 204
+    assert response.body == b""
+    edit_disc.execute.assert_not_called()
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_patch_current_tag_disc_returns_404_when_missing():
+    get_current_tag_status = create_autospec(GetCurrentTagStatus, instance=True, spec_set=True)
+    get_current_tag_status.execute.return_value = CurrentTagStatus(tag_id="missing", known_in_library=False)
+    edit_disc = MagicMock()
+    edit_disc.execute.side_effect = ValueError("Tag does not exist: tag_id='missing'")
+    controller = build_controller(get_current_tag_status=get_current_tag_status, edit_disc=edit_disc)
+    route = get_route(controller, "/api/v1/current-tag/disc", "PATCH")
+
+    with pytest.raises(HTTPException) as err:
+        route.endpoint(DiscPatchInput(uri="/music/new-song.mp3"))
+
+    assert err.value.status_code == 404
+    assert err.value.detail == "Tag does not exist: tag_id='missing'"
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_delete_current_tag_disc_returns_no_content():
+    get_current_tag_status = create_autospec(GetCurrentTagStatus, instance=True, spec_set=True)
+    get_current_tag_status.execute.return_value = CurrentTagStatus(tag_id="tag-123", known_in_library=True)
+    remove_disc = MagicMock()
+    controller = build_controller(get_current_tag_status=get_current_tag_status, remove_disc=remove_disc)
+    route = get_route(controller, "/api/v1/current-tag/disc", "DELETE")
+
+    response = route.endpoint()
+
+    assert response.status_code == 204
+    assert response.body == b""
+    remove_disc.execute.assert_called_once_with("tag-123")
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_delete_current_tag_disc_returns_no_content_when_absent():
+    get_current_tag_status = create_autospec(GetCurrentTagStatus, instance=True, spec_set=True)
+    get_current_tag_status.execute.return_value = None
+    remove_disc = MagicMock()
+    controller = build_controller(get_current_tag_status=get_current_tag_status, remove_disc=remove_disc)
+    route = get_route(controller, "/api/v1/current-tag/disc", "DELETE")
+
+    response = route.endpoint()
+
+    assert response.status_code == 204
+    assert response.body == b""
+    remove_disc.execute.assert_not_called()
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+@pytest.mark.parametrize("method", ["POST", "PATCH", "DELETE"])
+def test_current_tag_disc_mutations_return_409_when_expected_tag_id_mismatches(method):
+    get_current_tag_status = create_autospec(GetCurrentTagStatus, instance=True, spec_set=True)
+    get_current_tag_status.execute.return_value = CurrentTagStatus(tag_id="other-tag", known_in_library=True)
+    controller = build_controller(get_current_tag_status=get_current_tag_status)
+    route = get_route(controller, "/api/v1/current-tag/disc", method)
+
+    if method == "POST":
+        call_args = (DiscInput(uri="/music/song.mp3", metadata=DiscMetadata(), option=DiscOption()), "tag-123")
+    elif method == "PATCH":
+        call_args = (DiscPatchInput(uri="/music/song.mp3"), "tag-123")
+    else:
+        call_args = ("tag-123",)
+
+    with pytest.raises(HTTPException) as err:
+        route.endpoint(*call_args)
+
+    assert err.value.status_code == 409
+    assert err.value.detail == "Current tag changed: expected_tag_id='tag-123', actual_tag_id='other-tag'"
 
 
 @pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")

--- a/tests/discstore/adapters/inbound/test_api_controller.py
+++ b/tests/discstore/adapters/inbound/test_api_controller.py
@@ -315,7 +315,12 @@ def test_patch_current_tag_disc_partially_updates_existing_disc():
     controller = build_controller(get_current_tag_status=get_current_tag_status, edit_disc=edit_disc, get_disc=get_disc)
     route = get_route(controller, "/api/v1/current-tag/disc", "PATCH")
 
-    response = route.endpoint(DiscPatchInput(metadata={"track": "Updated Track"}, option={"shuffle": False}))
+    response = route.endpoint(
+        DiscPatchInput(
+            metadata=DiscPatchMetadataInput(track="Updated Track"),
+            option=DiscPatchOptionInput(shuffle=False),
+        )
+    )
 
     assert response.model_dump() == {
         "tag_id": "tag-123",


### PR DESCRIPTION
Closes #136.

## Summary

Adds complete `current-tag` API support:

- add `GET /api/v1/current-tag/disc`
- add `POST /api/v1/current-tag/disc`
- add `PATCH /api/v1/current-tag/disc`
- add `DELETE /api/v1/current-tag/disc`
- return both `tag_id` and `disc` for current-tag disc reads
- follow the issue comment semantics for `204`, `404`, and `409`
- support optional `expected_tag_id` race protection on mutations
