### PR TITLE
✨ Allow clearing nullable fields via PATCH to disc and current-disc routes

### DIFF
--- a/discstore/adapters/inbound/api/current_tag_router.py
+++ b/discstore/adapters/inbound/api/current_tag_router.py
@@ -1,6 +1,7 @@
 from typing import Any, Optional
 
 from fastapi import APIRouter, HTTPException, Response, status
+from pydantic import ValidationError
 
 from discstore.adapters.inbound.api.models import (
     CurrentTagDiscOutput,
@@ -121,14 +122,16 @@ def build_current_tag_router(
         try:
             metadata = None
             if disc_patch.metadata is not None:
-                metadata = DiscMetadata(**disc_patch.metadata.model_dump(exclude_unset=True, exclude_none=True))
+                metadata = DiscMetadata(**disc_patch.metadata.model_dump(exclude_unset=True))
 
             option = None
             if disc_patch.option is not None:
-                option = DiscOption(**disc_patch.option.model_dump(exclude_unset=True, exclude_none=True))
+                option = DiscOption(**disc_patch.option.model_dump(exclude_unset=True))
 
             updated_disc = edit_disc.execute(current_tag_status.tag_id, disc_patch.uri, metadata, option)
             return build_current_tag_disc_output(current_tag_status.tag_id, updated_disc)
+        except ValidationError as err:
+            raise HTTPException(status_code=422, detail=err.errors())
         except ValueError as value_err:
             raise HTTPException(status_code=404, detail=str(value_err))
         except Exception as err:

--- a/discstore/adapters/inbound/api/discs_router.py
+++ b/discstore/adapters/inbound/api/discs_router.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
 from fastapi import APIRouter, HTTPException, Response, status
+from pydantic import ValidationError
 
 from discstore.adapters.inbound.api.models import DiscInput, DiscOutput, DiscPatchInput
 from discstore.domain.entities import Disc, DiscMetadata, DiscOption
@@ -48,13 +49,15 @@ def build_discs_router(
         try:
             metadata = None
             if disc_patch.metadata is not None:
-                metadata = DiscMetadata(**disc_patch.metadata.model_dump(exclude_unset=True, exclude_none=True))
+                metadata = DiscMetadata(**disc_patch.metadata.model_dump(exclude_unset=True))
 
             option = None
             if disc_patch.option is not None:
-                option = DiscOption(**disc_patch.option.model_dump(exclude_unset=True, exclude_none=True))
+                option = DiscOption(**disc_patch.option.model_dump(exclude_unset=True))
 
             return edit_disc.execute(tag_id, disc_patch.uri, metadata, option)
+        except ValidationError as err:
+            raise HTTPException(status_code=422, detail=err.errors())
         except ValueError as value_err:
             raise HTTPException(status_code=404, detail=str(value_err))
         except Exception as err:

--- a/discstore/domain/use_cases/edit_disc.py
+++ b/discstore/domain/use_cases/edit_disc.py
@@ -24,14 +24,14 @@ class EditDisc:
         new_metadata = current_disc.metadata
         if metadata is not None:
             current_data = current_disc.metadata.model_dump()
-            new_data = metadata.model_dump(exclude_unset=True, exclude_none=True)
+            new_data = metadata.model_dump(exclude_unset=True)
             current_data.update(new_data)
             new_metadata = DiscMetadata(**current_data)
 
         new_option = current_disc.option
         if option is not None:
             current_opt_data = current_disc.option.model_dump()
-            new_opt_data = option.model_dump(exclude_unset=True, exclude_none=True)
+            new_opt_data = option.model_dump(exclude_unset=True)
             current_opt_data.update(new_opt_data)
             new_option = DiscOption(**current_opt_data)
 

--- a/tests/discstore/adapters/inbound/test_api_controller.py
+++ b/tests/discstore/adapters/inbound/test_api_controller.py
@@ -370,6 +370,50 @@ def test_patch_current_tag_disc_returns_404_when_missing():
 
 
 @pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_patch_current_tag_disc_returns_422_when_null_assigned_to_non_nullable_option_field():
+    get_current_tag_status = create_autospec(GetCurrentTagStatus, instance=True, spec_set=True)
+    get_current_tag_status.execute.return_value = CurrentTagStatus(tag_id="tag-123", known_in_library=True)
+    controller = build_controller(get_current_tag_status=get_current_tag_status)
+    route = get_route(controller, "/api/v1/current-tag/disc", "PATCH")
+
+    with pytest.raises(HTTPException) as err:
+        route.endpoint(DiscPatchInput(option=DiscPatchOptionInput(shuffle=None)))
+
+    assert err.value.status_code == 422
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_patch_current_tag_disc_clears_nullable_metadata_field():
+    get_current_tag_status = create_autospec(GetCurrentTagStatus, instance=True, spec_set=True)
+    get_current_tag_status.execute.return_value = CurrentTagStatus(tag_id="tag-123", known_in_library=True)
+    edit_disc = MagicMock()
+    edit_disc.execute.return_value = Disc(
+        uri="/music/song.mp3",
+        metadata=DiscMetadata(artist=None, album="Album", track="Track"),
+        option=DiscOption(shuffle=False),
+    )
+    controller = build_controller(get_current_tag_status=get_current_tag_status, edit_disc=edit_disc)
+    route = get_route(controller, "/api/v1/current-tag/disc", "PATCH")
+
+    response = route.endpoint(DiscPatchInput(metadata=DiscPatchMetadataInput(artist=None)))
+
+    assert response.model_dump() == {
+        "disc": {
+            "metadata": {"album": "Album", "artist": None, "playlist": None, "track": "Track"},
+            "option": {"is_test": False, "shuffle": False},
+            "uri": "/music/song.mp3",
+        },
+        "tag_id": "tag-123",
+    }
+    edit_disc.execute.assert_called_once_with(
+        "tag-123",
+        None,
+        DiscMetadata(artist=None),
+        None,
+    )
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
 def test_delete_current_tag_disc_returns_no_content():
     get_current_tag_status = create_autospec(GetCurrentTagStatus, instance=True, spec_set=True)
     get_current_tag_status.execute.return_value = CurrentTagStatus(tag_id="tag-123", known_in_library=True)

--- a/tests/discstore/adapters/inbound/test_api_controller.py
+++ b/tests/discstore/adapters/inbound/test_api_controller.py
@@ -530,6 +530,17 @@ def test_patch_disc_partially_updates_existing_disc():
 
 
 @pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_patch_disc_returns_422_when_null_assigned_to_non_nullable_option_field():
+    controller = build_controller()
+    route = get_route(controller, "/api/v1/discs/{tag_id}", "PATCH")
+
+    with pytest.raises(HTTPException) as err:
+        route.endpoint("tag-123", DiscPatchInput(option=DiscPatchOptionInput(shuffle=None)))
+
+    assert err.value.status_code == 422
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
 def test_patch_disc_returns_404_when_missing():
     edit_disc = MagicMock()
     edit_disc.execute.side_effect = ValueError("Tag does not exist: tag_id='missing'")
@@ -541,6 +552,24 @@ def test_patch_disc_returns_404_when_missing():
 
     assert err.value.status_code == 404
     assert err.value.detail == "Tag does not exist: tag_id='missing'"
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_patch_disc_clears_nullable_metadata_field():
+    edit_disc = MagicMock()
+    edit_disc.execute.return_value = "the_value_returned_by_the_EditDisc_use_case"
+    controller = build_controller(edit_disc=edit_disc)
+    route = get_route(controller, "/api/v1/discs/{tag_id}", "PATCH")
+
+    response = route.endpoint("tag-123", DiscPatchInput(metadata=DiscPatchMetadataInput(artist=None)))
+
+    assert response == "the_value_returned_by_the_EditDisc_use_case"
+    edit_disc.execute.assert_called_once_with(
+        "tag-123",
+        None,
+        DiscMetadata(artist=None),
+        None,
+    )
 
 
 @pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")

--- a/tests/discstore/domain/use_cases/test_edit_disc.py
+++ b/tests/discstore/domain/use_cases/test_edit_disc.py
@@ -207,6 +207,23 @@ def test_edit_nonexistent_tag_raises_error():
     assert repo.update_calls == []
 
 
+def test_edit_clears_metadata_field():
+    original_disc = Disc(
+        uri="uri:123",
+        metadata=DiscMetadata(artist="Artist", album="Album", track="Track"),
+        option=DiscOption(),
+    )
+    repo = MockRepo(Library(discs={"tag:123": original_disc}))
+
+    edit_disc = EditDisc(repo)
+    edit_disc.execute(tag_id="tag:123", metadata=DiscMetadata(artist=None))
+
+    updated_disc = repo.library.discs["tag:123"]
+    assert updated_disc.metadata.artist is None
+    assert updated_disc.metadata.album == "Album"
+    assert updated_disc.metadata.track == "Track"
+
+
 def test_edit_with_no_changes():
     original_disc = Disc(uri="uri:123", metadata=DiscMetadata(artist="Artist"), option=DiscOption())
     repo = MockRepo(Library(discs={"tag:noop": original_disc}))


### PR DESCRIPTION
 ## Summary

Previously, `PATCH /api/v1/discs/{tag_id}` and `PATCH /api/v1/current-tag/disc` silently ignored `null` values in the request body due to `exclude_none=True` being applied during `model_dump`. This made it impossible to clear an optional metadata field once set (e.g. `artist`, `album`, `track`, `playlist`).

## What changed

- Removed `exclude_none=True` from metadata field deserialization in `discs_router`, `current_tag_router`, and `EditDisc`, so that explicitly provided `null` values overwrite the current stored value
- Removed `exclude_none=True` from option field deserialization for the same reasons
  sending `null` for a non-nullable field (`shuffle`, `is_test`) now raises a Pydantic `ValidationError`, caught and returned as a `422 Unprocessable Entity` (the same as type errors)

## Behavior

| Field type | Before | After |
|---|---|---|
| `Optional[str]` (metadata) | `null` silently ignored | `null` clears the field |
| `bool` (option) | `null` silently ignored | `null` returns `422` |
| Omitted field | kept as-is | kept as-is |

The `exclude_unset=True` + Pydantic `model_fields_set` tracking ensures that omitted fields are still distinguished from explicitly-nulled ones.

## Excluded from the scope 

CLI and UI support for clearing nullable fields is not included in this PR.