### PR TITLE
💥♻️ Replace generic NFC reader with a more explicit PN532 reader family

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ This file provides guidance to AI coding agents when working with code in this r
 uv sync                   # base installation (always safe)
 
 # Install optional extras (EXPLICIT ONLY — do not guess)
-uv sync --extra nfc       # enable NFC tag reading in jukebox (requires compatible hardware)
+uv sync --extra pn532     # enable NFC tag reading in jukebox (requires compatible hardware)
 uv sync --extra api       # enable REST API for discstore
 uv sync --extra ui        # enable Web UI for discstore
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Start the jukebox with the `jukebox` command (show help message with `--help`)
 jukebox PLAYER_TO_USE READER_TO_USE
 ```
 
-🎉 With choosing the `sonos` player and `nfc` reader, by approaching a NFC tag stored in the `library.json` file, you should hear the associated music begins.
+🎉 With choosing the `sonos` player and `pn532` reader, by approaching a NFC tag stored in the `library.json` file, you should hear the associated music begins.
 
 Optional Parameters
 
@@ -184,7 +184,7 @@ Expected syntax: `tag_id` or `tag_id duration_seconds`.
 - duration_seconds: a non-negative number of seconds used to simulate how long the tag remains in place. Fractional values are allowed.
 Complete example: `your:tag:uid 2.5`
 
-**NFC** (`nfc`)
+**NFC Pn532** (`pn532`)
 Read an NFC tag and get its UID.
 This project works with an NFC reader like the **PN532** and NFC tags like the **NTAG2xx**.
 It is configured according to the [Waveshare PN532 wiki](https://www.waveshare.com/wiki/PN532_NFC_HAT).

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Install the package from [PyPI](https://pypi.org/project/gukebox/).
 > The package name is `gukebox` with `g` instead of a `j` (due to a name already taken).
 
 > [!NOTE]
-> The `nfc` extra is optional but required for NFC reading, [check compatibility](#readers).
+> The `pn532` extra is optional but required for NFC reading, [check compatibility](#readers).
 
 ### Recommended installation
 
@@ -74,7 +74,7 @@ source jukebox/bin/activate
 
 3. Install `gukebox` into the virtual environment:
 ```shell
-pip install "gukebox[nfc]"
+pip install "gukebox[pn532]"
 ```
 
 > [!IMPORTANT]

--- a/jukebox/adapters/inbound/config.py
+++ b/jukebox/adapters/inbound/config.py
@@ -16,7 +16,7 @@ class JukeboxCliConfig(BaseModel):
     library: Optional[str] = None
     verbose: bool = False
     player: Optional[Literal["dryrun", "sonos"]] = None
-    reader: Optional[Literal["dryrun", "nfc"]] = None
+    reader: Optional[Literal["dryrun", "pn532"]] = None
     sonos_host: Optional[str] = None
     sonos_name: Optional[str] = None
     pause_duration_seconds: Optional[int] = None
@@ -40,7 +40,7 @@ def parse_config() -> JukeboxCliConfig:
     add_version_arg(parser)
 
     parser.add_argument("positional_player", nargs="?", choices=["dryrun", "sonos"], help="override the player type")
-    parser.add_argument("positional_reader", nargs="?", choices=["dryrun", "nfc"], help="override the reader type")
+    parser.add_argument("positional_reader", nargs="?", choices=["dryrun", "pn532"], help="override the reader type")
 
     parser.add_argument(
         "--player",
@@ -50,7 +50,7 @@ def parse_config() -> JukeboxCliConfig:
     )
     parser.add_argument(
         "--reader",
-        choices=["dryrun", "nfc"],
+        choices=["dryrun", "pn532"],
         default=None,
         help="override the reader type without providing both positional type arguments",
     )

--- a/jukebox/adapters/outbound/readers/pn532_reader_adapter.py
+++ b/jukebox/adapters/outbound/readers/pn532_reader_adapter.py
@@ -9,7 +9,7 @@ from jukebox.shared.dependency_messages import optional_extra_dependency_message
 try:
     from pn532 import PN532_SPI
 except ModuleNotFoundError as err:
-    raise ModuleNotFoundError(optional_extra_dependency_message("The `nfc` reader", "nfc", "jukebox ...")) from err
+    raise ModuleNotFoundError(optional_extra_dependency_message("The `pn532` reader", "nfc", "jukebox ...")) from err
 
 from jukebox.domain.ports import ReaderPort
 from jukebox.shared.timing import DEFAULT_NFC_READ_TIMEOUT_SECONDS
@@ -25,13 +25,13 @@ def spi_active():
     return any(dev.startswith("spidev") for dev in os.listdir("/dev"))
 
 
-class NfcReaderAdapter(ReaderPort):
-    """Adapter for NFC reader implementing ReaderPort."""
+class Pn532ReaderAdapter(ReaderPort):
+    """Adapter for Pn532 NFC reader implementing ReaderPort."""
 
     def __init__(self, read_timeout_seconds: float = DEFAULT_NFC_READ_TIMEOUT_SECONDS):
         if not spi_active():
             error_message = (
-                "The SPI interface is not enabled. Please enable it to use the NFC reader."
+                "The SPI interface is not enabled. Please enable it to use the PN532 NFC reader."
                 "You can enable SPI using `sudo raspi-config` then navigate to: Interface Options > SPI > Enable > Yes."
             )
             LOGGER.error(error_message)

--- a/jukebox/adapters/outbound/readers/pn532_reader_adapter.py
+++ b/jukebox/adapters/outbound/readers/pn532_reader_adapter.py
@@ -9,7 +9,7 @@ from jukebox.shared.dependency_messages import optional_extra_dependency_message
 try:
     from pn532 import PN532_SPI
 except ModuleNotFoundError as err:
-    raise ModuleNotFoundError(optional_extra_dependency_message("The `pn532` reader", "nfc", "jukebox ...")) from err
+    raise ModuleNotFoundError(optional_extra_dependency_message("The `pn532` reader", "pn532", "jukebox ...")) from err
 
 from jukebox.domain.ports import ReaderPort
 from jukebox.shared.timing import DEFAULT_NFC_READ_TIMEOUT_SECONDS

--- a/jukebox/di_container.py
+++ b/jukebox/di_container.py
@@ -24,9 +24,9 @@ def build_jukebox(config: ResolvedJukeboxRuntimeConfig):
         raise ValueError(f"Unknown player type: {config.player_type}")
 
     if config.reader_type == "nfc":
-        from jukebox.adapters.outbound.readers.nfc_reader_adapter import NfcReaderAdapter
+        from jukebox.adapters.outbound.readers.pn532_reader_adapter import Pn532ReaderAdapter
 
-        reader = NfcReaderAdapter(read_timeout_seconds=config.nfc_read_timeout_seconds)
+        reader = Pn532ReaderAdapter(read_timeout_seconds=config.nfc_read_timeout_seconds)
     elif config.reader_type == "dryrun":
         reader = DryrunReaderAdapter()
     else:

--- a/jukebox/di_container.py
+++ b/jukebox/di_container.py
@@ -23,10 +23,10 @@ def build_jukebox(config: ResolvedJukeboxRuntimeConfig):
     else:
         raise ValueError(f"Unknown player type: {config.player_type}")
 
-    if config.reader_type == "nfc":
+    if config.reader_type == "pn532":
         from jukebox.adapters.outbound.readers.pn532_reader_adapter import Pn532ReaderAdapter
 
-        reader = Pn532ReaderAdapter(read_timeout_seconds=config.nfc_read_timeout_seconds)
+        reader = Pn532ReaderAdapter(read_timeout_seconds=config.pn532_read_timeout_seconds)
     elif config.reader_type == "dryrun":
         reader = DryrunReaderAdapter()
     else:

--- a/jukebox/settings/definitions.py
+++ b/jukebox/settings/definitions.py
@@ -165,13 +165,13 @@ SETTINGS = {
         requires_restart=True,
         choices=(
             SettingChoice(value="dryrun", label="Dry Run"),
-            SettingChoice(value="nfc", label="NFC"),
+            SettingChoice(value="pn532", label="Pn532 NFC"),
         ),
     ),
-    "jukebox.reader.nfc.read_timeout_seconds": SettingDefinition(
-        path="jukebox.reader.nfc.read_timeout_seconds",
-        label="NFC Read Timeout",
-        description="Timeout in seconds for each NFC poll attempt.",
+    "jukebox.reader.pn532.read_timeout_seconds": SettingDefinition(
+        path="jukebox.reader.pn532.read_timeout_seconds",
+        label="Pn532 NFC Read Timeout",
+        description="Timeout in seconds for each Pn532 NFC poll attempt.",
         field_type="number",
         section="reader",
         requires_restart=True,

--- a/jukebox/settings/entities.py
+++ b/jukebox/settings/entities.py
@@ -66,13 +66,13 @@ class PlayerSettings(PersistedPlayerSettings):
     sonos: SonosPlayerSettings = Field(default_factory=SonosPlayerSettings)
 
 
-class NfcReaderSettings(StrictModel):
+class Pn532ReaderSettings(StrictModel):
     read_timeout_seconds: float = Field(default=0.1, gt=0)
 
 
 class ReaderSettings(StrictModel):
-    type: Literal["dryrun", "nfc"] = "dryrun"
-    nfc: NfcReaderSettings = Field(default_factory=NfcReaderSettings)
+    type: Literal["dryrun", "pn532"] = "dryrun"
+    pn532: Pn532ReaderSettings = Field(default_factory=Pn532ReaderSettings)
 
 
 class PlaybackSettings(StrictModel):
@@ -146,13 +146,13 @@ class SparsePlayerSettings(SparsePersistedPlayerSettings):
     sonos: Optional[SparseSonosPlayerSettings] = None
 
 
-class SparseNfcReaderSettings(StrictModel):
+class SparsePn532ReaderSettings(StrictModel):
     read_timeout_seconds: Optional[float] = None
 
 
 class SparseReaderSettings(StrictModel):
-    type: Optional[Literal["dryrun", "nfc"]] = None
-    nfc: Optional[SparseNfcReaderSettings] = None
+    type: Optional[Literal["dryrun", "pn532"]] = None
+    pn532: Optional[SparsePn532ReaderSettings] = None
 
 
 class SparsePlaybackSettings(StrictModel):
@@ -247,11 +247,11 @@ class ResolvedJukeboxRuntimeConfig(StrictModel):
     sonos_host: Optional[str] = None
     sonos_name: Optional[str] = None
     sonos_group: Optional[ResolvedSonosGroupRuntime] = None
-    reader_type: Literal["dryrun", "nfc"]
+    reader_type: Literal["dryrun", "pn532"]
     pause_duration_seconds: int
     pause_delay_seconds: float
     loop_interval_seconds: float
-    nfc_read_timeout_seconds: float
+    pn532_read_timeout_seconds: float
     verbose: bool = False
 
     @model_validator(mode="after")

--- a/jukebox/settings/runtime_resolver.py
+++ b/jukebox/settings/runtime_resolver.py
@@ -35,7 +35,7 @@ class JukeboxRuntimeResolver:
                 pause_duration_seconds=effective_settings.jukebox.playback.pause_duration_seconds,
                 pause_delay_seconds=effective_settings.jukebox.playback.pause_delay_seconds,
                 loop_interval_seconds=effective_settings.jukebox.runtime.loop_interval_seconds,
-                nfc_read_timeout_seconds=effective_settings.jukebox.reader.nfc.read_timeout_seconds,
+                pn532_read_timeout_seconds=effective_settings.jukebox.reader.pn532.read_timeout_seconds,
                 verbose=verbose,
             )
         except (ValidationError, ValueError) as err:

--- a/pn532/pn532.py
+++ b/pn532/pn532.py
@@ -288,7 +288,7 @@ class PN532:
         # Return frame data.
         return response[offset+2:offset+2+frame_len]
 
-    def call_function(self, command, response_length=0, params=None, timeout=1):
+    def call_function(self, command, response_length=0, params=None, timeout=1.0):
         """Send specified command to the PN532 and expect up to response_length
         bytes back in a response.  Note that less than the expected bytes might
         be returned!  Params can optionally specify an array of bytes to send as
@@ -344,7 +344,7 @@ class PN532:
         # check the command was executed as expected.
         self.call_function(_COMMAND_SAMCONFIGURATION, params=[0x01, 0x14, 0x01])
 
-    def read_passive_target(self, card_baud=_MIFARE_ISO14443A, timeout=1):
+    def read_passive_target(self, card_baud=_MIFARE_ISO14443A, timeout=1.0):
         """Wait for a MiFare card to be available and return its UID when found.
         Will wait up to timeout seconds and return None if no card is found,
         otherwise a bytearray with the UID of the found card is returned.

--- a/pn532/spi.py
+++ b/pn532/spi.py
@@ -152,7 +152,7 @@ class PN532_SPI(PN532):
         self._spi.writebytes(bytearray([0x00])) #pylint: disable=no-member
         time.sleep(1)
 
-    def _wait_ready(self, timeout=1):
+    def _wait_ready(self, timeout=1.0):
         """Poll PN532 if status byte is ready, up to `timeout` seconds"""
         status = bytearray([reverse_bit(_SPI_STATREAD), 0])
         timestamp = time.monotonic()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ ui = [
     "fastui==0.9.0 ; python_version >= '3.10'",
     "python-multipart==0.0.22; python_version >= '3.10'",
 ]
-nfc = [
+pn532 = [
   "pyserial==3.5",
   "spidev==3.8",
   # lgpio wheels not available for Python >= 3.13

--- a/tests/discstore/adapters/inbound/test_api_controller.py
+++ b/tests/discstore/adapters/inbound/test_api_controller.py
@@ -523,8 +523,8 @@ def test_patch_settings_updates_reader_settings():
             "schema_version": 1,
             "jukebox": {
                 "reader": {
-                    "type": "nfc",
-                    "nfc": {"read_timeout_seconds": 0.2},
+                    "type": "pn532",
+                    "pn532": {"read_timeout_seconds": 0.2},
                 }
             },
         }
@@ -540,7 +540,7 @@ def test_patch_settings_updates_reader_settings():
     )
 
     response = route.endpoint(
-        SettingsPatchInput(root={"jukebox": {"reader": {"type": "nfc", "nfc": {"read_timeout_seconds": 0.2}}}})
+        SettingsPatchInput(root={"jukebox": {"reader": {"type": "pn532", "pn532": {"read_timeout_seconds": 0.2}}}})
     )
 
     assert response == {
@@ -548,14 +548,14 @@ def test_patch_settings_updates_reader_settings():
             "schema_version": 1,
             "jukebox": {
                 "reader": {
-                    "type": "nfc",
-                    "nfc": {"read_timeout_seconds": 0.2},
+                    "type": "pn532",
+                    "pn532": {"read_timeout_seconds": 0.2},
                 }
             },
         }
     }
     settings_service.patch_persisted_settings.assert_called_once_with(
-        {"jukebox": {"reader": {"type": "nfc", "nfc": {"read_timeout_seconds": 0.2}}}}
+        {"jukebox": {"reader": {"type": "pn532", "pn532": {"read_timeout_seconds": 0.2}}}}
     )
 
 
@@ -739,7 +739,7 @@ def test_reset_settings_removes_selected_group_override():
 def test_reset_settings_removes_reader_override():
     settings_service = MagicMock()
     settings_service.reset_persisted_value.return_value = {
-        "persisted": {"schema_version": 1, "jukebox": {"reader": {"type": "nfc"}}}
+        "persisted": {"schema_version": 1, "jukebox": {"reader": {"type": "pn532"}}}
     }
     controller = build_controller(settings_service=settings_service)
     route = cast(
@@ -751,10 +751,10 @@ def test_reset_settings_removes_reader_override():
         ),
     )
 
-    response = route.endpoint(SettingsResetInput(path="jukebox.reader.nfc.read_timeout_seconds"))
+    response = route.endpoint(SettingsResetInput(path="jukebox.reader.pn532.read_timeout_seconds"))
 
-    assert response == {"persisted": {"schema_version": 1, "jukebox": {"reader": {"type": "nfc"}}}}
-    settings_service.reset_persisted_value.assert_called_once_with("jukebox.reader.nfc.read_timeout_seconds")
+    assert response == {"persisted": {"schema_version": 1, "jukebox": {"reader": {"type": "pn532"}}}}
+    settings_service.reset_persisted_value.assert_called_once_with("jukebox.reader.pn532.read_timeout_seconds")
 
 
 @pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")

--- a/tests/discstore/adapters/inbound/test_ui_controller.py
+++ b/tests/discstore/adapters/inbound/test_ui_controller.py
@@ -58,7 +58,7 @@ def build_controller():
             "jukebox": {
                 "playback": {"pause_duration_seconds": 900, "pause_delay_seconds": 0.25},
                 "runtime": {"loop_interval_seconds": 0.1},
-                "reader": {"type": "dryrun", "nfc": {"read_timeout_seconds": 0.1}},
+                "reader": {"type": "dryrun", "pn532": {"read_timeout_seconds": 0.1}},
                 "player": {
                     "type": "dryrun",
                     "sonos": {
@@ -79,7 +79,7 @@ def build_controller():
             "jukebox": {
                 "playback": {"pause_duration_seconds": "default", "pause_delay_seconds": "default"},
                 "runtime": {"loop_interval_seconds": "default"},
-                "reader": {"type": "default", "nfc": {"read_timeout_seconds": "default"}},
+                "reader": {"type": "default", "pn532": {"read_timeout_seconds": "default"}},
                 "player": {
                     "type": "default",
                     "sonos": {
@@ -294,7 +294,7 @@ def test_settings_edit_pages_render_select_text_and_json_fields():
     assert select_field.initial == "dryrun"
     assert select_field.options == [
         {"value": "dryrun", "label": "Dry Run"},
-        {"value": "nfc", "label": "NFC"},
+        {"value": "pn532", "label": "Pn532 NFC"},
     ]
 
     text_page = route.endpoint("admin.ui.port")[0]
@@ -422,7 +422,7 @@ def test_settings_edit_page_renders_empty_object_field_with_placeholder_when_no_
             "jukebox": {
                 "playback": {"pause_duration_seconds": 900, "pause_delay_seconds": 0.25},
                 "runtime": {"loop_interval_seconds": 0.1},
-                "reader": {"type": "dryrun", "nfc": {"read_timeout_seconds": 0.1}},
+                "reader": {"type": "dryrun", "pn532": {"read_timeout_seconds": 0.1}},
                 "player": {
                     "type": "dryrun",
                     "sonos": {
@@ -437,7 +437,7 @@ def test_settings_edit_page_renders_empty_object_field_with_placeholder_when_no_
             "jukebox": {
                 "playback": {"pause_duration_seconds": "default", "pause_delay_seconds": "default"},
                 "runtime": {"loop_interval_seconds": "default"},
-                "reader": {"type": "default", "nfc": {"read_timeout_seconds": "default"}},
+                "reader": {"type": "default", "pn532": {"read_timeout_seconds": "default"}},
                 "player": {
                     "type": "default",
                     "sonos": {

--- a/tests/jukebox/adapters/inbound/test_config.py
+++ b/tests/jukebox/adapters/inbound/test_config.py
@@ -12,22 +12,22 @@ def test_parse_config_without_overrides():
     assert config == JukeboxCliConfig()
 
 
-@patch("sys.argv", ["jukebox", "sonos", "nfc", "--sonos-host", "192.168.1.50"])
+@patch("sys.argv", ["jukebox", "sonos", "pn532", "--sonos-host", "192.168.1.50"])
 def test_parse_config_with_player_reader_and_host_overrides():
     config = parse_config()
 
     assert config.player == "sonos"
-    assert config.reader == "nfc"
+    assert config.reader == "pn532"
     assert config.sonos_host == "192.168.1.50"
     assert config.sonos_name is None
 
 
-@patch("sys.argv", ["jukebox", "sonos", "nfc", "--sonos-name", "Living Room"])
+@patch("sys.argv", ["jukebox", "sonos", "pn532", "--sonos-name", "Living Room"])
 def test_parse_config_with_sonos_name_override():
     config = parse_config()
 
     assert config.player == "sonos"
-    assert config.reader == "nfc"
+    assert config.reader == "pn532"
     assert config.sonos_host is None
     assert config.sonos_name == "Living Room"
 
@@ -60,21 +60,21 @@ def test_parse_config_allows_partial_type_overrides(capsys):
     )
 
 
-@patch("sys.argv", ["jukebox", "--reader", "nfc"])
+@patch("sys.argv", ["jukebox", "--reader", "pn532"])
 def test_parse_config_allows_reader_only_override_flag(capsys):
     config = parse_config()
 
     assert config.player is None
-    assert config.reader == "nfc"
+    assert config.reader == "pn532"
     assert capsys.readouterr().err == ""
 
 
-@patch("sys.argv", ["jukebox", "dryrun", "dryrun", "--reader", "nfc"])
+@patch("sys.argv", ["jukebox", "dryrun", "dryrun", "--reader", "pn532"])
 def test_parse_config_reader_flag_overrides_positional_reader(capsys):
     config = parse_config()
 
     assert config.player == "dryrun"
-    assert config.reader == "nfc"
+    assert config.reader == "pn532"
     assert (
         capsys.readouterr().err.strip()
         == "warning: positional player/reader arguments are deprecated; use --player/--reader instead"

--- a/tests/jukebox/adapters/outbound/readers/test_pn532_reader_adapters.py
+++ b/tests/jukebox/adapters/outbound/readers/test_pn532_reader_adapters.py
@@ -17,24 +17,24 @@ def mock_pn532_lib_installed():
 
 
 def test_parse_raw_uid(mock_pn532_lib_installed):
-    from jukebox.adapters.outbound.readers.nfc_reader_adapter import parse_raw_uid
+    from jukebox.adapters.outbound.readers.pn532_reader_adapter import parse_raw_uid
 
     raw_uid = bytearray(b"\x04\xf2=v\x8fa\x80")
     assert parse_raw_uid(raw_uid) == "04:f2:3d:76:8f:61:80"
 
 
 def test_dependencies_import_failure(mocker):
-    sys.modules.pop("jukebox.adapters.outbound.readers.nfc_reader_adapter", None)
+    sys.modules.pop("jukebox.adapters.outbound.readers.pn532_reader_adapter", None)
     mocker.patch.dict("sys.modules", {"pn532": None})
 
     with pytest.raises(ModuleNotFoundError) as err:
-        import jukebox.adapters.outbound.readers.nfc_reader_adapter  # noqa: F401
+        import jukebox.adapters.outbound.readers.pn532_reader_adapter  # noqa: F401
 
-    assert "The `nfc` reader requires the optional `nfc` dependencies." in str(err.value)
+    assert "The `pn532` reader requires the optional `nfc` dependencies." in str(err.value)
     assert "pip install 'gukebox[nfc]'" in str(err.value)
     assert "uv sync --extra nfc" in str(err.value)
     assert "uv run --extra nfc jukebox ..." in str(err.value)
 
 
-# Note: NfcReaderAdapter tests would require hardware mocking (PN532_SPI)
+# Note: Pn532ReaderAdapter tests would require hardware mocking (PN532_SPI)
 # which is complex and not critical since it's a thin wrapper.

--- a/tests/jukebox/adapters/outbound/readers/test_pn532_reader_adapters.py
+++ b/tests/jukebox/adapters/outbound/readers/test_pn532_reader_adapters.py
@@ -30,10 +30,10 @@ def test_dependencies_import_failure(mocker):
     with pytest.raises(ModuleNotFoundError) as err:
         import jukebox.adapters.outbound.readers.pn532_reader_adapter  # noqa: F401
 
-    assert "The `pn532` reader requires the optional `nfc` dependencies." in str(err.value)
-    assert "pip install 'gukebox[nfc]'" in str(err.value)
-    assert "uv sync --extra nfc" in str(err.value)
-    assert "uv run --extra nfc jukebox ..." in str(err.value)
+    assert "The `pn532` reader requires the optional `pn532` dependencies." in str(err.value)
+    assert "pip install 'gukebox[pn532]'" in str(err.value)
+    assert "uv sync --extra pn532" in str(err.value)
+    assert "uv run --extra pn532 jukebox ..." in str(err.value)
 
 
 # Note: Pn532ReaderAdapter tests would require hardware mocking (PN532_SPI)

--- a/tests/jukebox/admin/test_cli_presentation.py
+++ b/tests/jukebox/admin/test_cli_presentation.py
@@ -14,6 +14,7 @@ from jukebox.settings.errors import (
     MalformedSettingsFileError,
     UnsupportedSettingsVersionError,
 )
+from jukebox.settings.types import JsonObject
 from jukebox.sonos.discovery import DiscoveredSonosSpeaker
 from jukebox.sonos.selection import SonosSelectionAvailability, SonosSelectionResult, SonosSelectionStatus
 
@@ -386,7 +387,7 @@ def test_render_settings_output_json_mode_preserves_payload_shape():
         value="9000",
         json_output=True,
     )
-    payload = {"persisted": {"schema_version": 1, "admin": {"api": {"port": 9000}}}}
+    payload: JsonObject = {"persisted": {"schema_version": 1, "admin": {"api": {"port": 9000}}}}
 
     assert (
         render_settings_output(command, payload)

--- a/tests/jukebox/admin/test_cli_presentation.py
+++ b/tests/jukebox/admin/test_cli_presentation.py
@@ -79,7 +79,7 @@ def test_render_settings_output_effective_includes_manual_sonos_targets():
                 "jukebox": {
                     "playback": {"pause_duration_seconds": 900, "pause_delay_seconds": 0.25},
                     "runtime": {"loop_interval_seconds": 0.1},
-                    "reader": {"type": "dryrun", "nfc": {"read_timeout_seconds": 0.1}},
+                    "reader": {"type": "dryrun", "pn532": {"read_timeout_seconds": 0.1}},
                     "player": {
                         "type": "sonos",
                         "sonos": {
@@ -96,7 +96,7 @@ def test_render_settings_output_effective_includes_manual_sonos_targets():
                 "jukebox": {
                     "playback": {"pause_duration_seconds": "default", "pause_delay_seconds": "default"},
                     "runtime": {"loop_interval_seconds": "default"},
-                    "reader": {"type": "default", "nfc": {"read_timeout_seconds": "default"}},
+                    "reader": {"type": "default", "pn532": {"read_timeout_seconds": "default"}},
                     "player": {
                         "type": "file",
                         "sonos": {
@@ -126,7 +126,7 @@ def test_render_settings_output_effective_treats_selected_group_as_atomic():
                 "jukebox": {
                     "playback": {"pause_duration_seconds": 900, "pause_delay_seconds": 0.25},
                     "runtime": {"loop_interval_seconds": 0.1},
-                    "reader": {"type": "dryrun", "nfc": {"read_timeout_seconds": 0.1}},
+                    "reader": {"type": "dryrun", "pn532": {"read_timeout_seconds": 0.1}},
                     "player": {
                         "type": "sonos",
                         "sonos": {
@@ -147,7 +147,7 @@ def test_render_settings_output_effective_treats_selected_group_as_atomic():
                 "jukebox": {
                     "playback": {"pause_duration_seconds": "default", "pause_delay_seconds": "default"},
                     "runtime": {"loop_interval_seconds": "default"},
-                    "reader": {"type": "default", "nfc": {"read_timeout_seconds": "default"}},
+                    "reader": {"type": "default", "pn532": {"read_timeout_seconds": "default"}},
                     "player": {
                         "type": "file",
                         "sonos": {
@@ -179,7 +179,7 @@ def test_render_settings_output_effective_collapses_nested_selected_group_proven
                 "jukebox": {
                     "playback": {"pause_duration_seconds": 900, "pause_delay_seconds": 0.25},
                     "runtime": {"loop_interval_seconds": 0.1},
-                    "reader": {"type": "dryrun", "nfc": {"read_timeout_seconds": 0.1}},
+                    "reader": {"type": "dryrun", "pn532": {"read_timeout_seconds": 0.1}},
                     "player": {
                         "type": "sonos",
                         "sonos": {
@@ -200,7 +200,7 @@ def test_render_settings_output_effective_collapses_nested_selected_group_proven
                 "jukebox": {
                     "playback": {"pause_duration_seconds": "default", "pause_delay_seconds": "default"},
                     "runtime": {"loop_interval_seconds": "default"},
-                    "reader": {"type": "default", "nfc": {"read_timeout_seconds": "default"}},
+                    "reader": {"type": "default", "pn532": {"read_timeout_seconds": "default"}},
                     "player": {
                         "type": "default",
                         "sonos": {
@@ -233,7 +233,7 @@ def test_render_settings_output_effective_reports_mixed_nested_provenance():
                 "jukebox": {
                     "playback": {"pause_duration_seconds": 900, "pause_delay_seconds": 0.25},
                     "runtime": {"loop_interval_seconds": 0.1},
-                    "reader": {"type": "dryrun", "nfc": {"read_timeout_seconds": 0.1}},
+                    "reader": {"type": "dryrun", "pn532": {"read_timeout_seconds": 0.1}},
                     "player": {
                         "type": "sonos",
                         "sonos": {
@@ -254,7 +254,7 @@ def test_render_settings_output_effective_reports_mixed_nested_provenance():
                 "jukebox": {
                     "playback": {"pause_duration_seconds": "default", "pause_delay_seconds": "default"},
                     "runtime": {"loop_interval_seconds": "default"},
-                    "reader": {"type": "default", "nfc": {"read_timeout_seconds": "default"}},
+                    "reader": {"type": "default", "pn532": {"read_timeout_seconds": "default"}},
                     "player": {
                         "type": "default",
                         "sonos": {

--- a/tests/jukebox/admin/test_command_handlers.py
+++ b/tests/jukebox/admin/test_command_handlers.py
@@ -61,7 +61,7 @@ def test_execute_settings_command_renders_human_readable_persisted_settings():
                     "jukebox": {
                         "playback": {"pause_duration_seconds": 900, "pause_delay_seconds": 0.25},
                         "runtime": {"loop_interval_seconds": 0.1},
-                        "reader": {"type": "dryrun", "nfc": {"read_timeout_seconds": 0.1}},
+                        "reader": {"type": "dryrun", "pn532": {"read_timeout_seconds": 0.1}},
                         "player": {
                             "type": "sonos",
                             "sonos": {
@@ -82,7 +82,7 @@ def test_execute_settings_command_renders_human_readable_persisted_settings():
                     "jukebox": {
                         "playback": {"pause_duration_seconds": "default", "pause_delay_seconds": "default"},
                         "runtime": {"loop_interval_seconds": "default"},
-                        "reader": {"type": "default", "nfc": {"read_timeout_seconds": "default"}},
+                        "reader": {"type": "default", "pn532": {"read_timeout_seconds": "default"}},
                         "player": {
                             "type": "file",
                             "sonos": {"selected_group": "file"},
@@ -145,11 +145,11 @@ def test_execute_settings_command_renders_human_readable_persisted_settings():
             SettingsSetCommand(
                 type="settings_set",
                 dotted_path="jukebox.reader.type",
-                value="nfc",
+                value="pn532",
             ),
             "set_persisted_value",
-            ("jukebox.reader.type", "nfc"),
-            {"persisted": {"schema_version": 1, "jukebox": {"reader": {"type": "nfc"}}}},
+            ("jukebox.reader.type", "pn532"),
+            {"persisted": {"schema_version": 1, "jukebox": {"reader": {"type": "pn532"}}}},
             [
                 "Settings command completed.",
                 "Restart Required: no",
@@ -158,12 +158,12 @@ def test_execute_settings_command_renders_human_readable_persisted_settings():
         (
             SettingsSetCommand(
                 type="settings_set",
-                dotted_path="jukebox.reader.nfc.read_timeout_seconds",
+                dotted_path="jukebox.reader.pn532.read_timeout_seconds",
                 value="0.2",
             ),
             "set_persisted_value",
-            ("jukebox.reader.nfc.read_timeout_seconds", "0.2"),
-            {"persisted": {"schema_version": 1, "jukebox": {"reader": {"nfc": {"read_timeout_seconds": 0.2}}}}},
+            ("jukebox.reader.pn532.read_timeout_seconds", "0.2"),
+            {"persisted": {"schema_version": 1, "jukebox": {"reader": {"pn532": {"read_timeout_seconds": 0.2}}}}},
             [
                 "Settings command completed.",
                 "Restart Required: no",
@@ -242,10 +242,10 @@ def test_execute_settings_command_renders_human_readable_persisted_settings():
             ],
         ),
         (
-            SettingsResetCommand(type="settings_reset", dotted_path="jukebox.reader.nfc.read_timeout_seconds"),
+            SettingsResetCommand(type="settings_reset", dotted_path="jukebox.reader.pn532.read_timeout_seconds"),
             "reset_persisted_value",
-            ("jukebox.reader.nfc.read_timeout_seconds",),
-            {"persisted": {"schema_version": 1, "jukebox": {"reader": {"nfc": {}}}}},
+            ("jukebox.reader.pn532.read_timeout_seconds",),
+            {"persisted": {"schema_version": 1, "jukebox": {"reader": {"pn532": {}}}}},
             [
                 "Settings command completed.",
                 "Restart Required: no",
@@ -345,7 +345,7 @@ def test_execute_settings_command_writes_discstore_deprecation_warning_to_stderr
             "jukebox": {
                 "playback": {"pause_duration_seconds": 900, "pause_delay_seconds": 0.25},
                 "runtime": {"loop_interval_seconds": 0.1},
-                "reader": {"type": "dryrun", "nfc": {"read_timeout_seconds": 0.1}},
+                "reader": {"type": "dryrun", "pn532": {"read_timeout_seconds": 0.1}},
                 "player": {"type": "dryrun", "sonos": {"selected_group": None}},
             },
         },
@@ -355,7 +355,7 @@ def test_execute_settings_command_writes_discstore_deprecation_warning_to_stderr
             "jukebox": {
                 "playback": {"pause_duration_seconds": "default", "pause_delay_seconds": "default"},
                 "runtime": {"loop_interval_seconds": "default"},
-                "reader": {"type": "default", "nfc": {"read_timeout_seconds": "default"}},
+                "reader": {"type": "default", "pn532": {"read_timeout_seconds": "default"}},
                 "player": {"type": "default", "sonos": {"selected_group": "default"}},
             },
         },

--- a/tests/jukebox/settings/test_definitions.py
+++ b/tests/jukebox/settings/test_definitions.py
@@ -14,7 +14,7 @@ def test_build_settings_metadata_tree_includes_field_choices():
 
     assert reader_type_metadata["choices"] == [
         {"value": "dryrun", "label": "Dry Run"},
-        {"value": "nfc", "label": "NFC"},
+        {"value": "pn532", "label": "Pn532 NFC"},
     ]
     assert player_type_metadata["choices"] == [
         {"value": "dryrun", "label": "Dry Run"},
@@ -48,7 +48,7 @@ def test_build_editable_setting_displays_flattens_values_and_collapses_object_pr
                 "jukebox": {
                     "playback": {"pause_duration_seconds": 900, "pause_delay_seconds": 0.25},
                     "runtime": {"loop_interval_seconds": 0.1},
-                    "reader": {"type": "dryrun", "nfc": {"read_timeout_seconds": 0.1}},
+                    "reader": {"type": "dryrun", "pn532": {"read_timeout_seconds": 0.1}},
                     "player": {
                         "type": "dryrun",
                         "sonos": {
@@ -69,7 +69,7 @@ def test_build_editable_setting_displays_flattens_values_and_collapses_object_pr
                 "jukebox": {
                     "playback": {"pause_duration_seconds": "default", "pause_delay_seconds": "default"},
                     "runtime": {"loop_interval_seconds": "default"},
-                    "reader": {"type": "default", "nfc": {"read_timeout_seconds": "default"}},
+                    "reader": {"type": "default", "pn532": {"read_timeout_seconds": "default"}},
                     "player": {
                         "type": "default",
                         "sonos": {
@@ -124,7 +124,7 @@ def test_build_editable_setting_displays_marks_mixed_object_provenance():
                 "jukebox": {
                     "playback": {"pause_duration_seconds": 900, "pause_delay_seconds": 0.25},
                     "runtime": {"loop_interval_seconds": 0.1},
-                    "reader": {"type": "dryrun", "nfc": {"read_timeout_seconds": 0.1}},
+                    "reader": {"type": "dryrun", "pn532": {"read_timeout_seconds": 0.1}},
                     "player": {
                         "type": "dryrun",
                         "sonos": {
@@ -145,7 +145,7 @@ def test_build_editable_setting_displays_marks_mixed_object_provenance():
                 "jukebox": {
                     "playback": {"pause_duration_seconds": "default", "pause_delay_seconds": "default"},
                     "runtime": {"loop_interval_seconds": "default"},
-                    "reader": {"type": "default", "nfc": {"read_timeout_seconds": "default"}},
+                    "reader": {"type": "default", "pn532": {"read_timeout_seconds": "default"}},
                     "player": {
                         "type": "default",
                         "sonos": {

--- a/tests/jukebox/settings/test_settings_service_mutation_validation.py
+++ b/tests/jukebox/settings/test_settings_service_mutation_validation.py
@@ -51,7 +51,7 @@ def test_settings_service_set_rejects_invalid_reader_timeout_without_writing(tmp
     service = SettingsService(repository=FileSettingsRepository(str(settings_path)))
 
     with pytest.raises(InvalidSettingsError, match="Invalid settings update"):
-        service.set_persisted_value("jukebox.reader.nfc.read_timeout_seconds", "0")
+        service.set_persisted_value("jukebox.reader.pn532.read_timeout_seconds", "0")
 
     assert json.loads(settings_path.read_text(encoding="utf-8")) == {
         "schema_version": 1,
@@ -234,8 +234,8 @@ def test_settings_service_preserves_inactive_reader_subtree_when_switching_reade
                 "schema_version": 1,
                 "jukebox": {
                     "reader": {
-                        "type": "nfc",
-                        "nfc": {"read_timeout_seconds": 0.2},
+                        "type": "pn532",
+                        "pn532": {"read_timeout_seconds": 0.2},
                     }
                 },
             }
@@ -251,7 +251,7 @@ def test_settings_service_preserves_inactive_reader_subtree_when_switching_reade
         "jukebox": {
             "reader": {
                 "type": "dryrun",
-                "nfc": {"read_timeout_seconds": 0.2},
+                "pn532": {"read_timeout_seconds": 0.2},
             }
         },
     }
@@ -259,23 +259,23 @@ def test_settings_service_preserves_inactive_reader_subtree_when_switching_reade
 
     runtime_config = resolve_jukebox_runtime(service)
     assert runtime_config.reader_type == "dryrun"
-    assert runtime_config.nfc_read_timeout_seconds == 0.2
+    assert runtime_config.pn532_read_timeout_seconds == 0.2
 
-    nfc_result = service.set_persisted_value("jukebox.reader.type", "nfc")
+    pn532_result = service.set_persisted_value("jukebox.reader.type", "pn532")
 
     assert json.loads(settings_path.read_text(encoding="utf-8")) == {
         "schema_version": 1,
         "jukebox": {
             "reader": {
-                "type": "nfc",
-                "nfc": {"read_timeout_seconds": 0.2},
+                "type": "pn532",
+                "pn532": {"read_timeout_seconds": 0.2},
             }
         },
     }
-    assert nfc_result["updated_paths"] == ["jukebox.reader.type"]
+    assert pn532_result["updated_paths"] == ["jukebox.reader.type"]
     runtime_config = resolve_jukebox_runtime(service)
-    assert runtime_config.reader_type == "nfc"
-    assert runtime_config.nfc_read_timeout_seconds == 0.2
+    assert runtime_config.reader_type == "pn532"
+    assert runtime_config.pn532_read_timeout_seconds == 0.2
 
 
 def test_settings_service_patch_rejects_malformed_inactive_reader_branch_transactionally(tmp_path):
@@ -287,7 +287,7 @@ def test_settings_service_patch_rejects_malformed_inactive_reader_branch_transac
     service = SettingsService(repository=FileSettingsRepository(str(settings_path)))
 
     with pytest.raises(InvalidSettingsError, match="Unsupported settings path for write"):
-        service.patch_persisted_settings({"jukebox": {"reader": {"nfc": {"unexpected": "value"}}}})
+        service.patch_persisted_settings({"jukebox": {"reader": {"pn532": {"unexpected": "value"}}}})
 
     assert json.loads(settings_path.read_text(encoding="utf-8")) == {
         "schema_version": 1,

--- a/tests/jukebox/settings/test_settings_service_mutations.py
+++ b/tests/jukebox/settings/test_settings_service_mutations.py
@@ -192,8 +192,8 @@ def test_settings_service_reset_jukebox_resets_editable_player_reader_and_timing
                         },
                     },
                     "reader": {
-                        "type": "nfc",
-                        "nfc": {"read_timeout_seconds": 0.2},
+                        "type": "pn532",
+                        "pn532": {"read_timeout_seconds": 0.2},
                     },
                     "playback": {
                         "pause_duration_seconds": 600,
@@ -216,7 +216,7 @@ def test_settings_service_reset_jukebox_resets_editable_player_reader_and_timing
         "jukebox.playback.pause_duration_seconds",
         "jukebox.player.sonos.selected_group",
         "jukebox.player.type",
-        "jukebox.reader.nfc.read_timeout_seconds",
+        "jukebox.reader.pn532.read_timeout_seconds",
         "jukebox.reader.type",
         "jukebox.runtime.loop_interval_seconds",
     ]
@@ -227,7 +227,7 @@ def test_settings_service_reset_jukebox_resets_editable_player_reader_and_timing
     assert runtime_config.pause_duration_seconds == 900
     assert runtime_config.pause_delay_seconds == 0.25
     assert runtime_config.loop_interval_seconds == 0.1
-    assert runtime_config.nfc_read_timeout_seconds == 0.1
+    assert runtime_config.pn532_read_timeout_seconds == 0.1
 
 
 def test_settings_service_patch_updates_library_path_and_derived_current_tag_path(tmp_path):
@@ -379,8 +379,8 @@ def test_settings_service_patch_updates_reader_settings_and_reports_restart(tmp_
         {
             "jukebox": {
                 "reader": {
-                    "type": "nfc",
-                    "nfc": {"read_timeout_seconds": 0.2},
+                    "type": "pn532",
+                    "pn532": {"read_timeout_seconds": 0.2},
                 }
             }
         }
@@ -390,14 +390,14 @@ def test_settings_service_patch_updates_reader_settings_and_reports_restart(tmp_
         "schema_version": 1,
         "jukebox": {
             "reader": {
-                "type": "nfc",
-                "nfc": {"read_timeout_seconds": 0.2},
+                "type": "pn532",
+                "pn532": {"read_timeout_seconds": 0.2},
             }
         },
     }
     effective_view = lookup_json_object(result, "effective")
-    assert lookup_json_value(effective_view, "settings", "jukebox", "reader", "type") == "nfc"
-    assert lookup_json_value(effective_view, "settings", "jukebox", "reader", "nfc", "read_timeout_seconds") == 0.2
+    assert lookup_json_value(effective_view, "settings", "jukebox", "reader", "type") == "pn532"
+    assert lookup_json_value(effective_view, "settings", "jukebox", "reader", "pn532", "read_timeout_seconds") == 0.2
     assert lookup_json_value(effective_view, "provenance", "jukebox", "reader", "type") == "file"
     assert (
         lookup_json_value(
@@ -405,7 +405,7 @@ def test_settings_service_patch_updates_reader_settings_and_reports_restart(tmp_
             "provenance",
             "jukebox",
             "reader",
-            "nfc",
+            "pn532",
             "read_timeout_seconds",
         )
         == "file"
@@ -417,25 +417,25 @@ def test_settings_service_patch_updates_reader_settings_and_reports_restart(tmp_
             "settings_metadata",
             "jukebox",
             "reader",
-            "nfc",
+            "pn532",
             "read_timeout_seconds",
             "requires_restart",
         )
         is True
     )
     assert result["updated_paths"] == [
-        "jukebox.reader.nfc.read_timeout_seconds",
+        "jukebox.reader.pn532.read_timeout_seconds",
         "jukebox.reader.type",
     ]
     assert result["restart_required_paths"] == [
-        "jukebox.reader.nfc.read_timeout_seconds",
+        "jukebox.reader.pn532.read_timeout_seconds",
         "jukebox.reader.type",
     ]
     assert result["message"] == "Settings saved. Changes take effect after restart."
 
     runtime_config = resolve_jukebox_runtime(service)
-    assert runtime_config.reader_type == "nfc"
-    assert runtime_config.nfc_read_timeout_seconds == 0.2
+    assert runtime_config.reader_type == "pn532"
+    assert runtime_config.pn532_read_timeout_seconds == 0.2
 
 
 def test_settings_service_set_selected_group_from_json_string(tmp_path):
@@ -618,8 +618,8 @@ def test_settings_service_reset_removes_only_requested_reader_override(tmp_path)
                 "schema_version": 1,
                 "jukebox": {
                     "reader": {
-                        "type": "nfc",
-                        "nfc": {"read_timeout_seconds": 0.2},
+                        "type": "pn532",
+                        "pn532": {"read_timeout_seconds": 0.2},
                     }
                 },
             }
@@ -628,13 +628,13 @@ def test_settings_service_reset_removes_only_requested_reader_override(tmp_path)
     )
     service = SettingsService(repository=FileSettingsRepository(str(settings_path)))
 
-    result = service.reset_persisted_value("jukebox.reader.nfc.read_timeout_seconds")
+    result = service.reset_persisted_value("jukebox.reader.pn532.read_timeout_seconds")
 
     assert json.loads(settings_path.read_text(encoding="utf-8")) == {
         "schema_version": 1,
         "jukebox": {
             "reader": {
-                "type": "nfc",
+                "type": "pn532",
             }
         },
     }
@@ -642,15 +642,15 @@ def test_settings_service_reset_removes_only_requested_reader_override(tmp_path)
         "schema_version": 1,
         "jukebox": {
             "reader": {
-                "type": "nfc",
+                "type": "pn532",
             }
         },
     }
-    assert result["updated_paths"] == ["jukebox.reader.nfc.read_timeout_seconds"]
-    assert result["restart_required_paths"] == ["jukebox.reader.nfc.read_timeout_seconds"]
+    assert result["updated_paths"] == ["jukebox.reader.pn532.read_timeout_seconds"]
+    assert result["restart_required_paths"] == ["jukebox.reader.pn532.read_timeout_seconds"]
     runtime_config = resolve_jukebox_runtime(service)
-    assert runtime_config.reader_type == "nfc"
-    assert runtime_config.nfc_read_timeout_seconds == 0.1
+    assert runtime_config.reader_type == "pn532"
+    assert runtime_config.pn532_read_timeout_seconds == 0.1
 
 
 def test_settings_service_reset_removes_only_requested_selected_group_override(tmp_path):

--- a/tests/jukebox/test_jukebox_app.py
+++ b/tests/jukebox/test_jukebox_app.py
@@ -35,7 +35,7 @@ def test_main_uses_resolved_runtime_config(app_mocks):
         pause_duration_seconds=100,
         pause_delay_seconds=1.0,
         loop_interval_seconds=0.5,
-        nfc_read_timeout_seconds=0.1,
+        pn532_read_timeout_seconds=0.1,
         verbose=True,
     )
     settings_service = MagicMock()
@@ -76,7 +76,7 @@ def test_main_exits_on_build_jukebox_settings_error(app_mocks):
         pause_duration_seconds=100,
         pause_delay_seconds=1.0,
         loop_interval_seconds=0.5,
-        nfc_read_timeout_seconds=0.1,
+        pn532_read_timeout_seconds=0.1,
         verbose=True,
     )
     settings_service = MagicMock()
@@ -123,7 +123,7 @@ def test_build_settings_service_maps_sonos_host_override():
 def test_build_settings_service_reads_persisted_reader_and_timing_settings(tmp_path, mocker):
     settings_path = tmp_path / "settings.json"
     settings_path.write_text(
-        '{"schema_version": 1, "jukebox": {"reader": {"type": "nfc", "nfc": {"read_timeout_seconds": 0.2}}, "playback": {"pause_duration_seconds": 600, "pause_delay_seconds": 0.3}, "runtime": {"loop_interval_seconds": 0.2}}}',
+        '{"schema_version": 1, "jukebox": {"reader": {"type": "pn532", "pn532": {"read_timeout_seconds": 0.2}}, "playback": {"pause_duration_seconds": 600, "pause_delay_seconds": 0.3}, "runtime": {"loop_interval_seconds": 0.2}}}',
         encoding="utf-8",
     )
     mocker.patch("jukebox.app.FileSettingsRepository", return_value=FileSettingsRepository(str(settings_path)))
@@ -131,8 +131,8 @@ def test_build_settings_service_reads_persisted_reader_and_timing_settings(tmp_p
     settings_service = app._build_settings_service(JukeboxCliConfig())
     runtime_config = resolve_jukebox_runtime(settings_service)
 
-    assert runtime_config.reader_type == "nfc"
-    assert runtime_config.nfc_read_timeout_seconds == 0.2
+    assert runtime_config.reader_type == "pn532"
+    assert runtime_config.pn532_read_timeout_seconds == 0.2
     assert runtime_config.pause_duration_seconds == 600
     assert runtime_config.pause_delay_seconds == 0.3
     assert runtime_config.loop_interval_seconds == 0.2

--- a/tests/jukebox/test_jukebox_di_container.py
+++ b/tests/jukebox/test_jukebox_di_container.py
@@ -32,11 +32,11 @@ class TestBuildJukebox:
             sonos_group=build_resolved_sonos_group_runtime(
                 speakers=[("speaker-1", "Living Room", "192.168.1.100", "household-1")]
             ),
-            reader_type="nfc",
+            reader_type="pn532",
             pause_duration_seconds=50,
             pause_delay_seconds=3,
             loop_interval_seconds=0.1,
-            nfc_read_timeout_seconds=0.25,
+            pn532_read_timeout_seconds=0.25,
             verbose=False,
         )
 
@@ -64,7 +64,7 @@ class TestBuildJukebox:
             pause_duration_seconds=50,
             pause_delay_seconds=3,
             loop_interval_seconds=0.1,
-            nfc_read_timeout_seconds=0.25,
+            pn532_read_timeout_seconds=0.25,
             verbose=False,
         )
 
@@ -92,7 +92,7 @@ class TestBuildJukebox:
             pause_duration_seconds=50,
             pause_delay_seconds=3,
             loop_interval_seconds=0.1,
-            nfc_read_timeout_seconds=0.25,
+            pn532_read_timeout_seconds=0.25,
             verbose=False,
         )
 
@@ -119,7 +119,7 @@ class TestBuildJukebox:
             pause_duration_seconds=100,
             pause_delay_seconds=5,
             loop_interval_seconds=0.1,
-            nfc_read_timeout_seconds=0.1,
+            pn532_read_timeout_seconds=0.1,
             verbose=False,
         )
 
@@ -149,7 +149,7 @@ class TestBuildJukebox:
             pause_duration_seconds=200,
             pause_delay_seconds=0.2,
             loop_interval_seconds=0.1,
-            nfc_read_timeout_seconds=0.1,
+            pn532_read_timeout_seconds=0.1,
             verbose=False,
         )
 

--- a/tests/jukebox/test_jukebox_di_container.py
+++ b/tests/jukebox/test_jukebox_di_container.py
@@ -16,12 +16,12 @@ class TestBuildJukebox:
     @patch("jukebox.di_container.SonosPlayerAdapter")
     @patch("jukebox.di_container.TextCurrentTagAdapter")
     @patch("jukebox.di_container.JsonLibraryAdapter")
-    def test_build_jukebox_with_sonos_and_nfc(self, mock_library, mock_current_tag, mock_player, mocker):
-        mock_nfc_instance = MagicMock()
-        mock_nfc_class = MagicMock(return_value=mock_nfc_instance)
+    def test_build_jukebox_with_sonos_and_pn532(self, mock_library, mock_current_tag, mock_player, mocker):
+        mock_pn532_instance = MagicMock()
+        mock_pn532_class = MagicMock(return_value=mock_pn532_instance)
         mocker.patch.dict(
             "sys.modules",
-            {"jukebox.adapters.outbound.readers.nfc_reader_adapter": MagicMock(NfcReaderAdapter=mock_nfc_class)},
+            {"jukebox.adapters.outbound.readers.pn532_reader_adapter": MagicMock(Pn532ReaderAdapter=mock_pn532_class)},
         )
 
         config = ResolvedJukeboxRuntimeConfig(
@@ -45,8 +45,8 @@ class TestBuildJukebox:
         mock_library.assert_called_once_with("/test/library.json")
         mock_current_tag.assert_called_once_with("/test/current-tag.txt")
         mock_player.assert_called_once_with(host="192.168.1.100", name=None, group=config.sonos_group)
-        mock_nfc_class.assert_called_once_with(read_timeout_seconds=0.25)
-        assert reader == mock_nfc_instance
+        mock_pn532_class.assert_called_once_with(read_timeout_seconds=0.25)
+        assert reader == mock_pn532_instance
         assert handle_tag_event is not None
 
     @patch("jukebox.di_container.SonosPlayerAdapter")

--- a/uv.lock
+++ b/uv.lock
@@ -290,7 +290,7 @@ api = [
     { name = "uvicorn", version = "0.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "uvicorn", version = "0.41.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
-nfc = [
+pn532 = [
     { name = "lgpio", marker = "python_full_version < '3.13'" },
     { name = "pyserial" },
     { name = "spidev" },
@@ -318,19 +318,19 @@ requires-dist = [
     { name = "fastapi", marker = "python_full_version < '3.10' and extra == 'api'", specifier = "==0.128.7" },
     { name = "fastui", marker = "python_full_version >= '3.10' and extra == 'ui'", specifier = "==0.9.0" },
     { name = "gukebox", extras = ["api"], marker = "extra == 'ui'" },
-    { name = "lgpio", marker = "python_full_version < '3.13' and extra == 'nfc'", specifier = "==0.2.2.0" },
+    { name = "lgpio", marker = "python_full_version < '3.13' and extra == 'pn532'", specifier = "==0.2.2.0" },
     { name = "pydantic", specifier = "==2.12.5" },
-    { name = "pyserial", marker = "extra == 'nfc'", specifier = "==3.5" },
+    { name = "pyserial", marker = "extra == 'pn532'", specifier = "==3.5" },
     { name = "python-multipart", marker = "python_full_version >= '3.10' and extra == 'ui'", specifier = "==0.0.22" },
     { name = "questionary", specifier = "==2.1.1" },
     { name = "soco", specifier = "==0.30.14" },
-    { name = "spidev", marker = "extra == 'nfc'", specifier = "==3.8" },
+    { name = "spidev", marker = "extra == 'pn532'", specifier = "==3.8" },
     { name = "typer", marker = "python_full_version < '3.10'", specifier = "==0.23.2" },
     { name = "typer", marker = "python_full_version >= '3.10'", specifier = "==0.24.1" },
     { name = "uvicorn", marker = "python_full_version >= '3.10' and extra == 'api'", specifier = "==0.41.0" },
     { name = "uvicorn", marker = "python_full_version < '3.10' and extra == 'api'", specifier = "==0.39.0" },
 ]
-provides-extras = ["api", "ui", "nfc"]
+provides-extras = ["api", "ui", "pn532"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Refs #152 

Replace generic NFC reader with a more explicit PN532 NFC reader family.

Just a name change. No functional changes. 

## BREAKING CHANGES
- the `nfc` parameter is no longer supported and has been replaced by  `pn532`.
- the `nfc` extra is no longer available; use `pn532` instead.

I haven't implemented backward compatibility or a migration script, given what's been said about version 1.0.0 (Refs #190).
If we prefer, the reader selector could keep `nfc` as an alias for the `pn532`.