### PR TITLE
Split up UI controller

### DIFF
--- a/discstore/adapters/inbound/ui_controller.py
+++ b/discstore/adapters/inbound/ui_controller.py
@@ -1,9 +1,4 @@
-import asyncio
-import json
 import sys
-from itertools import groupby
-from typing import cast
-from urllib.parse import urlencode
 
 if sys.version_info < (3, 10):
     raise RuntimeError("The `ui_controller` module requires Python 3.10+.")
@@ -17,16 +12,18 @@ try:
     from fastapi.responses import HTMLResponse, StreamingResponse
     from fastui import AnyComponent, FastUI, prebuilt_html
     from fastui import components as c
-    from fastui.components.forms import FormFieldInput, FormFieldSelect, FormFieldTextarea
-    from fastui.events import BackEvent, GoToEvent, PageEvent
+    from fastui.events import GoToEvent
     from fastui.forms import fastui_form
 except ModuleNotFoundError as e:
     raise ModuleNotFoundError(
         optional_extra_dependency_message("The `ui_controller` module", "ui", "discstore ui")
     ) from e
+
 from pydantic import BaseModel, Field
 
 from discstore.adapters.inbound.api_controller import APIController
+from discstore.adapters.inbound.ui_pages.library import DiscForm, DiscTable, LibraryUIPageBuilder
+from discstore.adapters.inbound.ui_pages.settings import SettingsUIPageBuilder
 from discstore.domain.entities import CurrentTagStatus, Disc, DiscMetadata, DiscOption
 from discstore.domain.use_cases.add_disc import AddDisc
 from discstore.domain.use_cases.edit_disc import EditDisc
@@ -36,29 +33,12 @@ from discstore.domain.use_cases.list_discs import ListDiscs
 from discstore.domain.use_cases.remove_disc import RemoveDisc
 from jukebox.settings.definitions import (
     EditableSettingDisplay,
-    build_editable_setting_displays,
     get_setting_definition,
 )
 from jukebox.settings.errors import SettingsError
 from jukebox.settings.service_protocols import SettingsService
 from jukebox.settings.types import JsonObject
 from jukebox.sonos.service import SonosService
-
-_MISSING = object()
-
-
-class DiscTable(DiscMetadata, DiscOption):
-    tag: str = Field(title="Tag ID")
-    uri: str = Field(title="URI / Path")
-
-
-class DiscForm(BaseModel):
-    tag: str = Field(title="Tag ID")
-    uri: str = Field(title="URI / Path")
-    artist: Optional[str] = Field(None, title="Artist")
-    album: Optional[str] = Field(None, title="Album")
-    track: Optional[str] = Field(None, title="Track")
-    shuffle: bool = Field(False, title="Shuffle")
 
 
 class SettingValueForm(BaseModel):
@@ -78,6 +58,12 @@ class UIController(APIController):
         sonos_service: SonosService,
     ):
         self.get_disc = get_disc
+        self.library_pages = LibraryUIPageBuilder(
+            list_discs=list_discs,
+            get_disc=get_disc,
+            get_current_tag_status=get_current_tag_status,
+        )
+        self.settings_pages = SettingsUIPageBuilder(settings_service=settings_service)
         super().__init__(
             add_disc,
             list_discs,
@@ -247,825 +233,122 @@ class UIController(APIController):
         ]
 
     def _build_settings_success_response(self, message: str) -> list[AnyComponent]:
-        query = urlencode(
-            {
-                "toast": "toast-settings-success",
-                "toast_message": message,
-            }
-        )
-        return [
-            c.FireEvent(event=GoToEvent(url=f"/settings?{query}")),
-        ]
+        return self.settings_pages.build_settings_success_response(message)
 
     def _reset_setting(self, setting_path: str) -> list[AnyComponent]:
-        definition = get_setting_definition(setting_path)
-        if definition is None:
-            raise HTTPException(status_code=404, detail=f"Unknown setting path: {setting_path}")
-
-        try:
-            result = self.settings_service.reset_persisted_value(setting_path)
-        except SettingsError as err:
-            if not self._has_persisted_value(setting_path):
-                return self._build_settings_success_response(
-                    "Settings reset, but effective settings are still unavailable."
-                )
-            return self._build_settings_edit_page_components(setting_path, reset_error=str(err))
-        except HTTPException:
-            raise
-        except Exception as err:
-            raise HTTPException(status_code=500, detail=f"Server error: {str(err)}")
-
-        return self._build_settings_success_response(str(result["message"]))
+        return self.settings_pages.reset_setting(setting_path)
 
     def _build_index_page_components(self, toast: Optional[str] = None) -> List[AnyComponent]:
-        discs = self.list_discs.execute()
-        discs_list = [
-            DiscTable(tag=tag, uri=disc.uri, **disc.metadata.model_dump(), **disc.option.model_dump())
-            for tag, disc in discs.items()
-        ]
-
-        components: list[AnyComponent] = [
-            c.Heading(text="DiscStore for Jukebox", level=1),
-            c.Paragraph(text=f"📀 {len(discs)} disc(s) in library"),
-            c.ServerLoad(
-                path="/current-tag-banner/events",
-                sse=True,
-                sse_retry=2000,
-            ),
-            c.Div(
-                class_name="d-flex flex-wrap gap-2",
-                components=[
-                    c.Button(text="➕ Add a new disc", on_click=GoToEvent(url="/discs/new")),
-                    c.Button(text="⚙️ Settings", on_click=GoToEvent(url="/settings"), class_name="btn btn-secondary"),
-                ],
-            ),
-            c.Toast(
-                title="Toast",
-                body=[c.Paragraph(text="🎉 Disc added")],
-                open_trigger=PageEvent(name="toast-add-disc-success"),
-                position="bottom-end",
-            ),
-            c.Toast(
-                title="Toast",
-                body=[c.Paragraph(text="🎉 Disc edited")],
-                open_trigger=PageEvent(name="toast-edit-disc-success"),
-                position="bottom-end",
-            ),
-            c.Toast(
-                title="Toast",
-                body=[c.Paragraph(text="🗑️ Disc removed")],
-                open_trigger=PageEvent(name="toast-remove-disc-success"),
-                position="bottom-end",
-            ),
-            *self._build_disc_library_components(discs_list),
-        ]
-
-        page_components: list[AnyComponent] = [c.Page(components=components)]
-
-        if toast in {"toast-add-disc-success", "toast-edit-disc-success", "toast-remove-disc-success"}:
-            page_components.append(c.FireEvent(event=PageEvent(name=toast)))
-
-        return page_components
+        return self.library_pages.build_index_page_components(toast=toast)
 
     def _build_settings_page_components(
         self,
         toast: Optional[str] = None,
         toast_message: Optional[str] = None,
     ) -> List[AnyComponent]:
-        settings, effective_settings_error = self._get_settings_displays()
-        components: list[AnyComponent] = [
-            c.Heading(text="Settings", level=1),
-            c.Div(
-                class_name="d-flex flex-wrap gap-2 mb-4",
-                components=[
-                    c.Link(components=[c.Text(text="Back to Library")], on_click=GoToEvent(url="/")),
-                ],
-            ),
-        ]
-        if effective_settings_error:
-            components.append(
-                c.Error(
-                    title="Effective settings unavailable",
-                    description=(
-                        f"{effective_settings_error} Persisted overrides are still shown below so you can inspect"
-                        " and repair saved values."
-                    ),
-                )
-            )
-
-        for section, entries_iter in groupby(settings, key=lambda entry: entry.section):
-            entries = list(entries_iter)
-            components.extend(self._build_settings_section_components(section, entries))
-
-        components.append(
-            c.Toast(
-                title="Toast",
-                body=[c.Paragraph(text=toast_message or "Settings saved.")],
-                open_trigger=PageEvent(name="toast-settings-success"),
-                position="bottom-end",
-            )
-        )
-
-        page_components: list[AnyComponent] = [c.Page(components=components)]
-        if toast == "toast-settings-success":
-            page_components.append(c.FireEvent(event=PageEvent(name=toast)))
-
-        return page_components
+        return self.settings_pages.build_settings_page_components(toast=toast, toast_message=toast_message)
 
     def _build_settings_section_components(
         self,
         section: str,
         settings: List[EditableSettingDisplay],
     ) -> List[AnyComponent]:
-        first_setting = settings[0]
-        section_components: list[AnyComponent] = [
-            c.Heading(text=first_setting.section_label, level=2),
-        ]
-        if first_setting.section_description:
-            section_components.append(c.Paragraph(text=first_setting.section_description, class_name="mb-2"))
-
-        section_components.append(
-            c.Div(
-                class_name="border rounded overflow-hidden mb-4",
-                components=[self._build_settings_row(setting, index) for index, setting in enumerate(settings)],
-            )
-        )
-
-        return [
-            *section_components,
-        ]
+        return self.settings_pages.build_settings_section_components(section, settings)
 
     def _build_settings_row(self, setting: EditableSettingDisplay, index: int) -> AnyComponent:
-        info_components: list[AnyComponent] = [
-            c.Heading(text=setting.label, level=4),
-            c.Paragraph(text=setting.path, class_name="text-muted small mb-1"),
-            c.Paragraph(text=setting.description, class_name="mb-2"),
-        ]
-
-        badge_components = self._build_settings_badges(setting)
-        if badge_components:
-            info_components.append(
-                c.Div(
-                    class_name="d-flex flex-wrap gap-2 mb-3",
-                    components=badge_components,
-                )
-            )
-        info_components.append(self._build_settings_value_summary(setting))
-
-        action_components: list[AnyComponent] = [
-            c.Button(
-                text="Edit ✏️",
-                on_click=GoToEvent(url=f"/settings/{setting.path}/edit"),
-                class_name="btn btn-secondary",
-            )
-        ]
-        row_class_name = "px-3 py-3"
-        if index > 0:
-            row_class_name += " border-top"
-
-        return c.Div(
-            class_name=row_class_name,
-            components=[
-                c.Div(
-                    class_name="d-flex flex-column flex-xl-row gap-3 justify-content-between align-items-xl-start",
-                    components=[
-                        c.Div(class_name="flex-grow-1", components=info_components),
-                        c.Div(class_name="d-grid gap-2 align-self-start", components=action_components),
-                    ],
-                )
-            ],
-        )
+        return self.settings_pages.build_settings_row(setting, index)
 
     def _build_settings_edit_page_components(
         self,
         setting_path: str,
         reset_error: Optional[str] = None,
     ) -> List[AnyComponent]:
-        settings, effective_settings_error = self._get_settings_displays()
-        setting = next((candidate for candidate in settings if candidate.path == setting_path), None)
-        if setting is None:
-            return [
-                c.Page(
-                    components=[
-                        c.Heading(text="Edit setting", level=1),
-                        c.Error(title="Setting not found", description=f"Unknown setting path: {setting_path}"),
-                        c.Link(components=[c.Text(text="Back to Settings")], on_click=GoToEvent(url="/settings")),
-                        c.Link(components=[c.Text(text="Back to Library")], on_click=GoToEvent(url="/")),
-                    ]
-                )
-            ]
-
-        components: list[AnyComponent] = [
-            c.Heading(text=f"Edit {setting.label}", level=1),
-            c.Paragraph(
-                text=f"{setting.section_label} setting", class_name="text-uppercase text-muted small fw-semibold mb-1"
-            ),
-            c.Paragraph(text=setting.path, class_name="text-muted small mb-1"),
-            c.Paragraph(text=setting.description, class_name="mb-3"),
-        ]
-
-        badge_components = self._build_settings_badges(setting)
-        if badge_components:
-            components.append(
-                c.Div(
-                    class_name="d-flex flex-wrap gap-2 mb-3",
-                    components=badge_components,
-                )
-            )
-
-        if reset_error:
-            components.append(
-                c.Error(
-                    title="Reset failed",
-                    description=reset_error,
-                )
-            )
-
-        if effective_settings_error:
-            components.append(
-                c.Error(
-                    title="Effective settings unavailable",
-                    description=(
-                        f"{effective_settings_error} Showing persisted and default values where possible so this"
-                        " setting can still be reviewed or repaired."
-                    ),
-                )
-            )
-
-        components.append(
-            c.Div(
-                class_name="border rounded p-3 mb-4 bg-light-subtle",
-                components=[
-                    c.Heading(text="Current values", level=3),
-                    self._build_settings_value_summary(setting),
-                ],
-            )
-        )
-
-        components.append(
-            c.Div(
-                class_name="border rounded p-3 mb-4",
-                components=[
-                    c.Heading(text="Update override", level=3),
-                    c.Paragraph(text=self._build_settings_edit_guidance(setting), class_name="mb-3"),
-                    self._build_settings_edit_form(setting),
-                ],
-            )
-        )
-
-        if setting.is_persisted:
-            components.extend(
-                [
-                    c.Div(
-                        class_name="border rounded p-3 mb-4",
-                        components=[
-                            c.Heading(text="Reset override", level=3),
-                            c.Paragraph(
-                                text=(
-                                    "Reset removes the persisted override entirely. Use it to fall back to defaults,"
-                                    " environment overrides, or CLI overrides."
-                                )
-                            ),
-                            self._build_settings_reset_form(setting.path),
-                        ],
-                    )
-                ]
-            )
-
-        components.append(
-            c.Div(
-                class_name="mt-3 d-flex flex-wrap gap-3",
-                components=[
-                    c.Link(components=[c.Text(text="Back to Settings")], on_click=GoToEvent(url="/settings")),
-                    c.Link(components=[c.Text(text="Back to Library")], on_click=GoToEvent(url="/")),
-                ],
-            )
-        )
-
-        return [c.Page(components=components)]
+        return self.settings_pages.build_settings_edit_page_components(setting_path, reset_error=reset_error)
 
     def _build_settings_edit_form(self, setting: EditableSettingDisplay) -> AnyComponent:
-        initial_value = setting.persisted_value if setting.is_persisted else setting.effective_value
-        field_description = setting.description
-        if setting.field_type == "object":
-            field_description = (
-                f"{field_description} Enter a JSON object matching the persisted setting shape. "
-                "Leave blank to persist null. Use Reset to remove the persisted override."
-            )
-        if setting.requires_restart:
-            field_description = f"{field_description} Takes effect after restart."
-
-        if setting.choices:
-            form_field = FormFieldSelect(
-                name="value",
-                title=setting.label,
-                options=[
-                    {
-                        "value": choice.value,
-                        "label": choice.label,
-                    }
-                    for choice in setting.choices
-                ],
-                initial=None if initial_value is None else str(initial_value),
-                description=field_description,
-                required=True,
-                vanilla=True,
-            )
-        elif setting.field_type == "object":
-            form_field = FormFieldTextarea(
-                name="value",
-                title=setting.label,
-                initial=json.dumps(initial_value, indent=2) if initial_value is not None else "",
-                description=field_description,
-                required=False,
-                rows=12,
-                placeholder="Enter a JSON object. Leave blank to persist null.",
-            )
-        else:
-            form_field = FormFieldInput(
-                name="value",
-                title=setting.label,
-                initial=None if initial_value is None else str(initial_value),
-                description=field_description,
-                required=True,
-                html_type="number" if setting.field_type == "integer" else "text",
-            )
-
-        return c.Form(
-            form_fields=[form_field],
-            submit_url=f"/api/ui/settings/{setting.path}",
-            method="POST",
-            footer=[c.Button(text="Save", html_type="submit", class_name="btn btn-primary")],
-        )
+        return self.settings_pages.build_settings_edit_form(setting)
 
     def _build_settings_reset_form(self, setting_path: str) -> AnyComponent:
-        return c.Form(
-            form_fields=[],
-            submit_url=f"/api/ui/settings/{setting_path}/reset",
-            method="POST",
-            footer=[c.Button(text="Reset", html_type="submit", class_name="btn btn-outline-danger text-nowrap px-3")],
-        )
+        return self.settings_pages.build_settings_reset_form(setting_path)
 
     def _get_settings_displays(self) -> tuple[List[EditableSettingDisplay], Optional[str]]:
-        persisted_settings = self.settings_service.get_persisted_settings_view()
-        effective_settings_error: Optional[str] = None
-        try:
-            effective_settings_view = self.settings_service.get_effective_settings_view()
-        except SettingsError as err:
-            effective_settings_view = {}
-            effective_settings_error = str(err)
-
-        return build_editable_setting_displays(persisted_settings, effective_settings_view), effective_settings_error
+        return self.settings_pages.get_settings_displays()
 
     def _build_settings_badges(self, setting: EditableSettingDisplay) -> list[AnyComponent]:
-        badge_components: list[AnyComponent] = []
-        if setting.is_pinned_default:
-            badge_components.append(c.Paragraph(text="Pinned default", class_name="badge text-bg-info text-uppercase"))
-        if setting.requires_restart:
-            badge_components.append(
-                c.Paragraph(text="Restart required", class_name="badge text-bg-warning text-uppercase")
-            )
-        if setting.advanced:
-            badge_components.append(c.Paragraph(text="Advanced", class_name="badge text-bg-dark text-uppercase"))
-        return badge_components
+        return self.settings_pages.build_settings_badges(setting)
 
     def _build_settings_value_summary(self, setting: EditableSettingDisplay) -> AnyComponent:
-        return c.Div(
-            class_name="row g-3",
-            components=[
-                self._build_settings_value_cell(
-                    "Default",
-                    self._format_settings_display_value(setting.path, setting.default_value),
-                ),
-                self._build_settings_value_cell(
-                    "Persisted override",
-                    self._format_settings_display_value(setting.path, setting.persisted_value)
-                    if setting.is_persisted
-                    else "None",
-                ),
-                self._build_settings_value_cell(
-                    "Effective value",
-                    self._format_settings_display_value(setting.path, setting.effective_value),
-                ),
-                self._build_settings_value_cell(
-                    "Source",
-                    self._format_settings_provenance(setting.provenance),
-                ),
-            ],
-        )
+        return self.settings_pages.build_settings_value_summary(setting)
 
     def _build_settings_value_cell(self, label: str, value: str) -> AnyComponent:
-        return c.Div(
-            class_name="col-12 col-md-6 col-xl-3",
-            components=[
-                c.Paragraph(text=label, class_name="text-uppercase text-muted small fw-semibold mb-1"),
-                c.Paragraph(text=value, class_name="mb-0 text-break"),
-            ],
-        )
+        return self.settings_pages.build_settings_value_cell(label, value)
 
     def _build_settings_edit_guidance(self, setting: EditableSettingDisplay) -> str:
-        guidance = "Save a persisted override for this setting."
-        if setting.choices:
-            guidance = f"{guidance} Choose one of the supported options below."
-        elif setting.field_type == "object":
-            guidance = (
-                f"{guidance} Provide a JSON object matching the stored setting shape,"
-                " or leave the field blank to persist null."
-            )
-
-        return f"{guidance} The effective value may still be superseded by environment or CLI overrides."
+        return self.settings_pages.build_settings_edit_guidance(setting)
 
     def _build_settings_patch(self, setting_path: str, raw_value: str) -> JsonObject:
-        definition = get_setting_definition(setting_path)
-        if definition is None:
-            raise ValueError(f"Unknown setting path: {setting_path}")
-
-        if definition.choices and raw_value not in {choice.value for choice in definition.choices}:
-            raise ValueError("Choose a valid option.")
-
-        if definition.field_type == "integer":
-            try:
-                value: object = int(raw_value)
-            except ValueError as err:
-                raise ValueError("Enter a valid integer.") from err
-        elif definition.field_type == "number":
-            try:
-                value = float(raw_value)
-            except ValueError as err:
-                raise ValueError("Enter a valid number.") from err
-        elif definition.field_type == "object":
-            if raw_value.strip() == "":
-                value = None
-                return self._build_dotted_patch(setting_path, value)
-            try:
-                value = json.loads(raw_value)
-            except json.JSONDecodeError as err:
-                raise ValueError("Enter valid JSON.") from err
-            if not isinstance(value, dict):
-                raise ValueError("Enter a JSON object.")
-        else:
-            value = raw_value
-
-        return self._build_dotted_patch(setting_path, value)
+        return self.settings_pages.build_settings_patch(setting_path, raw_value)
 
     def _build_dotted_patch(self, dotted_path: str, value: object) -> JsonObject:
-        patch: JsonObject = {}
-        cursor = patch
-        parts = dotted_path.split(".")
-        for part in parts[:-1]:
-            child: JsonObject = {}
-            cursor[part] = child
-            cursor = child
-        cursor[parts[-1]] = value
-        return patch
+        return self.settings_pages.build_dotted_patch(dotted_path, value)
 
     def _persisted_value_matches(self, dotted_path: str, expected_value: object) -> bool:
-        return (
-            self._lookup_optional_dotted_path(self.settings_service.get_persisted_settings_view(), dotted_path)
-            == expected_value
-        )
+        return self.settings_pages.persisted_value_matches(dotted_path, expected_value)
 
     def _has_persisted_value(self, dotted_path: str) -> bool:
-        return (
-            self._lookup_optional_dotted_path(self.settings_service.get_persisted_settings_view(), dotted_path)
-            is not _MISSING
-        )
+        return self.settings_pages.has_persisted_value(dotted_path)
 
     def _lookup_optional_dotted_path(self, root: JsonObject, dotted_path: str) -> object:
-        current: JsonObject = root
-        parts = dotted_path.split(".")
-        for part in parts[:-1]:
-            child = current.get(part, _MISSING)
-            if not isinstance(child, dict):
-                return _MISSING
-            current = cast(JsonObject, child)
-        return current.get(parts[-1], _MISSING)
+        return self.settings_pages.lookup_optional_dotted_path(root, dotted_path)
 
     def _format_settings_display_value(self, setting_path: str, value: object) -> str:
-        if value is None:
-            return "null"
-
-        definition = get_setting_definition(setting_path)
-        if definition is not None and definition.choices and isinstance(value, str):
-            choice_labels = {choice.value: choice.label for choice in definition.choices}
-            if value in choice_labels:
-                return choice_labels[value]
-
-        if setting_path == "jukebox.player.sonos.selected_group" and isinstance(value, dict):
-            selected_group = cast(dict[str, object], value)
-            members = selected_group.get("members")
-            coordinator_uid = selected_group.get("coordinator_uid")
-            if isinstance(members, list) and isinstance(coordinator_uid, str):
-                member_uids = []
-                for member in members:
-                    if not isinstance(member, dict):
-                        continue
-                    selected_member = cast(dict[str, object], member)
-                    uid = selected_member.get("uid")
-                    if not isinstance(uid, str):
-                        continue
-                    member_uids.append(uid)
-                if member_uids:
-                    return "{} (coordinator); members: {}".format(coordinator_uid, ", ".join(member_uids))
-
-        if isinstance(value, bool):
-            return "true" if value else "false"
-        if isinstance(value, (int, float)):
-            return str(value)
-        if isinstance(value, str):
-            return value
-        try:
-            return json.dumps(value, sort_keys=True, separators=(", ", ": "))
-        except TypeError:
-            return str(value)
+        return self.settings_pages.format_settings_display_value(setting_path, value)
 
     def _format_settings_provenance(self, provenance: str) -> str:
-        labels = {
-            "default": "Default",
-            "file": "Settings file",
-            "env": "Environment override",
-            "cli": "CLI override",
-            "mixed": "Mixed source",
-        }
-        return labels.get(provenance, provenance)
+        return self.settings_pages.format_settings_provenance(provenance)
 
     def _build_form_page_components(self, title: str, form_components: List[AnyComponent]) -> List[AnyComponent]:
-        return [
-            c.Page(
-                components=[
-                    c.Heading(text=title, level=1),
-                    *form_components,
-                    c.Div(
-                        class_name="mt-3",
-                        components=[
-                            c.Link(
-                                components=[c.Text(text="Back to Library")],
-                                on_click=GoToEvent(url="/"),
-                            )
-                        ],
-                    ),
-                ]
-            )
-        ]
+        return self.library_pages.build_form_page_components(title=title, form_components=form_components)
 
     def _build_current_tag_banner_components(
         self, current_tag_status: Optional[CurrentTagStatus]
     ) -> List[AnyComponent]:
-        if current_tag_status is None:
-            return []
-
-        if current_tag_status.known_in_library:
-            return [
-                c.Div(
-                    class_name="alert alert-info mb-3 d-flex flex-column flex-md-row gap-3 justify-content-between align-items-md-center",
-                    components=[
-                        c.Div(
-                            class_name="mb-0",
-                            components=[
-                                c.Heading(text="Known disc on reader", level=4),
-                                c.Paragraph(text=f'Tag "{current_tag_status.tag_id}" is already in the library.'),
-                            ],
-                        ),
-                        c.Button(
-                            text="Edit this disc",
-                            on_click=GoToEvent(url=f"/discs/{current_tag_status.tag_id}/edit"),
-                        ),
-                    ],
-                )
-            ]
-
-        return [
-            c.Div(
-                class_name="alert alert-warning mb-3 d-flex flex-column flex-md-row gap-3 justify-content-between align-items-md-center",
-                components=[
-                    c.Div(
-                        class_name="mb-0",
-                        components=[
-                            c.Heading(text="Unknown disc on reader", level=4),
-                            c.Paragraph(text=f'Tag "{current_tag_status.tag_id}" is ready to be added to the library.'),
-                        ],
-                    ),
-                    c.Button(text="Add this disc", on_click=GoToEvent(url="/discs/new?prefill=current")),
-                ],
-            )
-        ]
+        return self.library_pages.build_current_tag_banner_components(current_tag_status)
 
     def _build_disc_library_components(self, discs: List[DiscTable]) -> List[AnyComponent]:
-        if not discs:
-            return [c.Paragraph(text="No disc found")]
-
-        return [
-            c.Div(
-                class_name="border rounded mt-3 mb-5 overflow-hidden",
-                components=[
-                    self._build_disc_library_header(),
-                    *[self._build_disc_library_row(disc) for disc in discs],
-                ],
-            )
-        ]
+        return self.library_pages.build_disc_library_components(discs)
 
     def _build_disc_library_header(self) -> AnyComponent:
-        return c.Div(
-            class_name="d-none d-lg-block px-3 py-2 bg-light-subtle",
-            components=[
-                c.Div(
-                    class_name="row g-2 align-items-center",
-                    components=[
-                        self._build_disc_header_cell("Tag ID", "col-lg"),
-                        self._build_disc_header_cell("URI / Path", "col-lg-3"),
-                        self._build_disc_header_cell("Artist", "col-lg-2 text-lg-center"),
-                        self._build_disc_header_cell("Album", "col-lg-2 text-lg-center"),
-                        self._build_disc_header_cell("Track", "col-lg-2 text-lg-center"),
-                        self._build_disc_header_cell("Shuffle", "col-lg-1 text-lg-center"),
-                        c.Div(
-                            class_name="col-lg-auto d-flex justify-content-lg-end",
-                            components=[
-                                c.Button(
-                                    text="Edit ✏️",
-                                    class_name="btn btn-secondary invisible",
-                                )
-                            ],
-                        ),
-                    ],
-                )
-            ],
-        )
+        return self.library_pages._build_disc_library_header()
 
     def _build_disc_library_row(self, disc: DiscTable) -> AnyComponent:
-        return c.Div(
-            class_name="px-3 py-2 border-top",
-            components=[
-                c.Div(
-                    class_name="row g-2 align-items-center",
-                    components=[
-                        self._build_disc_value_cell("Tag ID", disc.tag, "col-12 col-lg"),
-                        self._build_disc_value_cell("URI / Path", disc.uri, "col-12 col-lg-3"),
-                        self._build_disc_value_cell("Artist", disc.artist, "col-6 col-md-3 col-lg-2 text-lg-center"),
-                        self._build_disc_value_cell("Album", disc.album, "col-6 col-md-3 col-lg-2 text-lg-center"),
-                        self._build_disc_value_cell("Track", disc.track, "col-6 col-md-3 col-lg-2 text-lg-center"),
-                        self._build_disc_value_cell(
-                            "Shuffle", "✓" if disc.shuffle else "×", "col-6 col-md-3 col-lg-1 text-lg-center"
-                        ),
-                        c.Div(
-                            class_name="col-12 col-lg-auto d-flex justify-content-lg-end",
-                            components=[
-                                c.Button(
-                                    text="Edit ✏️",
-                                    on_click=GoToEvent(url=f"/discs/{disc.tag}/edit"),
-                                    class_name="btn btn-secondary",
-                                ),
-                            ],
-                        ),
-                    ],
-                )
-            ],
-        )
+        return self.library_pages._build_disc_library_row(disc)
 
     def _build_disc_header_cell(self, label: str, class_name: str) -> AnyComponent:
-        justify_class = "justify-content-lg-start"
-        if "text-lg-center" in class_name:
-            justify_class = "justify-content-lg-center"
-        elif "text-lg-end" in class_name:
-            justify_class = "justify-content-lg-end"
-
-        return c.Div(
-            class_name=f"{class_name} d-flex align-items-center {justify_class}",
-            components=[
-                c.Paragraph(text=label, class_name="text-uppercase text-muted small fw-semibold mb-0"),
-            ],
-        )
+        return self.library_pages._build_disc_header_cell(label, class_name)
 
     def _build_disc_value_cell(self, label: str, value: Optional[str], class_name: str) -> AnyComponent:
-        return c.Div(
-            class_name=class_name,
-            components=[
-                c.Paragraph(text=label, class_name="d-lg-none text-uppercase text-muted small fw-semibold mb-1"),
-                c.Paragraph(text=value or "—", class_name="mb-0 text-break"),
-            ],
-        )
+        return self.library_pages._build_disc_value_cell(label, value, class_name)
 
     def _build_new_disc_form_components(self, prefill_current: bool) -> List[AnyComponent]:
-        initial = None
-
-        if prefill_current:
-            current_tag_status = self.get_current_tag_status.execute()
-            if current_tag_status is None:
-                return [
-                    c.Error(
-                        title="No current tag available",
-                        description="There is no tag on the reader right now, so the form cannot be prefilled.",
-                    )
-                ]
-            if current_tag_status.known_in_library:
-                return [
-                    c.Error(
-                        title="Current tag already known",
-                        description=f'Tag "{current_tag_status.tag_id}" is already in the library.',
-                    )
-                ]
-            initial = {"tag": current_tag_status.tag_id, "shuffle": False}
-
-        return [
-            c.ModelForm(
-                model=DiscForm,
-                submit_url="/api/ui/discs",
-                method="POST",
-                initial=initial,
-            )
-        ]
+        return self.library_pages.build_new_disc_form_components(prefill_current)
 
     def _build_edit_disc_form_components(self, tag_id: str) -> List[AnyComponent]:
-        if not tag_id:
-            return [
-                c.Error(
-                    title="No disc selected",
-                    description="Edit mode requires an existing disc tag ID.",
-                )
-            ]
-        try:
-            disc = self.get_disc.execute(tag_id)
-        except ValueError as err:
-            return [
-                c.Error(
-                    title="Disc not found",
-                    description=str(err),
-                )
-            ]
-
-        return [
-            c.ModelForm(
-                model=DiscForm,
-                submit_url=f"/api/ui/discs/{tag_id}",
-                method="POST",
-                initial={
-                    "tag": tag_id,
-                    "uri": disc.uri,
-                    "artist": disc.metadata.artist,
-                    "album": disc.metadata.album,
-                    "track": disc.metadata.track,
-                    "shuffle": disc.option.shuffle,
-                },
-            ),
-            c.Button(
-                text="🗑️ Delete this disc",
-                on_click=GoToEvent(url=f"/discs/{tag_id}/delete"),
-                class_name="btn btn-danger mt-3",
-            ),
-        ]
+        return self.library_pages.build_edit_disc_form_components(tag_id)
 
     def _build_delete_disc_form_components(self, tag_id: str) -> List[AnyComponent]:
-        if not tag_id:
-            return [c.Error(title="No disc selected", description="Delete mode requires an existing disc tag ID.")]
-        try:
-            _ = self.get_disc.execute(tag_id)
-        except ValueError as err:
-            return [c.Error(title="Disc not found", description=str(err))]
-
-        return [
-            c.Paragraph(text=f'Are you sure you want to delete the disc with tag "{tag_id}"?'),
-            c.Div(
-                class_name="alert alert-danger",
-                components=[c.Paragraph(text="This action cannot be undone.")],
-            ),
-            c.Div(
-                class_name="d-flex gap-2 mt-3",
-                components=[
-                    c.Form(
-                        form_fields=[],
-                        submit_url=f"/api/ui/discs/{tag_id}/delete",
-                        method="POST",
-                    ),
-                    c.Button(
-                        text="Cancel",
-                        on_click=BackEvent(),
-                        class_name="btn btn-secondary",
-                    ),
-                ],
-            ),
-        ]
+        return self.library_pages.build_delete_disc_form_components(tag_id)
 
     async def _current_tag_banner_event_stream(
         self,
         request: Request,
         poll_interval_seconds: float = 0.5,
     ) -> AsyncIterator[bytes]:
-        previous_payload: Optional[str] = None
-
-        while True:
-            payload = self._serialize_current_tag_components(
-                self._build_current_tag_banner_components(self.get_current_tag_status.execute())
-            )
-            if payload != previous_payload:
-                previous_payload = payload
-                yield f"data: {payload}\n\n".encode("utf-8")
-
-            if await request.is_disconnected():
-                break
-
-            await asyncio.sleep(poll_interval_seconds)
+        async for payload in self.library_pages.current_tag_banner_event_stream(request, poll_interval_seconds):
+            yield payload
 
     def _serialize_current_tag_components(self, components: List[AnyComponent]) -> str:
-        return json.dumps([component.model_dump(by_alias=True, exclude_none=True) for component in components])
+        return self.library_pages.serialize_current_tag_components(components)
 
     def _field_validation_error(self, field_name: str, message: str) -> HTTPException:
         return HTTPException(

--- a/discstore/adapters/inbound/ui_pages/library.py
+++ b/discstore/adapters/inbound/ui_pages/library.py
@@ -1,0 +1,370 @@
+import asyncio
+import json
+from typing import AsyncIterator, List, Optional
+
+from fastapi import Request
+from fastui import AnyComponent
+from fastui import components as c
+from fastui.events import BackEvent, GoToEvent, PageEvent
+from pydantic import BaseModel, Field
+
+from discstore.domain.entities import CurrentTagStatus, DiscMetadata, DiscOption
+from discstore.domain.use_cases.get_current_tag_status import GetCurrentTagStatus
+from discstore.domain.use_cases.get_disc import GetDisc
+from discstore.domain.use_cases.list_discs import ListDiscs
+
+
+class DiscTable(DiscMetadata, DiscOption):
+    tag: str = Field(title="Tag ID")
+    uri: str = Field(title="URI / Path")
+
+
+class DiscForm(BaseModel):
+    tag: str = Field(title="Tag ID")
+    uri: str = Field(title="URI / Path")
+    artist: Optional[str] = Field(None, title="Artist")
+    album: Optional[str] = Field(None, title="Album")
+    track: Optional[str] = Field(None, title="Track")
+    shuffle: bool = Field(False, title="Shuffle")
+
+
+class LibraryUIPageBuilder:
+    def __init__(
+        self,
+        list_discs: ListDiscs,
+        get_disc: GetDisc,
+        get_current_tag_status: GetCurrentTagStatus,
+    ):
+        self.list_discs = list_discs
+        self.get_disc = get_disc
+        self.get_current_tag_status = get_current_tag_status
+
+    def build_index_page_components(self, toast: Optional[str] = None) -> List[AnyComponent]:
+        discs = self.list_discs.execute()
+        discs_list = [
+            DiscTable(tag=tag, uri=disc.uri, **disc.metadata.model_dump(), **disc.option.model_dump())
+            for tag, disc in discs.items()
+        ]
+
+        components: list[AnyComponent] = [
+            c.Heading(text="DiscStore for Jukebox", level=1),
+            c.Paragraph(text=f"📀 {len(discs)} disc(s) in library"),
+            c.ServerLoad(
+                path="/current-tag-banner/events",
+                sse=True,
+                sse_retry=2000,
+            ),
+            c.Div(
+                class_name="d-flex flex-wrap gap-2",
+                components=[
+                    c.Button(text="➕ Add a new disc", on_click=GoToEvent(url="/discs/new")),
+                    c.Button(text="⚙️ Settings", on_click=GoToEvent(url="/settings"), class_name="btn btn-secondary"),
+                ],
+            ),
+            c.Toast(
+                title="Toast",
+                body=[c.Paragraph(text="🎉 Disc added")],
+                open_trigger=PageEvent(name="toast-add-disc-success"),
+                position="bottom-end",
+            ),
+            c.Toast(
+                title="Toast",
+                body=[c.Paragraph(text="🎉 Disc edited")],
+                open_trigger=PageEvent(name="toast-edit-disc-success"),
+                position="bottom-end",
+            ),
+            c.Toast(
+                title="Toast",
+                body=[c.Paragraph(text="🗑️ Disc removed")],
+                open_trigger=PageEvent(name="toast-remove-disc-success"),
+                position="bottom-end",
+            ),
+            *self.build_disc_library_components(discs_list),
+        ]
+
+        page_components: list[AnyComponent] = [c.Page(components=components)]
+
+        if toast in {"toast-add-disc-success", "toast-edit-disc-success", "toast-remove-disc-success"}:
+            page_components.append(c.FireEvent(event=PageEvent(name=toast)))
+
+        return page_components
+
+    def build_form_page_components(self, title: str, form_components: List[AnyComponent]) -> List[AnyComponent]:
+        return [
+            c.Page(
+                components=[
+                    c.Heading(text=title, level=1),
+                    *form_components,
+                    c.Div(
+                        class_name="mt-3",
+                        components=[
+                            c.Link(
+                                components=[c.Text(text="Back to Library")],
+                                on_click=GoToEvent(url="/"),
+                            )
+                        ],
+                    ),
+                ]
+            )
+        ]
+
+    def build_current_tag_banner_components(
+        self,
+        current_tag_status: Optional[CurrentTagStatus],
+    ) -> List[AnyComponent]:
+        if current_tag_status is None:
+            return []
+
+        if current_tag_status.known_in_library:
+            return [
+                c.Div(
+                    class_name="alert alert-info mb-3 d-flex flex-column flex-md-row gap-3 justify-content-between align-items-md-center",
+                    components=[
+                        c.Div(
+                            class_name="mb-0",
+                            components=[
+                                c.Heading(text="Known disc on reader", level=4),
+                                c.Paragraph(text=f'Tag "{current_tag_status.tag_id}" is already in the library.'),
+                            ],
+                        ),
+                        c.Button(
+                            text="Edit this disc",
+                            on_click=GoToEvent(url=f"/discs/{current_tag_status.tag_id}/edit"),
+                        ),
+                    ],
+                )
+            ]
+
+        return [
+            c.Div(
+                class_name="alert alert-warning mb-3 d-flex flex-column flex-md-row gap-3 justify-content-between align-items-md-center",
+                components=[
+                    c.Div(
+                        class_name="mb-0",
+                        components=[
+                            c.Heading(text="Unknown disc on reader", level=4),
+                            c.Paragraph(text=f'Tag "{current_tag_status.tag_id}" is ready to be added to the library.'),
+                        ],
+                    ),
+                    c.Button(text="Add this disc", on_click=GoToEvent(url="/discs/new?prefill=current")),
+                ],
+            )
+        ]
+
+    def build_disc_library_components(self, discs: List[DiscTable]) -> List[AnyComponent]:
+        if not discs:
+            return [c.Paragraph(text="No disc found")]
+
+        return [
+            c.Div(
+                class_name="border rounded mt-3 mb-5 overflow-hidden",
+                components=[
+                    self._build_disc_library_header(),
+                    *[self._build_disc_library_row(disc) for disc in discs],
+                ],
+            )
+        ]
+
+    def build_new_disc_form_components(self, prefill_current: bool) -> List[AnyComponent]:
+        initial = None
+
+        if prefill_current:
+            current_tag_status = self.get_current_tag_status.execute()
+            if current_tag_status is None:
+                return [
+                    c.Error(
+                        title="No current tag available",
+                        description="There is no tag on the reader right now, so the form cannot be prefilled.",
+                    )
+                ]
+            if current_tag_status.known_in_library:
+                return [
+                    c.Error(
+                        title="Current tag already known",
+                        description=f'Tag "{current_tag_status.tag_id}" is already in the library.',
+                    )
+                ]
+            initial = {"tag": current_tag_status.tag_id, "shuffle": False}
+
+        return [
+            c.ModelForm(
+                model=DiscForm,
+                submit_url="/api/ui/discs",
+                method="POST",
+                initial=initial,
+            )
+        ]
+
+    def build_edit_disc_form_components(self, tag_id: str) -> List[AnyComponent]:
+        if not tag_id:
+            return [
+                c.Error(
+                    title="No disc selected",
+                    description="Edit mode requires an existing disc tag ID.",
+                )
+            ]
+        try:
+            disc = self.get_disc.execute(tag_id)
+        except ValueError as err:
+            return [
+                c.Error(
+                    title="Disc not found",
+                    description=str(err),
+                )
+            ]
+
+        return [
+            c.ModelForm(
+                model=DiscForm,
+                submit_url=f"/api/ui/discs/{tag_id}",
+                method="POST",
+                initial={
+                    "tag": tag_id,
+                    "uri": disc.uri,
+                    "artist": disc.metadata.artist,
+                    "album": disc.metadata.album,
+                    "track": disc.metadata.track,
+                    "shuffle": disc.option.shuffle,
+                },
+            ),
+            c.Button(
+                text="🗑️ Delete this disc",
+                on_click=GoToEvent(url=f"/discs/{tag_id}/delete"),
+                class_name="btn btn-danger mt-3",
+            ),
+        ]
+
+    def build_delete_disc_form_components(self, tag_id: str) -> List[AnyComponent]:
+        if not tag_id:
+            return [c.Error(title="No disc selected", description="Delete mode requires an existing disc tag ID.")]
+        try:
+            _ = self.get_disc.execute(tag_id)
+        except ValueError as err:
+            return [c.Error(title="Disc not found", description=str(err))]
+
+        return [
+            c.Paragraph(text=f'Are you sure you want to delete the disc with tag "{tag_id}"?'),
+            c.Div(
+                class_name="alert alert-danger",
+                components=[c.Paragraph(text="This action cannot be undone.")],
+            ),
+            c.Div(
+                class_name="d-flex gap-2 mt-3",
+                components=[
+                    c.Form(
+                        form_fields=[],
+                        submit_url=f"/api/ui/discs/{tag_id}/delete",
+                        method="POST",
+                    ),
+                    c.Button(
+                        text="Cancel",
+                        on_click=BackEvent(),
+                        class_name="btn btn-secondary",
+                    ),
+                ],
+            ),
+        ]
+
+    async def current_tag_banner_event_stream(
+        self,
+        request: Request,
+        poll_interval_seconds: float = 0.5,
+    ) -> AsyncIterator[bytes]:
+        previous_payload: Optional[str] = None
+
+        while True:
+            payload = self.serialize_current_tag_components(
+                self.build_current_tag_banner_components(self.get_current_tag_status.execute())
+            )
+            if payload != previous_payload:
+                previous_payload = payload
+                yield f"data: {payload}\n\n".encode("utf-8")
+
+            if await request.is_disconnected():
+                break
+
+            await asyncio.sleep(poll_interval_seconds)
+
+    @staticmethod
+    def serialize_current_tag_components(components: List[AnyComponent]) -> str:
+        return json.dumps([component.model_dump(by_alias=True, exclude_none=True) for component in components])
+
+    def _build_disc_library_header(self) -> AnyComponent:
+        return c.Div(
+            class_name="d-none d-lg-block px-3 py-2 bg-light-subtle",
+            components=[
+                c.Div(
+                    class_name="row g-2 align-items-center",
+                    components=[
+                        self._build_disc_header_cell("Tag ID", "col-lg"),
+                        self._build_disc_header_cell("URI / Path", "col-lg-3"),
+                        self._build_disc_header_cell("Artist", "col-lg-2 text-lg-center"),
+                        self._build_disc_header_cell("Album", "col-lg-2 text-lg-center"),
+                        self._build_disc_header_cell("Track", "col-lg-2 text-lg-center"),
+                        self._build_disc_header_cell("Shuffle", "col-lg-1 text-lg-center"),
+                        c.Div(
+                            class_name="col-lg-auto d-flex justify-content-lg-end",
+                            components=[
+                                c.Button(
+                                    text="Edit ✏️",
+                                    class_name="btn btn-secondary invisible",
+                                )
+                            ],
+                        ),
+                    ],
+                )
+            ],
+        )
+
+    def _build_disc_library_row(self, disc: DiscTable) -> AnyComponent:
+        return c.Div(
+            class_name="px-3 py-2 border-top",
+            components=[
+                c.Div(
+                    class_name="row g-2 align-items-center",
+                    components=[
+                        self._build_disc_value_cell("Tag ID", disc.tag, "col-12 col-lg"),
+                        self._build_disc_value_cell("URI / Path", disc.uri, "col-12 col-lg-3"),
+                        self._build_disc_value_cell("Artist", disc.artist, "col-6 col-md-3 col-lg-2 text-lg-center"),
+                        self._build_disc_value_cell("Album", disc.album, "col-6 col-md-3 col-lg-2 text-lg-center"),
+                        self._build_disc_value_cell("Track", disc.track, "col-6 col-md-3 col-lg-2 text-lg-center"),
+                        self._build_disc_value_cell(
+                            "Shuffle", "✓" if disc.shuffle else "×", "col-6 col-md-3 col-lg-1 text-lg-center"
+                        ),
+                        c.Div(
+                            class_name="col-12 col-lg-auto d-flex justify-content-lg-end",
+                            components=[
+                                c.Button(
+                                    text="Edit ✏️",
+                                    on_click=GoToEvent(url=f"/discs/{disc.tag}/edit"),
+                                    class_name="btn btn-secondary",
+                                ),
+                            ],
+                        ),
+                    ],
+                )
+            ],
+        )
+
+    def _build_disc_header_cell(self, label: str, class_name: str) -> AnyComponent:
+        justify_class = "justify-content-lg-start"
+        if "text-lg-center" in class_name:
+            justify_class = "justify-content-lg-center"
+        elif "text-lg-end" in class_name:
+            justify_class = "justify-content-lg-end"
+
+        return c.Div(
+            class_name=f"{class_name} d-flex align-items-center {justify_class}",
+            components=[
+                c.Paragraph(text=label, class_name="text-uppercase text-muted small fw-semibold mb-0"),
+            ],
+        )
+
+    def _build_disc_value_cell(self, label: str, value: Optional[str], class_name: str) -> AnyComponent:
+        return c.Div(
+            class_name=class_name,
+            components=[
+                c.Paragraph(text=label, class_name="d-lg-none text-uppercase text-muted small fw-semibold mb-1"),
+                c.Paragraph(text=value or "—", class_name="mb-0 text-break"),
+            ],
+        )

--- a/discstore/adapters/inbound/ui_pages/settings.py
+++ b/discstore/adapters/inbound/ui_pages/settings.py
@@ -1,0 +1,517 @@
+import json
+from itertools import groupby
+from typing import List, Optional, cast
+from urllib.parse import urlencode
+
+from fastapi import HTTPException
+from fastui import AnyComponent
+from fastui import components as c
+from fastui.components.forms import FormFieldInput, FormFieldSelect, FormFieldTextarea
+from fastui.events import GoToEvent, PageEvent
+
+from jukebox.settings.definitions import (
+    EditableSettingDisplay,
+    build_editable_setting_displays,
+    get_setting_definition,
+)
+from jukebox.settings.errors import SettingsError
+from jukebox.settings.service_protocols import SettingsService
+from jukebox.settings.types import JsonObject
+
+_MISSING = object()
+
+
+class SettingsUIPageBuilder:
+    def __init__(self, settings_service: SettingsService):
+        self.settings_service = settings_service
+
+    def build_settings_success_response(self, message: str) -> list[AnyComponent]:
+        query = urlencode(
+            {
+                "toast": "toast-settings-success",
+                "toast_message": message,
+            }
+        )
+        return [
+            c.FireEvent(event=GoToEvent(url=f"/settings?{query}")),
+        ]
+
+    def reset_setting(self, setting_path: str) -> list[AnyComponent]:
+        definition = get_setting_definition(setting_path)
+        if definition is None:
+            raise HTTPException(status_code=404, detail=f"Unknown setting path: {setting_path}")
+
+        try:
+            result = self.settings_service.reset_persisted_value(setting_path)
+        except SettingsError as err:
+            if not self.has_persisted_value(setting_path):
+                return self.build_settings_success_response(
+                    "Settings reset, but effective settings are still unavailable."
+                )
+            return self.build_settings_edit_page_components(setting_path, reset_error=str(err))
+        except HTTPException:
+            raise
+        except Exception as err:
+            raise HTTPException(status_code=500, detail=f"Server error: {str(err)}")
+
+        return self.build_settings_success_response(str(result["message"]))
+
+    def build_settings_page_components(
+        self,
+        toast: Optional[str] = None,
+        toast_message: Optional[str] = None,
+    ) -> List[AnyComponent]:
+        settings, effective_settings_error = self.get_settings_displays()
+        components: list[AnyComponent] = [
+            c.Heading(text="Settings", level=1),
+            c.Div(
+                class_name="d-flex flex-wrap gap-2 mb-4",
+                components=[
+                    c.Link(components=[c.Text(text="Back to Library")], on_click=GoToEvent(url="/")),
+                ],
+            ),
+        ]
+        if effective_settings_error:
+            components.append(
+                c.Error(
+                    title="Effective settings unavailable",
+                    description=(
+                        f"{effective_settings_error} Persisted overrides are still shown below so you can inspect"
+                        " and repair saved values."
+                    ),
+                )
+            )
+
+        for section, entries_iter in groupby(settings, key=lambda entry: entry.section):
+            entries = list(entries_iter)
+            components.extend(self.build_settings_section_components(section, entries))
+
+        components.append(
+            c.Toast(
+                title="Toast",
+                body=[c.Paragraph(text=toast_message or "Settings saved.")],
+                open_trigger=PageEvent(name="toast-settings-success"),
+                position="bottom-end",
+            )
+        )
+
+        page_components: list[AnyComponent] = [c.Page(components=components)]
+        if toast == "toast-settings-success":
+            page_components.append(c.FireEvent(event=PageEvent(name=toast)))
+
+        return page_components
+
+    def build_settings_section_components(
+        self,
+        section: str,
+        settings: List[EditableSettingDisplay],
+    ) -> List[AnyComponent]:
+        first_setting = settings[0]
+        section_components: list[AnyComponent] = [
+            c.Heading(text=first_setting.section_label, level=2),
+        ]
+        if first_setting.section_description:
+            section_components.append(c.Paragraph(text=first_setting.section_description, class_name="mb-2"))
+
+        section_components.append(
+            c.Div(
+                class_name="border rounded overflow-hidden mb-4",
+                components=[self.build_settings_row(setting, index) for index, setting in enumerate(settings)],
+            )
+        )
+
+        return [*section_components]
+
+    def build_settings_row(self, setting: EditableSettingDisplay, index: int) -> AnyComponent:
+        info_components: list[AnyComponent] = [
+            c.Heading(text=setting.label, level=4),
+            c.Paragraph(text=setting.path, class_name="text-muted small mb-1"),
+            c.Paragraph(text=setting.description, class_name="mb-2"),
+        ]
+
+        badge_components = self.build_settings_badges(setting)
+        if badge_components:
+            info_components.append(
+                c.Div(
+                    class_name="d-flex flex-wrap gap-2 mb-3",
+                    components=badge_components,
+                )
+            )
+        info_components.append(self.build_settings_value_summary(setting))
+
+        action_components: list[AnyComponent] = [
+            c.Button(
+                text="Edit ✏️",
+                on_click=GoToEvent(url=f"/settings/{setting.path}/edit"),
+                class_name="btn btn-secondary",
+            )
+        ]
+        row_class_name = "px-3 py-3"
+        if index > 0:
+            row_class_name += " border-top"
+
+        return c.Div(
+            class_name=row_class_name,
+            components=[
+                c.Div(
+                    class_name="d-flex flex-column flex-xl-row gap-3 justify-content-between align-items-xl-start",
+                    components=[
+                        c.Div(class_name="flex-grow-1", components=info_components),
+                        c.Div(class_name="d-grid gap-2 align-self-start", components=action_components),
+                    ],
+                )
+            ],
+        )
+
+    def build_settings_edit_page_components(
+        self,
+        setting_path: str,
+        reset_error: Optional[str] = None,
+    ) -> List[AnyComponent]:
+        settings, effective_settings_error = self.get_settings_displays()
+        setting = next((candidate for candidate in settings if candidate.path == setting_path), None)
+        if setting is None:
+            return [
+                c.Page(
+                    components=[
+                        c.Heading(text="Edit setting", level=1),
+                        c.Error(title="Setting not found", description=f"Unknown setting path: {setting_path}"),
+                        c.Link(components=[c.Text(text="Back to Settings")], on_click=GoToEvent(url="/settings")),
+                        c.Link(components=[c.Text(text="Back to Library")], on_click=GoToEvent(url="/")),
+                    ]
+                )
+            ]
+
+        components: list[AnyComponent] = [
+            c.Heading(text=f"Edit {setting.label}", level=1),
+            c.Paragraph(
+                text=f"{setting.section_label} setting", class_name="text-uppercase text-muted small fw-semibold mb-1"
+            ),
+            c.Paragraph(text=setting.path, class_name="text-muted small mb-1"),
+            c.Paragraph(text=setting.description, class_name="mb-3"),
+        ]
+
+        badge_components = self.build_settings_badges(setting)
+        if badge_components:
+            components.append(
+                c.Div(
+                    class_name="d-flex flex-wrap gap-2 mb-3",
+                    components=badge_components,
+                )
+            )
+
+        if reset_error:
+            components.append(
+                c.Error(
+                    title="Reset failed",
+                    description=reset_error,
+                )
+            )
+
+        if effective_settings_error:
+            components.append(
+                c.Error(
+                    title="Effective settings unavailable",
+                    description=(
+                        f"{effective_settings_error} Showing persisted and default values where possible so this"
+                        " setting can still be reviewed or repaired."
+                    ),
+                )
+            )
+
+        components.append(
+            c.Div(
+                class_name="border rounded p-3 mb-4 bg-light-subtle",
+                components=[
+                    c.Heading(text="Current values", level=3),
+                    self.build_settings_value_summary(setting),
+                ],
+            )
+        )
+
+        components.append(
+            c.Div(
+                class_name="border rounded p-3 mb-4",
+                components=[
+                    c.Heading(text="Update override", level=3),
+                    c.Paragraph(text=self.build_settings_edit_guidance(setting), class_name="mb-3"),
+                    self.build_settings_edit_form(setting),
+                ],
+            )
+        )
+
+        if setting.is_persisted:
+            components.extend(
+                [
+                    c.Div(
+                        class_name="border rounded p-3 mb-4",
+                        components=[
+                            c.Heading(text="Reset override", level=3),
+                            c.Paragraph(
+                                text=(
+                                    "Reset removes the persisted override entirely. Use it to fall back to defaults,"
+                                    " environment overrides, or CLI overrides."
+                                )
+                            ),
+                            self.build_settings_reset_form(setting.path),
+                        ],
+                    )
+                ]
+            )
+
+        components.append(
+            c.Div(
+                class_name="mt-3 d-flex flex-wrap gap-3",
+                components=[
+                    c.Link(components=[c.Text(text="Back to Settings")], on_click=GoToEvent(url="/settings")),
+                    c.Link(components=[c.Text(text="Back to Library")], on_click=GoToEvent(url="/")),
+                ],
+            )
+        )
+
+        return [c.Page(components=components)]
+
+    def build_settings_edit_form(self, setting: EditableSettingDisplay) -> AnyComponent:
+        initial_value = setting.persisted_value if setting.is_persisted else setting.effective_value
+        field_description = setting.description
+        if setting.field_type == "object":
+            field_description = (
+                f"{field_description} Enter a JSON object matching the persisted setting shape. "
+                "Leave blank to persist null. Use Reset to remove the persisted override."
+            )
+        if setting.requires_restart:
+            field_description = f"{field_description} Takes effect after restart."
+
+        if setting.choices:
+            form_field = FormFieldSelect(
+                name="value",
+                title=setting.label,
+                options=[
+                    {
+                        "value": choice.value,
+                        "label": choice.label,
+                    }
+                    for choice in setting.choices
+                ],
+                initial=None if initial_value is None else str(initial_value),
+                description=field_description,
+                required=True,
+                vanilla=True,
+            )
+        elif setting.field_type == "object":
+            form_field = FormFieldTextarea(
+                name="value",
+                title=setting.label,
+                initial=json.dumps(initial_value, indent=2) if initial_value is not None else "",
+                description=field_description,
+                required=False,
+                rows=12,
+                placeholder="Enter a JSON object. Leave blank to persist null.",
+            )
+        else:
+            form_field = FormFieldInput(
+                name="value",
+                title=setting.label,
+                initial=None if initial_value is None else str(initial_value),
+                description=field_description,
+                required=True,
+                html_type="number" if setting.field_type == "integer" else "text",
+            )
+
+        return c.Form(
+            form_fields=[form_field],
+            submit_url=f"/api/ui/settings/{setting.path}",
+            method="POST",
+            footer=[c.Button(text="Save", html_type="submit", class_name="btn btn-primary")],
+        )
+
+    def build_settings_reset_form(self, setting_path: str) -> AnyComponent:
+        return c.Form(
+            form_fields=[],
+            submit_url=f"/api/ui/settings/{setting_path}/reset",
+            method="POST",
+            footer=[c.Button(text="Reset", html_type="submit", class_name="btn btn-outline-danger text-nowrap px-3")],
+        )
+
+    def get_settings_displays(self) -> tuple[List[EditableSettingDisplay], Optional[str]]:
+        persisted_settings = self.settings_service.get_persisted_settings_view()
+        effective_settings_error: Optional[str] = None
+        try:
+            effective_settings_view = self.settings_service.get_effective_settings_view()
+        except SettingsError as err:
+            effective_settings_view = {}
+            effective_settings_error = str(err)
+
+        return build_editable_setting_displays(persisted_settings, effective_settings_view), effective_settings_error
+
+    def build_settings_badges(self, setting: EditableSettingDisplay) -> list[AnyComponent]:
+        badge_components: list[AnyComponent] = []
+        if setting.is_pinned_default:
+            badge_components.append(c.Paragraph(text="Pinned default", class_name="badge text-bg-info text-uppercase"))
+        if setting.requires_restart:
+            badge_components.append(
+                c.Paragraph(text="Restart required", class_name="badge text-bg-warning text-uppercase")
+            )
+        if setting.advanced:
+            badge_components.append(c.Paragraph(text="Advanced", class_name="badge text-bg-dark text-uppercase"))
+        return badge_components
+
+    def build_settings_value_summary(self, setting: EditableSettingDisplay) -> AnyComponent:
+        return c.Div(
+            class_name="row g-3",
+            components=[
+                self.build_settings_value_cell(
+                    "Default",
+                    self.format_settings_display_value(setting.path, setting.default_value),
+                ),
+                self.build_settings_value_cell(
+                    "Persisted override",
+                    self.format_settings_display_value(setting.path, setting.persisted_value)
+                    if setting.is_persisted
+                    else "None",
+                ),
+                self.build_settings_value_cell(
+                    "Effective value",
+                    self.format_settings_display_value(setting.path, setting.effective_value),
+                ),
+                self.build_settings_value_cell(
+                    "Source",
+                    self.format_settings_provenance(setting.provenance),
+                ),
+            ],
+        )
+
+    def build_settings_value_cell(self, label: str, value: str) -> AnyComponent:
+        return c.Div(
+            class_name="col-12 col-md-6 col-xl-3",
+            components=[
+                c.Paragraph(text=label, class_name="text-uppercase text-muted small fw-semibold mb-1"),
+                c.Paragraph(text=value, class_name="mb-0 text-break"),
+            ],
+        )
+
+    def build_settings_edit_guidance(self, setting: EditableSettingDisplay) -> str:
+        guidance = "Save a persisted override for this setting."
+        if setting.choices:
+            guidance = f"{guidance} Choose one of the supported options below."
+        elif setting.field_type == "object":
+            guidance = (
+                f"{guidance} Provide a JSON object matching the stored setting shape,"
+                " or leave the field blank to persist null."
+            )
+
+        return f"{guidance} The effective value may still be superseded by environment or CLI overrides."
+
+    def build_settings_patch(self, setting_path: str, raw_value: str) -> JsonObject:
+        definition = get_setting_definition(setting_path)
+        if definition is None:
+            raise ValueError(f"Unknown setting path: {setting_path}")
+
+        if definition.choices and raw_value not in {choice.value for choice in definition.choices}:
+            raise ValueError("Choose a valid option.")
+
+        if definition.field_type == "integer":
+            try:
+                value: object = int(raw_value)
+            except ValueError as err:
+                raise ValueError("Enter a valid integer.") from err
+        elif definition.field_type == "number":
+            try:
+                value = float(raw_value)
+            except ValueError as err:
+                raise ValueError("Enter a valid number.") from err
+        elif definition.field_type == "object":
+            if raw_value.strip() == "":
+                value = None
+                return self.build_dotted_patch(setting_path, value)
+            try:
+                value = json.loads(raw_value)
+            except json.JSONDecodeError as err:
+                raise ValueError("Enter valid JSON.") from err
+            if not isinstance(value, dict):
+                raise ValueError("Enter a JSON object.")
+        else:
+            value = raw_value
+
+        return self.build_dotted_patch(setting_path, value)
+
+    def build_dotted_patch(self, dotted_path: str, value: object) -> JsonObject:
+        patch: JsonObject = {}
+        cursor = patch
+        parts = dotted_path.split(".")
+        for part in parts[:-1]:
+            child: JsonObject = {}
+            cursor[part] = child
+            cursor = child
+        cursor[parts[-1]] = value
+        return patch
+
+    def persisted_value_matches(self, dotted_path: str, expected_value: object) -> bool:
+        return (
+            self.lookup_optional_dotted_path(self.settings_service.get_persisted_settings_view(), dotted_path)
+            == expected_value
+        )
+
+    def has_persisted_value(self, dotted_path: str) -> bool:
+        return (
+            self.lookup_optional_dotted_path(self.settings_service.get_persisted_settings_view(), dotted_path)
+            is not _MISSING
+        )
+
+    def lookup_optional_dotted_path(self, root: JsonObject, dotted_path: str) -> object:
+        current: JsonObject = root
+        parts = dotted_path.split(".")
+        for part in parts[:-1]:
+            child = current.get(part, _MISSING)
+            if not isinstance(child, dict):
+                return _MISSING
+            current = cast(JsonObject, child)
+        return current.get(parts[-1], _MISSING)
+
+    def format_settings_display_value(self, setting_path: str, value: object) -> str:
+        if value is None:
+            return "null"
+
+        definition = get_setting_definition(setting_path)
+        if definition is not None and definition.choices and isinstance(value, str):
+            choice_labels = {choice.value: choice.label for choice in definition.choices}
+            if value in choice_labels:
+                return choice_labels[value]
+
+        if setting_path == "jukebox.player.sonos.selected_group" and isinstance(value, dict):
+            selected_group = cast(dict[str, object], value)
+            members = selected_group.get("members")
+            coordinator_uid = selected_group.get("coordinator_uid")
+            if isinstance(members, list) and isinstance(coordinator_uid, str):
+                member_uids = []
+                for member in members:
+                    if not isinstance(member, dict):
+                        continue
+                    selected_member = cast(dict[str, object], member)
+                    uid = selected_member.get("uid")
+                    if not isinstance(uid, str):
+                        continue
+                    member_uids.append(uid)
+                if member_uids:
+                    return "{} (coordinator); members: {}".format(coordinator_uid, ", ".join(member_uids))
+
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, (int, float)):
+            return str(value)
+        if isinstance(value, str):
+            return value
+        try:
+            return json.dumps(value, sort_keys=True, separators=(", ", ": "))
+        except TypeError:
+            return str(value)
+
+    def format_settings_provenance(self, provenance: str) -> str:
+        labels = {
+            "default": "Default",
+            "file": "Settings file",
+            "env": "Environment override",
+            "cli": "CLI override",
+            "mixed": "Mixed source",
+        }
+        return labels.get(provenance, provenance)

--- a/discstore/adapters/inbound/ui_pages/settings.py
+++ b/discstore/adapters/inbound/ui_pages/settings.py
@@ -8,6 +8,7 @@ from fastui import AnyComponent
 from fastui import components as c
 from fastui.components.forms import FormFieldInput, FormFieldSelect, FormFieldTextarea
 from fastui.events import GoToEvent, PageEvent
+from fastui.forms import SelectOption
 
 from jukebox.settings.definitions import (
     EditableSettingDisplay,
@@ -16,7 +17,7 @@ from jukebox.settings.definitions import (
 )
 from jukebox.settings.errors import SettingsError
 from jukebox.settings.service_protocols import SettingsService
-from jukebox.settings.types import JsonObject
+from jukebox.settings.types import JsonObject, JsonValue
 
 _MISSING = object()
 
@@ -283,16 +284,17 @@ class SettingsUIPageBuilder:
             field_description = f"{field_description} Takes effect after restart."
 
         if setting.choices:
+            options: list[SelectOption] = [
+                {
+                    "value": choice.value,
+                    "label": choice.label,
+                }
+                for choice in setting.choices
+            ]
             form_field = FormFieldSelect(
                 name="value",
                 title=setting.label,
-                options=[
-                    {
-                        "value": choice.value,
-                        "label": choice.label,
-                    }
-                    for choice in setting.choices
-                ],
+                options=options,
                 initial=None if initial_value is None else str(initial_value),
                 description=field_description,
                 required=True,
@@ -412,7 +414,7 @@ class SettingsUIPageBuilder:
 
         if definition.field_type == "integer":
             try:
-                value: object = int(raw_value)
+                value: JsonValue = int(raw_value)
             except ValueError as err:
                 raise ValueError("Enter a valid integer.") from err
         elif definition.field_type == "number":
@@ -425,7 +427,7 @@ class SettingsUIPageBuilder:
                 value = None
                 return self.build_dotted_patch(setting_path, value)
             try:
-                value = json.loads(raw_value)
+                value = cast(JsonValue, json.loads(raw_value))
             except json.JSONDecodeError as err:
                 raise ValueError("Enter valid JSON.") from err
             if not isinstance(value, dict):
@@ -435,7 +437,7 @@ class SettingsUIPageBuilder:
 
         return self.build_dotted_patch(setting_path, value)
 
-    def build_dotted_patch(self, dotted_path: str, value: object) -> JsonObject:
+    def build_dotted_patch(self, dotted_path: str, value: JsonValue) -> JsonObject:
         patch: JsonObject = {}
         cursor = patch
         parts = dotted_path.split(".")


### PR DESCRIPTION
## Summary

Extract FastUI page-building logic from `discstore.adapters.inbound.ui_controller` into dedicated inbound UI modules.

## Changes

- add `discstore.adapters.inbound.ui_pages.library`
- add `discstore.adapters.inbound.ui_pages.settings`
- keep `UIController` as the route/orchestration shell
- preserve existing route behavior and test-facing helper methods via delegation

## Notes

Should be no functional changes, this is just in preparation for adding the sonos admin UI.