### PR TITLE
Add Sonos Admin UI

### DIFF
--- a/discstore/adapters/inbound/ui_controller.py
+++ b/discstore/adapters/inbound/ui_controller.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel, Field
 from discstore.adapters.inbound.api_controller import APIController
 from discstore.adapters.inbound.ui_pages.library import DiscForm, DiscTable, LibraryUIPageBuilder
 from discstore.adapters.inbound.ui_pages.settings import SettingsUIPageBuilder
+from discstore.adapters.inbound.ui_pages.sonos import SonosSelectionForm, SonosUIPageBuilder
 from discstore.domain.entities import CurrentTagStatus, Disc, DiscMetadata, DiscOption
 from discstore.domain.use_cases.add_disc import AddDisc
 from discstore.domain.use_cases.edit_disc import EditDisc
@@ -36,8 +37,11 @@ from jukebox.settings.definitions import (
     get_setting_definition,
 )
 from jukebox.settings.errors import SettingsError
+from jukebox.settings.selected_sonos_group_repository import SettingsSelectedSonosGroupRepository
 from jukebox.settings.service_protocols import SettingsService
 from jukebox.settings.types import JsonObject
+from jukebox.sonos.discovery import SonosDiscoveryError
+from jukebox.sonos.selection import SaveSonosSelection
 from jukebox.sonos.service import SonosService
 
 
@@ -63,6 +67,7 @@ class UIController(APIController):
             get_disc=get_disc,
             get_current_tag_status=get_current_tag_status,
         )
+        self.sonos_pages = SonosUIPageBuilder(settings_service=settings_service, sonos_service=sonos_service)
         self.settings_pages = SettingsUIPageBuilder(settings_service=settings_service)
         super().__init__(
             add_disc,
@@ -222,6 +227,65 @@ class UIController(APIController):
         async def reset_setting(setting_path: str) -> list[AnyComponent]:
             return self._reset_setting(setting_path)
 
+        @self.app.get("/api/ui/sonos", response_model=FastUI, response_model_exclude_none=True)
+        def sonos_page(toast: Optional[str] = None, toast_message: Optional[str] = None) -> List[AnyComponent]:
+            return self._build_sonos_page_components(toast=toast, toast_message=toast_message)
+
+        @self.app.get("/api/ui/sonos/edit", response_model=FastUI, response_model_exclude_none=True)
+        def edit_sonos_form(
+            error_message: Optional[str] = None,
+            uids: Optional[List[str]] = None,
+            coordinator_uid: Optional[str] = None,
+        ) -> List[AnyComponent]:
+            field_errors = None
+            if error_message:
+                field_errors = {self._sonos_field_name_for_error(error_message): error_message}
+            return self._build_sonos_edit_page_components(
+                error_message=error_message,
+                field_errors=field_errors,
+                submitted_uids=uids,
+                submitted_coordinator_uid=coordinator_uid,
+            )
+
+        @self.app.post("/api/ui/sonos/edit", response_model=FastUI, response_model_exclude_none=True)
+        async def update_sonos_selection(
+            form: Annotated[SonosSelectionForm, fastui_form(SonosSelectionForm)],
+        ) -> list[AnyComponent]:
+            try:
+                result = SaveSonosSelection(
+                    selected_group_repository=SettingsSelectedSonosGroupRepository(self.settings_service),
+                    sonos_service=self.sonos_service,
+                ).execute(form.uids, coordinator_uid=form.coordinator_uid)
+            except SonosDiscoveryError as err:
+                raise HTTPException(status_code=502, detail=str(err))
+            except SettingsError as err:
+                display_message = self._build_sonos_error_message(str(err), form.coordinator_uid)
+                if self._persisted_sonos_selection_matches(form.uids, form.coordinator_uid):
+                    return self.sonos_pages.build_sonos_success_response(
+                        "Sonos selection saved, but effective settings are still unavailable."
+                    )
+                return self.sonos_pages.build_sonos_edit_error_response(
+                    display_message,
+                    form.uids,
+                    form.coordinator_uid,
+                )
+            except ValueError as err:
+                return self.sonos_pages.build_sonos_edit_error_response(
+                    self._build_sonos_error_message(str(err), form.coordinator_uid),
+                    form.uids,
+                    form.coordinator_uid,
+                )
+            except HTTPException:
+                raise
+            except Exception as err:
+                raise HTTPException(status_code=500, detail=f"Server error: {str(err)}")
+
+            return self.sonos_pages.build_sonos_success_response(str(result.settings_message))
+
+        @self.app.post("/api/ui/sonos/reset", response_model=FastUI, response_model_exclude_none=True)
+        async def reset_sonos_selection() -> list[AnyComponent]:
+            return self._reset_sonos_selection()
+
         @self.app.get("/{path:path}")
         def html_landing(path: str) -> HTMLResponse:
             del path
@@ -237,6 +301,80 @@ class UIController(APIController):
 
     def _reset_setting(self, setting_path: str) -> list[AnyComponent]:
         return self.settings_pages.reset_setting(setting_path)
+
+    def _build_sonos_page_components(
+        self,
+        toast: Optional[str] = None,
+        toast_message: Optional[str] = None,
+        error_message: Optional[str] = None,
+    ) -> List[AnyComponent]:
+        return self.sonos_pages.build_sonos_page_components(
+            toast=toast,
+            toast_message=toast_message,
+            error_message=error_message,
+        )
+
+    def _build_sonos_edit_page_components(
+        self,
+        error_message: Optional[str] = None,
+        field_errors: Optional[dict[str, str]] = None,
+        submitted_uids: Optional[List[str]] = None,
+        submitted_coordinator_uid: Optional[str] = None,
+    ) -> List[AnyComponent]:
+        return self.sonos_pages.build_sonos_edit_page_components(
+            error_message=error_message,
+            field_errors=field_errors,
+            submitted_uids=submitted_uids,
+            submitted_coordinator_uid=submitted_coordinator_uid,
+        )
+
+    def _reset_sonos_selection(self) -> list[AnyComponent]:
+        selected_group_repository = SettingsSelectedSonosGroupRepository(self.settings_service)
+        try:
+            result = self.settings_service.reset_persisted_value("jukebox.player.sonos.selected_group")
+        except SettingsError as err:
+            if selected_group_repository.get_selected_group() is None:
+                return self.sonos_pages.build_sonos_success_response(
+                    "Sonos selection cleared, but effective settings are still unavailable."
+                )
+            return self._build_sonos_page_components(error_message=str(err))
+        except HTTPException:
+            raise
+        except Exception as err:
+            raise HTTPException(status_code=500, detail=f"Server error: {str(err)}")
+
+        return self.sonos_pages.build_sonos_success_response(str(result.get("message", "Settings saved.")))
+
+    def _persisted_sonos_selection_matches(self, uids: List[str], coordinator_uid: Optional[str]) -> bool:
+        try:
+            selected_group = SettingsSelectedSonosGroupRepository(self.settings_service).get_selected_group()
+        except Exception:
+            return False
+
+        if selected_group is None:
+            return False
+
+        expected_coordinator_uid = coordinator_uid or (uids[0] if uids else None)
+        return (
+            selected_group.coordinator_uid == expected_coordinator_uid
+            and [member.uid for member in selected_group.members] == uids
+        )
+
+    def _build_sonos_error_message(self, message: str, coordinator_uid: Optional[str]) -> str:
+        prefix = "Selected Sonos coordinator must be one of the selected speakers: "
+        if coordinator_uid is None or not message.startswith(prefix):
+            return message
+
+        try:
+            speakers = self.sonos_service.list_available_speakers()
+        except Exception:
+            return message
+
+        speaker = next((speaker for speaker in speakers if speaker.uid == coordinator_uid), None)
+        if speaker is None:
+            return message
+
+        return "{}{} [{}]".format(prefix, speaker.name, speaker.uid)
 
     def _build_index_page_components(self, toast: Optional[str] = None) -> List[AnyComponent]:
         return self.library_pages.build_index_page_components(toast=toast)
@@ -349,6 +487,12 @@ class UIController(APIController):
 
     def _serialize_current_tag_components(self, components: List[AnyComponent]) -> str:
         return self.library_pages.serialize_current_tag_components(components)
+
+    @staticmethod
+    def _sonos_field_name_for_error(message: str) -> str:
+        if "coordinator" in message:
+            return "coordinator_uid"
+        return "uids"
 
     def _field_validation_error(self, field_name: str, message: str) -> HTTPException:
         return HTTPException(

--- a/discstore/adapters/inbound/ui_controller.py
+++ b/discstore/adapters/inbound/ui_controller.py
@@ -374,7 +374,7 @@ class UIController(APIController):
         if speaker is None:
             return message
 
-        return "{}{} [{}]".format(prefix, speaker.name, speaker.uid)
+        return f"{prefix}{speaker.name} [{speaker.uid}]"
 
     def _build_index_page_components(self, toast: Optional[str] = None) -> List[AnyComponent]:
         return self.library_pages.build_index_page_components(toast=toast)

--- a/discstore/adapters/inbound/ui_pages/library.py
+++ b/discstore/adapters/inbound/ui_pages/library.py
@@ -58,6 +58,11 @@ class LibraryUIPageBuilder:
                 class_name="d-flex flex-wrap gap-2",
                 components=[
                     c.Button(text="➕ Add a new disc", on_click=GoToEvent(url="/discs/new")),
+                    c.Button(
+                        text="🔊 Sonos Speakers",
+                        on_click=GoToEvent(url="/sonos"),
+                        class_name="btn btn-secondary",
+                    ),
                     c.Button(text="⚙️ Settings", on_click=GoToEvent(url="/settings"), class_name="btn btn-secondary"),
                 ],
             ),

--- a/discstore/adapters/inbound/ui_pages/settings.py
+++ b/discstore/adapters/inbound/ui_pages/settings.py
@@ -142,9 +142,13 @@ class SettingsUIPageBuilder:
 
         action_components: list[AnyComponent] = [
             c.Button(
-                text="Edit ✏️",
-                on_click=GoToEvent(url=f"/settings/{setting.path}/edit"),
-                class_name="btn btn-secondary",
+                text="Manage Speakers 🔊" if setting.path == "jukebox.player.sonos.selected_group" else "Edit ✏️",
+                on_click=(
+                    GoToEvent(url="/sonos")
+                    if setting.path == "jukebox.player.sonos.selected_group"
+                    else GoToEvent(url=f"/settings/{setting.path}/edit")
+                ),
+                class_name="btn btn-secondary text-nowrap",
             )
         ]
         row_class_name = "px-3 py-3"

--- a/discstore/adapters/inbound/ui_pages/sonos.py
+++ b/discstore/adapters/inbound/ui_pages/sonos.py
@@ -222,14 +222,10 @@ class SonosUIPageBuilder:
         speakers_by_uid = {speaker.uid: speaker for speaker in speakers}
         coordinator = speakers_by_uid.get(selected_group.coordinator_uid)
         coordinator_label = (
-            "{} [{}]".format(coordinator.name, coordinator.uid)
-            if coordinator is not None
-            else selected_group.coordinator_uid
+            f"{coordinator.name} [{coordinator.uid}]" if coordinator is not None else selected_group.coordinator_uid
         )
         member_labels = [
-            "{} [{}]".format(speakers_by_uid[member.uid].name, member.uid)
-            if member.uid in speakers_by_uid
-            else member.uid
+            f"{speakers_by_uid[member.uid].name} [{member.uid}]" if member.uid in speakers_by_uid else member.uid
             for member in selected_group.members
         ]
 
@@ -487,13 +483,13 @@ class SonosUIPageBuilder:
 
     @staticmethod
     def _build_speaker_option_label(speaker: DiscoveredSonosSpeaker) -> str:
-        return "{} ({})".format(speaker.name, speaker.host)
+        return f"{speaker.name} ({speaker.host})"
 
     @staticmethod
     def _format_status_member(member) -> str:
         if member.speaker is not None:
-            return "{} [{}]".format(member.speaker.name, member.uid)
-        return "{} [unavailable]".format(member.uid)
+            return f"{member.speaker.name} [{member.uid}]"
+        return f"{member.uid} [unavailable]"
 
     @staticmethod
     def _format_saved_coordinator(status: SonosSelectionStatus) -> str:
@@ -502,5 +498,5 @@ class SonosUIPageBuilder:
 
         for member in status.availability.members:
             if member.uid == status.selected_group.coordinator_uid and member.speaker is not None:
-                return "{} [{}]".format(member.speaker.name, member.uid)
+                return f"{member.speaker.name} [{member.uid}]"
         return status.selected_group.coordinator_uid

--- a/discstore/adapters/inbound/ui_pages/sonos.py
+++ b/discstore/adapters/inbound/ui_pages/sonos.py
@@ -1,0 +1,506 @@
+from typing import List, Optional
+from urllib.parse import urlencode
+
+from fastui import AnyComponent
+from fastui import components as c
+from fastui.components.forms import FormFieldSelect
+from fastui.events import GoToEvent, PageEvent
+from fastui.forms import SelectOption
+from pydantic import BaseModel, Field, field_validator
+
+from jukebox.settings.entities import SelectedSonosGroupSettings
+from jukebox.settings.selected_sonos_group_repository import SettingsSelectedSonosGroupRepository
+from jukebox.settings.service_protocols import SettingsService
+from jukebox.sonos.discovery import DiscoveredSonosSpeaker, SonosDiscoveryError
+from jukebox.sonos.selection import (
+    GetSonosSelectionStatus,
+    SonosSelectionStatus,
+)
+from jukebox.sonos.service import SonosService
+
+
+class SonosSelectionForm(BaseModel):
+    uids: List[str] = Field(default_factory=list, title="Speakers")
+    coordinator_uid: Optional[str] = Field(None, title="Coordinator")
+
+    @field_validator("uids", mode="before")
+    @classmethod
+    def coerce_single_uid_to_list(cls, value):
+        if isinstance(value, str):
+            return [value]
+        return value
+
+
+class SonosUIPageBuilder:
+    def __init__(self, settings_service: SettingsService, sonos_service: SonosService):
+        self.settings_service = settings_service
+        self.sonos_service = sonos_service
+
+    def build_sonos_success_response(self, message: str) -> list[AnyComponent]:
+        query = urlencode(
+            {
+                "toast": "toast-sonos-success",
+                "toast_message": message,
+            }
+        )
+        return [
+            c.FireEvent(event=GoToEvent(url=f"/sonos?{query}")),
+        ]
+
+    def build_sonos_edit_error_response(
+        self,
+        message: str,
+        uids: List[str],
+        coordinator_uid: Optional[str],
+    ) -> list[AnyComponent]:
+        query = urlencode(
+            [
+                ("error_message", message),
+                *[("uids", uid) for uid in uids],
+                *([("coordinator_uid", coordinator_uid)] if coordinator_uid is not None else []),
+            ]
+        )
+        return [
+            c.FireEvent(event=GoToEvent(url=f"/sonos/edit?{query}")),
+        ]
+
+    def build_sonos_page_components(
+        self,
+        toast: Optional[str] = None,
+        toast_message: Optional[str] = None,
+        error_message: Optional[str] = None,
+    ) -> List[AnyComponent]:
+        selected_group = self._get_selected_group()
+        status: Optional[SonosSelectionStatus] = None
+        speakers: list[DiscoveredSonosSpeaker] = []
+        discovery_error = error_message
+
+        try:
+            status = GetSonosSelectionStatus(
+                selected_group_repository=SettingsSelectedSonosGroupRepository(self.settings_service),
+                sonos_service=self.sonos_service,
+            ).execute()
+            speakers = self.sonos_service.list_available_speakers()
+        except SonosDiscoveryError as err:
+            discovery_error = str(err)
+
+        components: list[AnyComponent] = [
+            c.Heading(text="Sonos Speakers", level=1),
+            c.Div(
+                class_name="d-flex flex-wrap gap-3 mb-4",
+                components=[
+                    c.Link(components=[c.Text(text="Back to Library")], on_click=GoToEvent(url="/")),
+                    c.Link(components=[c.Text(text="Back to Settings")], on_click=GoToEvent(url="/settings")),
+                ],
+            ),
+        ]
+
+        if discovery_error:
+            components.append(
+                c.Error(
+                    title="Sonos discovery unavailable",
+                    description=discovery_error,
+                )
+            )
+
+        components.extend(self._build_saved_selection_components(status=status, selected_group=selected_group))
+
+        action_components: list[AnyComponent] = [
+            c.Button(text="Edit selection", on_click=GoToEvent(url="/sonos/edit")),
+        ]
+        if selected_group is not None:
+            action_components.append(self._build_reset_form(button_text="Clear saved selection"))
+        components.append(
+            c.Div(
+                class_name="d-flex flex-wrap gap-2 mb-4",
+                components=action_components,
+            )
+        )
+
+        if discovery_error is None:
+            components.extend(
+                self._build_discovered_speakers_components(speakers=speakers, selected_group=selected_group)
+            )
+
+        components.append(
+            c.Toast(
+                title="Toast",
+                body=[c.Paragraph(text=toast_message or "Sonos settings saved.")],
+                open_trigger=PageEvent(name="toast-sonos-success"),
+                position="bottom-end",
+            )
+        )
+
+        page_components: list[AnyComponent] = [c.Page(components=components)]
+        if toast == "toast-sonos-success":
+            page_components.append(c.FireEvent(event=PageEvent(name=toast)))
+
+        return page_components
+
+    def build_sonos_edit_page_components(
+        self,
+        error_message: Optional[str] = None,
+        field_errors: Optional[dict[str, str]] = None,
+        submitted_uids: Optional[List[str]] = None,
+        submitted_coordinator_uid: Optional[str] = None,
+    ) -> List[AnyComponent]:
+        selected_group = self._get_selected_group()
+        components: list[AnyComponent] = [
+            c.Heading(text="Edit Sonos Selection", level=1),
+            c.Paragraph(
+                text="Choose one or more visible speakers and select the coordinator used for playback.",
+                class_name="mb-3",
+            ),
+        ]
+
+        try:
+            speakers = self.sonos_service.list_available_speakers()
+        except SonosDiscoveryError as err:
+            components.append(
+                c.Error(
+                    title="Sonos discovery unavailable",
+                    description=error_message or str(err),
+                )
+            )
+            components.extend(self._build_navigation_links())
+            return [c.Page(components=components)]
+
+        if not speakers:
+            components.append(
+                c.Error(
+                    title="No Sonos speakers found",
+                    description="No visible Sonos speakers are currently discoverable on the network.",
+                )
+            )
+            components.extend(self._build_navigation_links())
+            return [c.Page(components=components)]
+
+        components.append(
+            c.Div(
+                class_name="border rounded p-3 mb-4",
+                components=[
+                    c.Heading(text="Selection", level=3),
+                    *self._build_edit_error_components(error_message),
+                    *self._build_edit_saved_selection_components(selected_group, speakers),
+                    c.Paragraph(text="Changes take effect after restart.", class_name="mb-3"),
+                    self._build_selection_form(
+                        speakers=speakers,
+                        selected_group=selected_group,
+                        field_errors=field_errors,
+                        submitted_uids=submitted_uids,
+                        submitted_coordinator_uid=submitted_coordinator_uid,
+                    ),
+                ],
+            )
+        )
+
+        components.extend(self._build_navigation_links())
+        return [c.Page(components=components)]
+
+    def _build_edit_error_components(self, error_message: Optional[str]) -> list[AnyComponent]:
+        if not error_message:
+            return []
+
+        return [
+            c.Div(
+                class_name="alert alert-danger mb-3",
+                components=[
+                    c.Paragraph(text="Selection not saved", class_name="fw-semibold mb-1"),
+                    c.Paragraph(text=error_message, class_name="mb-0"),
+                ],
+            )
+        ]
+
+    def _build_edit_saved_selection_components(
+        self,
+        selected_group: Optional[SelectedSonosGroupSettings],
+        speakers: list[DiscoveredSonosSpeaker],
+    ) -> list[AnyComponent]:
+        if selected_group is None:
+            return []
+
+        speakers_by_uid = {speaker.uid: speaker for speaker in speakers}
+        coordinator = speakers_by_uid.get(selected_group.coordinator_uid)
+        coordinator_label = (
+            "{} [{}]".format(coordinator.name, coordinator.uid)
+            if coordinator is not None
+            else selected_group.coordinator_uid
+        )
+        member_labels = [
+            "{} [{}]".format(speakers_by_uid[member.uid].name, member.uid)
+            if member.uid in speakers_by_uid
+            else member.uid
+            for member in selected_group.members
+        ]
+
+        return [
+            c.Div(
+                class_name="bg-light-subtle border rounded p-3 mb-3",
+                components=[
+                    c.Paragraph(text="Current saved selection", class_name="text-uppercase text-muted small mb-1"),
+                    c.Paragraph(text=f"Coordinator: {coordinator_label}", class_name="mb-1"),
+                    c.Paragraph(text="Members: {}".format(", ".join(member_labels)), class_name="mb-0"),
+                ],
+            )
+        ]
+
+    def _build_selection_form(
+        self,
+        speakers: list[DiscoveredSonosSpeaker],
+        selected_group: Optional[SelectedSonosGroupSettings],
+        field_errors: Optional[dict[str, str]] = None,
+        submitted_uids: Optional[List[str]] = None,
+        submitted_coordinator_uid: Optional[str] = None,
+    ) -> AnyComponent:
+        selected_uids = (
+            list(submitted_uids)
+            if submitted_uids is not None
+            else [member.uid for member in selected_group.members]
+            if selected_group is not None
+            else []
+        )
+        available_uids = {speaker.uid for speaker in speakers}
+        initial_uids = [uid for uid in selected_uids if uid in available_uids]
+        if submitted_uids is None and not initial_uids and speakers:
+            initial_uids = [speakers[0].uid]
+
+        if submitted_coordinator_uid is not None and submitted_coordinator_uid in available_uids:
+            initial_coordinator_uid = submitted_coordinator_uid
+        elif selected_group is not None and selected_group.coordinator_uid in available_uids:
+            initial_coordinator_uid = selected_group.coordinator_uid
+        else:
+            initial_coordinator_uid = initial_uids[0] if initial_uids else speakers[0].uid
+
+        speaker_options: list[SelectOption] = [
+            {
+                "value": speaker.uid,
+                "label": self._build_speaker_option_label(speaker),
+            }
+            for speaker in speakers
+        ]
+
+        return c.Form(
+            form_fields=[
+                FormFieldSelect(
+                    name="uids",
+                    title="Speakers",
+                    options=speaker_options,
+                    initial=initial_uids,
+                    description="Select the Sonos speakers that should participate in playback.",
+                    required=True,
+                    multiple=True,
+                    error=field_errors.get("uids") if field_errors is not None else None,
+                    vanilla=True,
+                ),
+                FormFieldSelect(
+                    name="coordinator_uid",
+                    title="Coordinator",
+                    options=speaker_options,
+                    initial=initial_coordinator_uid,
+                    description="Choose the speaker that should coordinate the selected group.",
+                    required=True,
+                    error=field_errors.get("coordinator_uid") if field_errors is not None else None,
+                    vanilla=True,
+                ),
+            ],
+            submit_url="/api/ui/sonos/edit",
+            method="POST",
+            footer=[c.Button(text="Save", html_type="submit", class_name="btn btn-primary")],
+        )
+
+    def _build_saved_selection_components(
+        self,
+        status: Optional[SonosSelectionStatus],
+        selected_group: Optional[SelectedSonosGroupSettings],
+    ) -> list[AnyComponent]:
+        if selected_group is None:
+            return [
+                c.Div(
+                    class_name="border rounded p-3 mb-4 bg-light-subtle",
+                    components=[
+                        c.Heading(text="Saved selection", level=3),
+                        c.Paragraph(text="No Sonos speaker selection is currently saved."),
+                    ],
+                )
+            ]
+
+        components: list[AnyComponent] = [
+            c.Heading(text="Saved selection", level=3),
+        ]
+
+        if status is None:
+            components.extend(
+                [
+                    c.Paragraph(text=f"Coordinator: {selected_group.coordinator_uid}"),
+                    c.Paragraph(text="Members: {}".format(", ".join(member.uid for member in selected_group.members))),
+                ]
+            )
+        else:
+            status_label = {
+                "available": "Available",
+                "partial": "Partially available",
+                "unavailable": "Unavailable",
+                "not_selected": "Not selected",
+            }.get(status.availability.status, status.availability.status)
+            coordinator_label = self._format_saved_coordinator(status)
+            components.append(c.Paragraph(text=f"Status: {status_label}"))
+            components.append(c.Paragraph(text=f"Coordinator: {coordinator_label}"))
+            components.append(
+                c.Paragraph(
+                    text="Members: {}".format(
+                        ", ".join(self._format_status_member(member) for member in status.availability.members)
+                    )
+                )
+            )
+
+        return [
+            c.Div(
+                class_name="border rounded p-3 mb-4 bg-light-subtle",
+                components=components,
+            )
+        ]
+
+    def _build_discovered_speakers_components(
+        self,
+        speakers: list[DiscoveredSonosSpeaker],
+        selected_group: Optional[SelectedSonosGroupSettings],
+    ) -> list[AnyComponent]:
+        if not speakers:
+            return [
+                c.Div(
+                    class_name="border rounded p-3 mb-4",
+                    components=[
+                        c.Heading(text="Discovered speakers", level=3),
+                        c.Paragraph(text="No visible Sonos speakers found."),
+                    ],
+                )
+            ]
+
+        selected_uids = {member.uid for member in selected_group.members} if selected_group is not None else set()
+        coordinator_uid = selected_group.coordinator_uid if selected_group is not None else None
+
+        return [
+            c.Heading(text="Discovered speakers", level=2),
+            c.Div(
+                class_name="border rounded overflow-hidden mb-4",
+                components=[
+                    self._build_speaker_header(),
+                    *[
+                        self._build_speaker_row(
+                            speaker=speaker,
+                            is_selected=speaker.uid in selected_uids,
+                            is_coordinator=speaker.uid == coordinator_uid,
+                        )
+                        for speaker in speakers
+                    ],
+                ],
+            ),
+        ]
+
+    def _build_speaker_header(self) -> AnyComponent:
+        return c.Div(
+            class_name="d-none d-lg-block px-3 py-2 bg-light-subtle",
+            components=[
+                c.Div(
+                    class_name="row g-2 align-items-center",
+                    components=[
+                        self._build_speaker_header_cell("Name", "col-lg-3"),
+                        self._build_speaker_header_cell("Host", "col-lg-3"),
+                        self._build_speaker_header_cell("Household", "col-lg-4"),
+                        self._build_speaker_header_cell("Selection", "col-lg-2 text-lg-center"),
+                    ],
+                )
+            ],
+        )
+
+    def _build_speaker_row(
+        self,
+        speaker: DiscoveredSonosSpeaker,
+        is_selected: bool,
+        is_coordinator: bool,
+    ) -> AnyComponent:
+        selection_label = "Coordinator" if is_coordinator else "Selected" if is_selected else "Available"
+        return c.Div(
+            class_name="px-3 py-2 border-top",
+            components=[
+                c.Div(
+                    class_name="row g-2 align-items-center",
+                    components=[
+                        self._build_speaker_value_cell("Name", speaker.name, "col-12 col-lg-3"),
+                        self._build_speaker_value_cell("Host", speaker.host, "col-12 col-lg-3"),
+                        self._build_speaker_value_cell("Household", speaker.household_id, "col-12 col-lg-4"),
+                        self._build_speaker_value_cell(
+                            "Selection",
+                            selection_label,
+                            "col-12 col-lg-2 text-lg-center",
+                        ),
+                    ],
+                )
+            ],
+        )
+
+    def _build_speaker_header_cell(self, label: str, class_name: str) -> AnyComponent:
+        return c.Div(
+            class_name=f"{class_name} d-flex align-items-center",
+            components=[
+                c.Paragraph(text=label, class_name="text-uppercase text-muted small fw-semibold mb-0"),
+            ],
+        )
+
+    def _build_speaker_value_cell(self, label: str, value: str, class_name: str) -> AnyComponent:
+        return c.Div(
+            class_name=class_name,
+            components=[
+                c.Paragraph(text=label, class_name="d-lg-none text-uppercase text-muted small fw-semibold mb-1"),
+                c.Paragraph(text=value, class_name="mb-0 text-break"),
+            ],
+        )
+
+    def _build_navigation_links(self) -> list[AnyComponent]:
+        return [
+            c.Div(
+                class_name="mt-3 d-flex flex-wrap gap-3",
+                components=[
+                    c.Link(components=[c.Text(text="Back to Sonos")], on_click=GoToEvent(url="/sonos")),
+                    c.Link(components=[c.Text(text="Back to Settings")], on_click=GoToEvent(url="/settings")),
+                    c.Link(components=[c.Text(text="Back to Library")], on_click=GoToEvent(url="/")),
+                ],
+            )
+        ]
+
+    def _build_reset_form(self, button_text: str) -> AnyComponent:
+        return c.Form(
+            form_fields=[],
+            submit_url="/api/ui/sonos/reset",
+            method="POST",
+            footer=[
+                c.Button(
+                    text=button_text,
+                    html_type="submit",
+                    class_name="btn btn-outline-danger text-nowrap px-3",
+                )
+            ],
+        )
+
+    def _get_selected_group(self) -> Optional[SelectedSonosGroupSettings]:
+        return SettingsSelectedSonosGroupRepository(self.settings_service).get_selected_group()
+
+    @staticmethod
+    def _build_speaker_option_label(speaker: DiscoveredSonosSpeaker) -> str:
+        return "{} ({})".format(speaker.name, speaker.host)
+
+    @staticmethod
+    def _format_status_member(member) -> str:
+        if member.speaker is not None:
+            return "{} [{}]".format(member.speaker.name, member.uid)
+        return "{} [unavailable]".format(member.uid)
+
+    @staticmethod
+    def _format_saved_coordinator(status: SonosSelectionStatus) -> str:
+        if status.selected_group is None:
+            return "unknown"
+
+        for member in status.availability.members:
+            if member.uid == status.selected_group.coordinator_uid and member.speaker is not None:
+                return "{} [{}]".format(member.speaker.name, member.uid)
+        return status.selected_group.coordinator_uid

--- a/tests/discstore/adapters/inbound/test_ui_controller.py
+++ b/tests/discstore/adapters/inbound/test_ui_controller.py
@@ -7,6 +7,18 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 
+def build_speaker(uid, name, host, household_id):
+    from jukebox.sonos.discovery import DiscoveredSonosSpeaker
+
+    return DiscoveredSonosSpeaker(
+        uid=uid,
+        name=name,
+        host=host,
+        household_id=household_id,
+        is_visible=True,
+    )
+
+
 def test_module_import_failure():
     version_below_py37 = (3, 7, 17, "final", 0)
     with mock.patch("sys.version_info", version_below_py37), pytest.raises(RuntimeError) as err:
@@ -31,6 +43,7 @@ def test_dependencies_import_failure(mocker):
 
 def build_controller():
     from discstore.adapters.inbound.ui_controller import UIController
+    from jukebox.sonos.service import InspectedSelectedSonosGroup
 
     settings_service = MagicMock()
     sonos_service = MagicMock()
@@ -94,6 +107,16 @@ def build_controller():
         "derived": {},
         "change_metadata": {},
     }
+    sonos_service.list_available_speakers.return_value = [
+        build_speaker(uid="speaker-1", name="Kitchen", host="192.168.1.30", household_id="household-1"),
+        build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31", household_id="household-1"),
+    ]
+    sonos_service.inspect_selected_group.return_value = InspectedSelectedSonosGroup(
+        coordinator=sonos_service.list_available_speakers.return_value[1],
+        resolved_members=list(sonos_service.list_available_speakers.return_value),
+        missing_member_uids=[],
+        error_message=None,
+    )
 
     return UIController(
         add_disc=MagicMock(),
@@ -156,6 +179,10 @@ def test_ui_controller_registers_fastui_routes_and_page_structure():
     assert ("/api/ui/settings/{setting_path}/edit", ("GET",)) in route_index
     assert ("/api/ui/settings/{setting_path}", ("POST",)) in route_index
     assert ("/api/ui/settings/{setting_path}/reset", ("POST",)) in route_index
+    assert ("/api/ui/sonos", ("GET",)) in route_index
+    assert ("/api/ui/sonos/edit", ("GET",)) in route_index
+    assert ("/api/ui/sonos/edit", ("POST",)) in route_index
+    assert ("/api/ui/sonos/reset", ("POST",)) in route_index
     assert ("/api/v1/discs", ("GET",)) in route_index
     assert ("/api/v1/discs/{tag_id}", ("GET",)) in route_index
     assert ("/api/v1/discs/{tag_id}", ("POST",)) in route_index
@@ -172,6 +199,11 @@ def test_ui_controller_registers_fastui_routes_and_page_structure():
         for component in all_components
         if component.type == "Button" and component.text == "➕ Add a new disc"
     )
+    sonos_button = next(
+        component
+        for component in all_components
+        if component.type == "Button" and component.text == "🔊 Sonos Speakers"
+    )
     settings_button = next(
         component for component in all_components if component.type == "Button" and component.text == "⚙️ Settings"
     )
@@ -186,6 +218,8 @@ def test_ui_controller_registers_fastui_routes_and_page_structure():
     assert server_load.sse is True
     assert add_button.on_click.type == "go-to"
     assert add_button.on_click.url == "/discs/new"
+    assert sonos_button.on_click.type == "go-to"
+    assert sonos_button.on_click.url == "/sonos"
     assert settings_button.on_click.type == "go-to"
     assert settings_button.on_click.url == "/settings"
     assert edit_button.on_click.type == "go-to"
@@ -261,6 +295,11 @@ def test_settings_page_groups_entries_and_shows_persisted_and_effective_values()
     assert any(component.type == "Heading" and component.text == "Admin" for component in all_components)
     assert any(component.type == "Heading" and component.text == "Player" for component in all_components)
     assert any(component.type == "Button" and component.text == "Edit ✏️" for component in all_components)
+    manage_speakers_button = next(
+        component
+        for component in all_components
+        if component.type == "Button" and component.text == "Manage Speakers 🔊"
+    )
     assert any(component.type == "Paragraph" and component.text == "Persisted override" for component in all_components)
     assert any(component.type == "Paragraph" and component.text == "8100" for component in all_components)
     assert any(component.type == "Paragraph" and component.text == "8000" for component in all_components)
@@ -273,6 +312,8 @@ def test_settings_page_groups_entries_and_shows_persisted_and_effective_values()
         component.type == "Paragraph" and component.text == "speaker-2 (coordinator); members: speaker-1, speaker-2"
         for component in all_components
     )
+    assert manage_speakers_button.on_click.url == "/sonos"
+    assert "text-nowrap" in manage_speakers_button.class_name
     assert not any(component.type == "Button" and component.text == "Reset" for component in all_components)
     assert page[1].event.name == "toast-settings-success"
 
@@ -343,6 +384,283 @@ def test_settings_edit_pages_render_select_text_and_json_fields():
     assert reset_form.method == "POST"
     assert reset_form.footer[0].type == "Button"
     assert reset_form.footer[0].text == "Reset"
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
+    reason="FastUI dependencies are not installed",
+)
+def test_sonos_page_renders_saved_selection_and_discovered_speakers():
+    controller = build_controller()
+    route = next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/ui/sonos")
+
+    page = route.endpoint(toast="toast-sonos-success", toast_message="Sonos settings saved.")
+    all_components = list(walk_components(page[0].components))
+
+    assert any(component.type == "Heading" and component.text == "Sonos Speakers" for component in all_components)
+    assert any(component.type == "Heading" and component.text == "Saved selection" for component in all_components)
+    assert any(component.type == "Paragraph" and component.text == "Status: Available" for component in all_components)
+    assert any(
+        component.type == "Paragraph" and component.text == "Coordinator: Living Room [speaker-2]"
+        for component in all_components
+    )
+    assert any(
+        component.type == "Paragraph" and component.text == "Members: Kitchen [speaker-1], Living Room [speaker-2]"
+        for component in all_components
+    )
+    assert any(component.type == "Heading" and component.text == "Discovered speakers" for component in all_components)
+    assert any(component.type == "Paragraph" and component.text == "Kitchen" for component in all_components)
+    assert any(component.type == "Paragraph" and component.text == "Living Room" for component in all_components)
+    assert any(component.type == "Paragraph" and component.text == "Coordinator" for component in all_components)
+    assert any(component.type == "Paragraph" and component.text == "Selected" for component in all_components)
+    assert page[1].event.name == "toast-sonos-success"
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
+    reason="FastUI dependencies are not installed",
+)
+def test_sonos_edit_page_renders_speaker_and_coordinator_selects():
+    controller = build_controller()
+    route = next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/ui/sonos/edit")
+
+    page = route.endpoint()[0]
+    form = next(component for component in walk_components(page.components) if component.type == "Form")
+    speakers_field = form.form_fields[0]
+    coordinator_field = form.form_fields[1]
+
+    assert page.components[0].text == "Edit Sonos Selection"
+    assert not any(
+        component.type == "Heading" and component.text == "Saved selection"
+        for component in walk_components(page.components)
+    )
+    assert any(
+        component.type == "Paragraph" and component.text == "Current saved selection"
+        for component in walk_components(page.components)
+    )
+    assert any(
+        component.type == "Paragraph" and component.text == "Coordinator: Living Room [speaker-2]"
+        for component in walk_components(page.components)
+    )
+    assert speakers_field.type == "FormFieldSelect"
+    assert speakers_field.name == "uids"
+    assert speakers_field.multiple is True
+    assert speakers_field.initial == ["speaker-1", "speaker-2"]
+    assert speakers_field.options == [
+        {"value": "speaker-1", "label": "Kitchen (192.168.1.30)"},
+        {"value": "speaker-2", "label": "Living Room (192.168.1.31)"},
+    ]
+    assert coordinator_field.type == "FormFieldSelect"
+    assert coordinator_field.name == "coordinator_uid"
+    assert coordinator_field.initial == "speaker-2"
+    assert form.submit_url == "/api/ui/sonos/edit"
+    assert form.method == "POST"
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
+    reason="FastUI dependencies are not installed",
+)
+@pytest.mark.anyio
+async def test_update_sonos_selection_saves_and_redirects():
+    from discstore.adapters.inbound.ui_controller import SonosSelectionForm
+
+    controller = build_controller()
+    controller.settings_service.patch_persisted_settings.return_value = {
+        "message": "Settings saved. Changes take effect after restart."
+    }
+    route = next(
+        route
+        for route in controller.app.routes
+        if getattr(route, "path", None) == "/api/ui/sonos/edit" and "POST" in route.methods
+    )
+
+    response = await route.endpoint(SonosSelectionForm(uids=["speaker-1", "speaker-2"], coordinator_uid="speaker-2"))
+
+    controller.settings_service.patch_persisted_settings.assert_called_once_with(
+        {
+            "jukebox": {
+                "player": {
+                    "type": "sonos",
+                    "sonos": {
+                        "selected_group": {
+                            "coordinator_uid": "speaker-2",
+                            "members": [{"uid": "speaker-1"}, {"uid": "speaker-2"}],
+                        }
+                    },
+                }
+            }
+        }
+    )
+    assert response[0].type == "FireEvent"
+    assert response[0].event.url.startswith("/sonos?")
+    assert "toast=toast-sonos-success" in response[0].event.url
+    assert "Changes+take+effect+after+restart." in response[0].event.url
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
+    reason="FastUI dependencies are not installed",
+)
+@pytest.mark.anyio
+async def test_update_sonos_selection_returns_field_error_for_invalid_coordinator():
+    from discstore.adapters.inbound.ui_controller import SonosSelectionForm
+
+    controller = build_controller()
+    route = next(
+        route
+        for route in controller.app.routes
+        if getattr(route, "path", None) == "/api/ui/sonos/edit" and "POST" in route.methods
+    )
+
+    response = await route.endpoint(SonosSelectionForm(uids=["speaker-1"], coordinator_uid="speaker-2"))
+
+    assert response[0].type == "FireEvent"
+    assert response[0].event.url.startswith("/sonos/edit?")
+    assert (
+        "error_message=Selected+Sonos+coordinator+must+be+one+of+the+selected+speakers%3A+Living+Room+%5Bspeaker-2%5D"
+        in response[0].event.url
+    )
+    assert "uids=speaker-1" in response[0].event.url
+    assert "coordinator_uid=speaker-2" in response[0].event.url
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
+    reason="FastUI dependencies are not installed",
+)
+def test_sonos_edit_page_renders_error_banner_and_preserves_submitted_values():
+    controller = build_controller()
+    route = next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/ui/sonos/edit")
+
+    page = route.endpoint(
+        error_message="Selected Sonos coordinator must be one of the selected speakers: Living Room [speaker-2]",
+        uids=["speaker-1"],
+        coordinator_uid="speaker-2",
+    )[0]
+    all_components = list(walk_components(page.components))
+    form = next(component for component in all_components if component.type == "Form")
+    speakers_field = form.form_fields[0]
+    coordinator_field = form.form_fields[1]
+
+    assert any(
+        component.type == "Paragraph" and component.text == "Selection not saved" for component in all_components
+    )
+    assert any(
+        component.type == "Paragraph"
+        and component.text == "Selected Sonos coordinator must be one of the selected speakers: Living Room [speaker-2]"
+        for component in all_components
+    )
+    assert speakers_field.initial == ["speaker-1"]
+    assert speakers_field.error is None
+    assert coordinator_field.initial == "speaker-2"
+    assert (
+        coordinator_field.error
+        == "Selected Sonos coordinator must be one of the selected speakers: Living Room [speaker-2]"
+    )
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
+    reason="FastUI dependencies are not installed",
+)
+@pytest.mark.anyio
+async def test_update_sonos_selection_saves_single_speaker_selection():
+    from discstore.adapters.inbound.ui_controller import SonosSelectionForm
+
+    controller = build_controller()
+    controller.settings_service.patch_persisted_settings.return_value = {"message": "Settings saved."}
+    route = next(
+        route
+        for route in controller.app.routes
+        if getattr(route, "path", None) == "/api/ui/sonos/edit" and "POST" in route.methods
+    )
+
+    response = await route.endpoint(SonosSelectionForm(uids="speaker-1", coordinator_uid="speaker-1"))
+
+    controller.settings_service.patch_persisted_settings.assert_called_once_with(
+        {
+            "jukebox": {
+                "player": {
+                    "type": "sonos",
+                    "sonos": {
+                        "selected_group": {
+                            "coordinator_uid": "speaker-1",
+                            "members": [{"uid": "speaker-1"}],
+                        }
+                    },
+                }
+            }
+        }
+    )
+    assert response[0].type == "FireEvent"
+    assert response[0].event.url.startswith("/sonos?")
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
+    reason="FastUI dependencies are not installed",
+)
+@pytest.mark.anyio
+async def test_update_sonos_selection_redirects_when_write_succeeds_but_effective_settings_stay_invalid():
+    from discstore.adapters.inbound.ui_controller import SonosSelectionForm
+    from jukebox.settings.errors import InvalidSettingsError
+
+    controller = build_controller()
+
+    def raise_after_persist(patch):
+        del patch
+        controller.settings_service.get_persisted_settings_view.return_value = {
+            "schema_version": 1,
+            "jukebox": {
+                "player": {
+                    "type": "sonos",
+                    "sonos": {
+                        "selected_group": {
+                            "coordinator_uid": "speaker-2",
+                            "members": [{"uid": "speaker-1"}, {"uid": "speaker-2"}],
+                        }
+                    },
+                }
+            },
+        }
+        raise InvalidSettingsError("Invalid effective settings after environment overrides.")
+
+    controller.settings_service.patch_persisted_settings.side_effect = raise_after_persist
+    route = next(
+        route
+        for route in controller.app.routes
+        if getattr(route, "path", None) == "/api/ui/sonos/edit" and "POST" in route.methods
+    )
+
+    response = await route.endpoint(SonosSelectionForm(uids=["speaker-1", "speaker-2"], coordinator_uid="speaker-2"))
+
+    assert response[0].type == "FireEvent"
+    assert response[0].event.url.startswith("/sonos?")
+    assert "toast=toast-sonos-success" in response[0].event.url
+    assert "effective+settings+are+still+unavailable" in response[0].event.url
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
+    reason="FastUI dependencies are not installed",
+)
+@pytest.mark.anyio
+async def test_reset_sonos_selection_calls_service_and_redirects():
+    controller = build_controller()
+    controller.settings_service.reset_persisted_value.return_value = {"message": "Settings saved."}
+    route = next(
+        route
+        for route in controller.app.routes
+        if getattr(route, "path", None) == "/api/ui/sonos/reset" and "POST" in route.methods
+    )
+
+    response = await route.endpoint()
+
+    controller.settings_service.reset_persisted_value.assert_called_once_with("jukebox.player.sonos.selected_group")
+    assert response[0].type == "FireEvent"
+    assert response[0].event.url.startswith("/sonos?")
+    assert "toast=toast-sonos-success" in response[0].event.url
 
 
 @pytest.mark.skipif(

--- a/tests/jukebox/settings/test_selected_sonos_group_repository.py
+++ b/tests/jukebox/settings/test_selected_sonos_group_repository.py
@@ -36,9 +36,6 @@ class StubSettingsService:
     def get_effective_settings(self) -> AppSettings:
         raise AssertionError("get_effective_settings should not be called in this test")
 
-    def format_invalid_settings_error(self, error: str) -> str:
-        raise AssertionError("format_invalid_settings_error should not be called in this test")
-
     def set_persisted_value(self, dotted_path: str, raw_value: str) -> JsonObject:
         raise AssertionError("set_persisted_value should not be called in this test")
 
@@ -51,6 +48,9 @@ class StubSettingsService:
 
     def resolve_admin_runtime(self, verbose: bool = False) -> ResolvedAdminRuntimeConfig:
         raise AssertionError("resolve_admin_runtime should not be called in this test")
+
+    def format_invalid_settings_error(self, error: str) -> str:
+        raise AssertionError("format_invalid_settings_error should not be called in this test")
 
 
 def test_get_selected_group_returns_none_when_not_persisted():


### PR DESCRIPTION
Closes #128 and #129.

## Summary

Adds a dedicated FastUI admin flow for managing the saved Sonos speaker selection.

This includes:

- a Sonos overview page showing the saved selection and currently discovered speakers
- a Sonos edit page for selecting speakers and coordinator in one form
- a reset flow for clearing the saved selection
- entry points from the library home page and the settings page

## Stack context

This branch is stacked on unmerged work already under review:

- `chore/ui-controller-refactor`
- `feature/sonos-speaker-selection-on-refactor`
- `feature/sonos-multi-speaker-selection-on-refactor`

Because I can only open PRs against `main`, GitHub will show the full stacked diff.

## What is new in this layer

Please review the delta from:

`20a8aa3..c58b6d3`

That range contains the actual Sonos admin UI work added in this PR.

## Notes

- The UI stays within the existing FastUI admin patterns used for library/settings.
- Sonos validation remains server-side.
- FastUI's stock prebuilt frontend does not visibly render select-field inline errors reliably, so invalid Sonos form submissions redirect back to the edit page with a compact in-card error message and preserved form values.
