### PR TITLE
👷 scope deployment secrets to prod environment

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -28,6 +28,7 @@ jobs:
   bump:
     name: Bump Version
     runs-on: ubuntu-latest
+    environment: prod
     outputs:
       version: ${{ steps.version.outputs.version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
   build-and-publish:
     name: Build & Publish to PyPI
     runs-on: ubuntu-latest
+    environment: prod
     outputs:
       is_stable: ${{ steps.check-stable.outputs.is_stable }}
     if: |


### PR DESCRIPTION
## Summary

Scope deployment secrets to the `prod` GitHub environment in both `bump-version.yml` and `release.yml`.

## Why

Without an environment, repository secrets are accessible to any workflow file, meaning a contributor with write access could exfiltrate them by simply editing a workflow to print or forward the secret value.

By moving secrets to a protected GitHub environment, access is gated by that environment's protection rules (required reviewers, branch restrictions), regardless of what a workflow file says.

PyPI must be configured with a trusted publisher whose scope is limited to the production environment, otherwise, any workflow could push a version of the package.

## Prerequisites 

- [x] The protection rules must be configured in **Settings** > **Environments** > **prod**:
  - Required reviewers
  - Deployment branches restricted to `main`
- [x] Variables must be created in the environment and **REMOVED from the repository secrets**.
- [x] Add a _trusted publisher_ to PyPI by restricting the environment to `prod` and **REMOVE the _trusted publisher_ without any environment restrictions** (**Your account** > **gukebox** > **Publishing**). 

## Test 

#209
