### PR TITLE
💥🗑️ remove deprecated features

### DIFF
--- a/discstore/app.py
+++ b/discstore/app.py
@@ -30,7 +30,6 @@ def _build_settings_service(config: DiscStoreConfig):
     return build_admin_settings_service(
         library=config.library,
         command=config.command,
-        logger_warning=LOGGER.warning,
     )
 
 
@@ -42,7 +41,6 @@ def main():
             services = build_admin_services(
                 library=config.library,
                 command=config.command,
-                logger_warning=LOGGER.warning,
             )
             try:
                 if is_settings_command(config.command):

--- a/discstore/commands.py
+++ b/discstore/commands.py
@@ -1,10 +1,5 @@
 from enum import Enum
-from typing import Optional, Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
+from typing import Literal, Optional, Union
 
 from pydantic import BaseModel, model_validator
 

--- a/jukebox/adapters/inbound/config.py
+++ b/jukebox/adapters/inbound/config.py
@@ -1,5 +1,4 @@
 import argparse
-import sys
 from typing import Optional
 
 try:
@@ -39,20 +38,17 @@ def parse_config() -> JukeboxCliConfig:
     add_verbose_arg(parser)
     add_version_arg(parser)
 
-    parser.add_argument("positional_player", nargs="?", choices=["dryrun", "sonos"], help="override the player type")
-    parser.add_argument("positional_reader", nargs="?", choices=["dryrun", "pn532"], help="override the reader type")
-
     parser.add_argument(
         "--player",
         choices=["dryrun", "sonos"],
         default=None,
-        help="override the player type without providing both positional type arguments",
+        help="override the player type for this process",
     )
     parser.add_argument(
         "--reader",
         choices=["dryrun", "pn532"],
         default=None,
-        help="override the reader type without providing both positional type arguments",
+        help="override the reader type for this process",
     )
 
     sonos_target_group = parser.add_mutually_exclusive_group()
@@ -82,17 +78,11 @@ def parse_config() -> JukeboxCliConfig:
 
     args = parser.parse_args()
 
-    if args.positional_player is not None or args.positional_reader is not None:
-        print(
-            "warning: positional player/reader arguments are deprecated; use --player/--reader instead",
-            file=sys.stderr,
-        )
-
     return JukeboxCliConfig(
         library=args.library,
         verbose=args.verbose,
-        player=args.player or args.positional_player,
-        reader=args.reader or args.positional_reader,
+        player=args.player,
+        reader=args.reader,
         sonos_host=args.sonos_host,
         sonos_name=args.sonos_name,
         pause_duration_seconds=args.pause_duration,

--- a/jukebox/adapters/inbound/config.py
+++ b/jukebox/adapters/inbound/config.py
@@ -1,10 +1,5 @@
 import argparse
-from typing import Optional
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
+from typing import Literal, Optional
 
 from pydantic import BaseModel
 

--- a/jukebox/admin/app.py
+++ b/jukebox/admin/app.py
@@ -1,4 +1,3 @@
-import logging
 import traceback
 from typing import Annotated, Optional
 
@@ -38,8 +37,6 @@ from .commands import (
 )
 from .di_container import build_admin_api_app, build_admin_services, build_admin_ui_app, build_settings_service
 
-LOGGER = logging.getLogger("jukebox-admin")
-
 
 class AdminCliState:
     def __init__(self, library: Optional[str], verbose: bool):
@@ -67,7 +64,6 @@ def _run_command(ctx: typer.Context, command: object) -> None:
         services = build_admin_services(
             library=state.library,
             command=command,
-            logger_warning=LOGGER.warning,
         )
         try:
             if is_settings_command(command):
@@ -123,7 +119,6 @@ def _run_library_command(ctx: typer.Context, command: object) -> None:
         settings_service = build_settings_service(
             library=state.library,
             command=command,
-            logger_warning=LOGGER.warning,
         )
         try:
             execute_library_command(

--- a/jukebox/admin/commands.py
+++ b/jukebox/admin/commands.py
@@ -1,9 +1,4 @@
-from typing import Optional, Union
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
+from typing import Literal, Optional, Union
 
 from pydantic import BaseModel, model_validator
 

--- a/jukebox/admin/di_container.py
+++ b/jukebox/admin/di_container.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional
+from typing import Optional
 
 from discstore.adapters.outbound.json_library_adapter import JsonLibraryAdapter
 from discstore.adapters.outbound.text_current_tag_adapter import TextCurrentTagAdapter
@@ -23,7 +23,6 @@ from .services import AdminServices
 def build_settings_service(
     library: Optional[str],
     command: Optional[object],
-    logger_warning: Callable[[str], None],
 ) -> SettingsService:
     cli_overrides = {}
 
@@ -38,7 +37,7 @@ def build_settings_service(
 
     return SettingsServiceImpl(
         repository=FileSettingsRepository(),
-        env_overrides=build_environment_settings_overrides(logger_warning),
+        env_overrides=build_environment_settings_overrides(),
         cli_overrides=cli_overrides,
     )
 
@@ -46,13 +45,11 @@ def build_settings_service(
 def build_admin_services(
     library: Optional[str],
     command: Optional[object],
-    logger_warning: Callable[[str], None],
 ) -> AdminServices:
     sonos_service = build_sonos_service()
     settings_service = build_settings_service(
         library=library,
         command=command,
-        logger_warning=logger_warning,
     )
     return AdminServices(settings=settings_service, sonos=sonos_service)
 

--- a/jukebox/app.py
+++ b/jukebox/app.py
@@ -50,7 +50,7 @@ def _build_settings_service(config: JukeboxCliConfig) -> SettingsService:
 
     return SettingsService(
         repository=FileSettingsRepository(),
-        env_overrides=build_environment_settings_overrides(LOGGER.warning),
+        env_overrides=build_environment_settings_overrides(),
         cli_overrides=cli_overrides,
     )
 

--- a/jukebox/settings/entities.py
+++ b/jukebox/settings/entities.py
@@ -1,10 +1,5 @@
 import os
-from typing import Optional
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
+from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 

--- a/jukebox/settings/resolve.py
+++ b/jukebox/settings/resolve.py
@@ -1,11 +1,11 @@
 import copy
 import json
 import os
-from typing import Callable, Optional, Union, cast
+from typing import Optional, Union, cast
 
 from pydantic import ValidationError
 
-from jukebox.shared.config_utils import get_current_tag_path, get_deprecated_env_with_warning
+from jukebox.shared.config_utils import get_current_tag_path
 
 from .definitions import (
     build_settings_metadata_tree,
@@ -29,24 +29,14 @@ from .validation_rules import validate_settings_rules
 _MISSING = object()
 
 
-def build_environment_settings_overrides(logger_warning: Callable[[str], None]) -> JsonObject:
+def build_environment_settings_overrides() -> JsonObject:
     overrides = {}
 
-    library_path = get_deprecated_env_with_warning(
-        "JUKEBOX_LIBRARY_PATH",
-        "LIBRARY_PATH",
-        None,
-        logger_warning,
-    )
+    library_path = os.environ.get("JUKEBOX_LIBRARY_PATH")
     if library_path is not None:
         overrides.setdefault("paths", {})["library_path"] = library_path
 
-    sonos_host = get_deprecated_env_with_warning(
-        "JUKEBOX_SONOS_HOST",
-        "SONOS_HOST",
-        None,
-        logger_warning,
-    )
+    sonos_host = os.environ.get("JUKEBOX_SONOS_HOST")
     sonos_name = os.environ.get("JUKEBOX_SONOS_NAME")
     if sonos_host is not None or sonos_name is not None:
         sonos_overrides = overrides.setdefault("jukebox", {}).setdefault("player", {}).setdefault("sonos", {})

--- a/jukebox/shared/config_utils.py
+++ b/jukebox/shared/config_utils.py
@@ -1,7 +1,6 @@
 import argparse
 import os
 from importlib.metadata import PackageNotFoundError, version
-from typing import Callable, Optional
 
 
 def get_package_version(package_name: str = "gukebox") -> str:
@@ -9,18 +8,6 @@ def get_package_version(package_name: str = "gukebox") -> str:
         return version(package_name)
     except PackageNotFoundError:
         return "unknown"
-
-
-def get_deprecated_env_with_warning(
-    new_var: str,
-    deprecated_var: str,
-    default: Optional[str],
-    logger_warning: Callable[[str], None],
-) -> Optional[str]:
-    deprecated_value = os.environ.get(deprecated_var)
-    if deprecated_value:
-        logger_warning(f"The {deprecated_var} environment variable is deprecated, use {new_var} instead.")
-    return os.environ.get(new_var, deprecated_value or default)
 
 
 def get_current_tag_path(library_path: str) -> str:

--- a/jukebox/sonos/selection.py
+++ b/jukebox/sonos/selection.py
@@ -1,9 +1,4 @@
-from typing import Optional, Protocol
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
+from typing import Literal, Optional, Protocol
 
 from pydantic import BaseModel, ConfigDict
 

--- a/tests/discstore/test_discstore_app.py
+++ b/tests/discstore/test_discstore_app.py
@@ -1,4 +1,4 @@
-from unittest.mock import ANY, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -72,7 +72,6 @@ def test_main_delegates_admin_commands_by_category(app_mocks, command, executor_
     app_mocks.build_admin_services.assert_called_once_with(
         library="fake_library_path",
         command=command,
-        logger_warning=ANY,
     )
 
     if executor_name == "execute_settings_command":

--- a/tests/jukebox/adapters/inbound/test_config.py
+++ b/tests/jukebox/adapters/inbound/test_config.py
@@ -12,7 +12,7 @@ def test_parse_config_without_overrides():
     assert config == JukeboxCliConfig()
 
 
-@patch("sys.argv", ["jukebox", "sonos", "pn532", "--sonos-host", "192.168.1.50"])
+@patch("sys.argv", ["jukebox", "--player", "sonos", "--reader", "pn532", "--sonos-host", "192.168.1.50"])
 def test_parse_config_with_player_reader_and_host_overrides():
     config = parse_config()
 
@@ -22,7 +22,7 @@ def test_parse_config_with_player_reader_and_host_overrides():
     assert config.sonos_name is None
 
 
-@patch("sys.argv", ["jukebox", "sonos", "pn532", "--sonos-name", "Living Room"])
+@patch("sys.argv", ["jukebox", "--player", "sonos", "--reader", "pn532", "--sonos-name", "Living Room"])
 def test_parse_config_with_sonos_name_override():
     config = parse_config()
 
@@ -48,37 +48,12 @@ def test_parse_config_with_library_and_verbose_flags():
     assert config.verbose is True
 
 
-@patch("sys.argv", ["jukebox", "dryrun"])
-def test_parse_config_allows_partial_type_overrides(capsys):
-    config = parse_config()
-
-    assert config.player == "dryrun"
-    assert config.reader is None
-    assert (
-        capsys.readouterr().err.strip()
-        == "warning: positional player/reader arguments are deprecated; use --player/--reader instead"
-    )
-
-
 @patch("sys.argv", ["jukebox", "--reader", "pn532"])
-def test_parse_config_allows_reader_only_override_flag(capsys):
+def test_parse_config_allows_reader_only_override_flag():
     config = parse_config()
 
     assert config.player is None
     assert config.reader == "pn532"
-    assert capsys.readouterr().err == ""
-
-
-@patch("sys.argv", ["jukebox", "dryrun", "dryrun", "--reader", "pn532"])
-def test_parse_config_reader_flag_overrides_positional_reader(capsys):
-    config = parse_config()
-
-    assert config.player == "dryrun"
-    assert config.reader == "pn532"
-    assert (
-        capsys.readouterr().err.strip()
-        == "warning: positional player/reader arguments are deprecated; use --player/--reader instead"
-    )
 
 
 @patch("sys.argv", ["jukebox", "--sonos-host", "192.168.1.1", "--sonos-name", "Living Room"])

--- a/tests/jukebox/admin/test_app.py
+++ b/tests/jukebox/admin/test_app.py
@@ -98,7 +98,6 @@ def test_jukebox_admin_routes_admin_commands_by_category(app_mocks, args, expect
     app_mocks.build_admin_services.assert_called_once_with(
         library="/custom/library.json",
         command=expected_command,
-        logger_warning=ANY,
     )
     executor = getattr(app_mocks, executor_name)
     assert executor.call_count == 1

--- a/tests/jukebox/admin/test_di_container.py
+++ b/tests/jukebox/admin/test_di_container.py
@@ -35,7 +35,6 @@ def test_build_settings_service_maps_cli_overrides(command, expected_overrides):
     service = build_settings_service(
         library="/custom/library.json",
         command=command,
-        logger_warning=MagicMock(),
     )
 
     assert isinstance(service, SettingsServiceImpl)
@@ -51,7 +50,6 @@ def test_build_admin_services_builds_peer_settings_and_sonos_services(mocker):
     services = build_admin_services(
         library="/custom/library.json",
         command=SettingsShowCommand(type="settings_show"),
-        logger_warning=MagicMock(),
     )
 
     assert isinstance(services, AdminServices)

--- a/tests/jukebox/settings/test_definitions_consistency.py
+++ b/tests/jukebox/settings/test_definitions_consistency.py
@@ -1,9 +1,4 @@
-from typing import Any, Optional, get_args, get_origin
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
+from typing import Any, Literal, Optional, get_args, get_origin
 
 from pydantic import BaseModel
 

--- a/tests/jukebox/settings/test_environment_settings_overrides.py
+++ b/tests/jukebox/settings/test_environment_settings_overrides.py
@@ -1,72 +1,27 @@
-from unittest.mock import MagicMock
-
 import pytest
 
 from jukebox.settings.resolve import build_environment_settings_overrides
 
 
 def test_build_environment_settings_overrides_reads_current_env_vars():
-    warning = MagicMock()
-
     with pytest.MonkeyPatch.context() as monkeypatch:
         monkeypatch.setenv("JUKEBOX_LIBRARY_PATH", "/env/library.json")
         monkeypatch.setenv("JUKEBOX_SONOS_NAME", "Living Room")
 
-        overrides = build_environment_settings_overrides(warning)
+        overrides = build_environment_settings_overrides()
 
     assert overrides == {
         "paths": {"library_path": "/env/library.json"},
         "jukebox": {"player": {"sonos": {"manual_host": None, "manual_name": "Living Room", "selected_group": None}}},
     }
-    warning.assert_not_called()
-
-
-def test_build_environment_settings_overrides_reads_deprecated_env_vars_with_warning():
-    warning = MagicMock()
-
-    with pytest.MonkeyPatch.context() as monkeypatch:
-        monkeypatch.setenv("LIBRARY_PATH", "/deprecated/library.json")
-        monkeypatch.setenv("SONOS_HOST", "192.168.1.20")
-
-        overrides = build_environment_settings_overrides(warning)
-
-    assert overrides == {
-        "paths": {"library_path": "/deprecated/library.json"},
-        "jukebox": {"player": {"sonos": {"manual_host": "192.168.1.20", "manual_name": None, "selected_group": None}}},
-    }
-    warning.assert_any_call("The LIBRARY_PATH environment variable is deprecated, use JUKEBOX_LIBRARY_PATH instead.")
-    warning.assert_any_call("The SONOS_HOST environment variable is deprecated, use JUKEBOX_SONOS_HOST instead.")
-    assert warning.call_count == 2
-
-
-def test_build_environment_settings_overrides_prefers_current_env_vars_over_deprecated():
-    warning = MagicMock()
-
-    with pytest.MonkeyPatch.context() as monkeypatch:
-        monkeypatch.setenv("JUKEBOX_LIBRARY_PATH", "/current/library.json")
-        monkeypatch.setenv("LIBRARY_PATH", "/deprecated/library.json")
-        monkeypatch.setenv("JUKEBOX_SONOS_HOST", "192.168.1.10")
-        monkeypatch.setenv("SONOS_HOST", "192.168.1.20")
-
-        overrides = build_environment_settings_overrides(warning)
-
-    assert overrides == {
-        "paths": {"library_path": "/current/library.json"},
-        "jukebox": {"player": {"sonos": {"manual_host": "192.168.1.10", "manual_name": None, "selected_group": None}}},
-    }
-    warning.assert_any_call("The LIBRARY_PATH environment variable is deprecated, use JUKEBOX_LIBRARY_PATH instead.")
-    warning.assert_any_call("The SONOS_HOST environment variable is deprecated, use JUKEBOX_SONOS_HOST instead.")
-    assert warning.call_count == 2
 
 
 def test_build_environment_settings_overrides_preserves_conflicting_sonos_target_env_vars():
-    warning = MagicMock()
-
     with pytest.MonkeyPatch.context() as monkeypatch:
         monkeypatch.setenv("JUKEBOX_SONOS_HOST", "192.168.1.20")
         monkeypatch.setenv("JUKEBOX_SONOS_NAME", "Living Room")
 
-        overrides = build_environment_settings_overrides(warning)
+        overrides = build_environment_settings_overrides()
 
     assert overrides == {
         "jukebox": {
@@ -79,4 +34,3 @@ def test_build_environment_settings_overrides_preserves_conflicting_sonos_target
             }
         }
     }
-    warning.assert_not_called()

--- a/tests/jukebox/settings/test_settings_service_runtime_resolution.py
+++ b/tests/jukebox/settings/test_settings_service_runtime_resolution.py
@@ -1,6 +1,5 @@
 import json
 import os
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -96,14 +95,13 @@ def test_settings_service_rejects_conflicting_sonos_target_env_vars(tmp_path):
         json.dumps({"schema_version": 1, "jukebox": {"player": {"type": "sonos"}}}),
         encoding="utf-8",
     )
-    warning = MagicMock()
 
     with pytest.MonkeyPatch.context() as monkeypatch:
         monkeypatch.setenv("JUKEBOX_SONOS_HOST", "192.168.1.20")
         monkeypatch.setenv("JUKEBOX_SONOS_NAME", "Living Room")
         service = SettingsService(
             repository=FileSettingsRepository(str(settings_path)),
-            env_overrides=build_environment_settings_overrides(warning),
+            env_overrides=build_environment_settings_overrides(),
         )
 
     with pytest.raises(InvalidSettingsError, match="manual_host and manual_name are mutually exclusive"):


### PR DESCRIPTION
## Summary 

Parts of #190  

- remove positional player/reader arguments (breaking change)
  replaced by `--player` and `--reader`
- remove unprefixed environment variables (breaking change)
  replaced by `JUKEBOX_` prefixed environment variables
- remove Literal import for Python 3.7
  `jukebox` only supports Python 3.9+

## Non-goals

I'd prefer to handle the decommissioning of discstore in a separate PR