### PR TITLE
♻️ fix asymmetric behavior in current-tag router POST and PATCH handlers

### DIFF
--- a/discstore/adapters/inbound/api/current_tag_router.py
+++ b/discstore/adapters/inbound/api/current_tag_router.py
@@ -92,8 +92,8 @@ def build_current_tag_router(
 
         try:
             new_disc = Disc(**disc.model_dump())
-            add_disc.execute(current_tag_status.tag_id, new_disc)
-            return build_current_tag_disc_output(current_tag_status.tag_id, new_disc)
+            created_disc = add_disc.execute(current_tag_status.tag_id, new_disc)
+            return build_current_tag_disc_output(current_tag_status.tag_id, created_disc)
         except ValueError as value_err:
             raise HTTPException(status_code=409, detail=str(value_err))
         except Exception as err:
@@ -127,8 +127,8 @@ def build_current_tag_router(
             if disc_patch.option is not None:
                 option = DiscOption(**disc_patch.option.model_dump(exclude_unset=True, exclude_none=True))
 
-            edit_disc.execute(current_tag_status.tag_id, disc_patch.uri, metadata, option)
-            return build_current_tag_disc_output(current_tag_status.tag_id, get_disc.execute(current_tag_status.tag_id))
+            updated_disc = edit_disc.execute(current_tag_status.tag_id, disc_patch.uri, metadata, option)
+            return build_current_tag_disc_output(current_tag_status.tag_id, updated_disc)
         except ValueError as value_err:
             raise HTTPException(status_code=404, detail=str(value_err))
         except Exception as err:

--- a/tests/discstore/adapters/inbound/test_api_controller.py
+++ b/tests/discstore/adapters/inbound/test_api_controller.py
@@ -253,13 +253,14 @@ def test_create_current_tag_disc_returns_created_disc_payload():
     get_current_tag_status = create_autospec(GetCurrentTagStatus, instance=True, spec_set=True)
     get_current_tag_status.execute.return_value = CurrentTagStatus(tag_id="tag-123", known_in_library=False)
     add_disc = MagicMock()
-    controller = build_controller(get_current_tag_status=get_current_tag_status, add_disc=add_disc)
-    route = get_route(controller, "/api/v1/current-tag/disc", "POST")
     request = DiscInput(
         uri="/music/song.mp3",
         metadata=DiscMetadata(artist="Artist", album="Album", track="Track"),
         option=DiscOption(shuffle=True),
     )
+    add_disc.execute.return_value = Disc(**request.model_dump())
+    controller = build_controller(get_current_tag_status=get_current_tag_status, add_disc=add_disc)
+    route = get_route(controller, "/api/v1/current-tag/disc", "POST")
 
     response = route.endpoint(request)
 
@@ -306,13 +307,12 @@ def test_patch_current_tag_disc_partially_updates_existing_disc():
     get_current_tag_status = create_autospec(GetCurrentTagStatus, instance=True, spec_set=True)
     get_current_tag_status.execute.return_value = CurrentTagStatus(tag_id="tag-123", known_in_library=True)
     edit_disc = MagicMock()
-    get_disc = MagicMock()
-    get_disc.execute.return_value = Disc(
+    edit_disc.execute.return_value = Disc(
         uri="/music/song.mp3",
         metadata=DiscMetadata(artist="Artist", album="Album", track="Updated Track"),
         option=DiscOption(shuffle=False),
     )
-    controller = build_controller(get_current_tag_status=get_current_tag_status, edit_disc=edit_disc, get_disc=get_disc)
+    controller = build_controller(get_current_tag_status=get_current_tag_status, edit_disc=edit_disc)
     route = get_route(controller, "/api/v1/current-tag/disc", "PATCH")
 
     response = route.endpoint(
@@ -336,7 +336,6 @@ def test_patch_current_tag_disc_partially_updates_existing_disc():
         DiscMetadata(track="Updated Track"),
         DiscOption(shuffle=False),
     )
-    get_disc.execute.assert_called_once_with("tag-123")
 
 
 @pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")


### PR DESCRIPTION
Closes #217 


Use the return value of add_disc/edit_disc use cases directly instead of re-fetching via get_disc or returning the locally constructed disc object.