### PR TITLE
✨ Configure SPI GPIO pins of the PN532 reader

### DIFF
--- a/jukebox/adapters/outbound/readers/pn532_reader_adapter.py
+++ b/jukebox/adapters/outbound/readers/pn532_reader_adapter.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Union
+from typing import Optional, Union
 
 from jukebox.shared.dependency_messages import optional_extra_dependency_message
 
@@ -28,7 +28,13 @@ def spi_active():
 class Pn532ReaderAdapter(ReaderPort):
     """Adapter for Pn532 NFC reader implementing ReaderPort."""
 
-    def __init__(self, read_timeout_seconds: float = DEFAULT_NFC_READ_TIMEOUT_SECONDS):
+    def __init__(
+        self,
+        read_timeout_seconds: float = DEFAULT_NFC_READ_TIMEOUT_SECONDS,
+        spi_reset: Optional[int] = None,
+        spi_cs: Optional[int] = None,
+        spi_irq: Optional[int] = None,
+    ):
         if not spi_active():
             error_message = (
                 "The SPI interface is not enabled. Please enable it to use the PN532 NFC reader."
@@ -37,7 +43,7 @@ class Pn532ReaderAdapter(ReaderPort):
             LOGGER.error(error_message)
             raise RuntimeError("SPI interface not enabled. Use raspi-config to enable it.")
 
-        self.pn532 = PN532_SPI(debug=False, reset=20, cs=4)
+        self.pn532 = PN532_SPI(debug=False, reset=spi_reset, cs=spi_cs, irq=spi_irq)
         self.read_timeout_seconds = read_timeout_seconds
         ic, ver, rev, support = self.pn532.get_firmware_version()
         LOGGER.info(f"Found PN532 with firmware version: {ver}.{rev}")

--- a/jukebox/di_container.py
+++ b/jukebox/di_container.py
@@ -26,7 +26,12 @@ def build_jukebox(config: ResolvedJukeboxRuntimeConfig):
     if config.reader_type == "pn532":
         from jukebox.adapters.outbound.readers.pn532_reader_adapter import Pn532ReaderAdapter
 
-        reader = Pn532ReaderAdapter(read_timeout_seconds=config.pn532_read_timeout_seconds)
+        reader = Pn532ReaderAdapter(
+            read_timeout_seconds=config.pn532_read_timeout_seconds,
+            spi_reset=config.pn532_spi_reset,
+            spi_cs=config.pn532_spi_cs,
+            spi_irq=config.pn532_spi_irq,
+        )
     elif config.reader_type == "dryrun":
         reader = DryrunReaderAdapter()
     else:

--- a/jukebox/di_container.py
+++ b/jukebox/di_container.py
@@ -26,12 +26,15 @@ def build_jukebox(config: ResolvedJukeboxRuntimeConfig):
     if config.reader_type == "pn532":
         from jukebox.adapters.outbound.readers.pn532_reader_adapter import Pn532ReaderAdapter
 
-        reader = Pn532ReaderAdapter(
-            read_timeout_seconds=config.pn532_read_timeout_seconds,
-            spi_reset=config.pn532_spi_reset,
-            spi_cs=config.pn532_spi_cs,
-            spi_irq=config.pn532_spi_irq,
-        )
+        if config.pn532_protocol == "spi":
+            reader = Pn532ReaderAdapter(
+                read_timeout_seconds=config.pn532_read_timeout_seconds,
+                spi_reset=config.pn532_spi_reset,
+                spi_cs=config.pn532_spi_cs,
+                spi_irq=config.pn532_spi_irq,
+            )
+        else:
+            raise ValueError(f"Unsupported PN532 protocol: {config.pn532_protocol}")
     elif config.reader_type == "dryrun":
         reader = DryrunReaderAdapter()
     else:

--- a/jukebox/settings/definitions.py
+++ b/jukebox/settings/definitions.py
@@ -176,6 +176,30 @@ SETTINGS = {
         section="reader",
         requires_restart=True,
     ),
+    "jukebox.reader.pn532.spi.reset": SettingDefinition(
+        path="jukebox.reader.pn532.spi.reset",
+        label="PN532 SPI Reset Pin",
+        description="GPIO BCM pin number for the PN532 reset line.",
+        field_type="integer",
+        section="reader",
+        requires_restart=True,
+    ),
+    "jukebox.reader.pn532.spi.cs": SettingDefinition(
+        path="jukebox.reader.pn532.spi.cs",
+        label="PN532 SPI Chip Select Pin",
+        description="GPIO BCM pin number for the PN532 chip select line.",
+        field_type="integer",
+        section="reader",
+        requires_restart=True,
+    ),
+    "jukebox.reader.pn532.spi.irq": SettingDefinition(
+        path="jukebox.reader.pn532.spi.irq",
+        label="PN532 SPI IRQ Pin",
+        description="GPIO BCM pin number for the PN532 IRQ line, or null if unused.",
+        field_type="integer",
+        section="reader",
+        requires_restart=True,
+    ),
 }
 
 

--- a/jukebox/settings/definitions.py
+++ b/jukebox/settings/definitions.py
@@ -176,6 +176,15 @@ SETTINGS = {
         section="reader",
         requires_restart=True,
     ),
+    "jukebox.reader.pn532.protocol": SettingDefinition(
+        path="jukebox.reader.pn532.protocol",
+        label="PN532 protocol",
+        description="Communication interface used to talk to the PN532 chip.",
+        field_type="string",
+        section="reader",
+        requires_restart=True,
+        choices=(SettingChoice(value="spi", label="SPI"),),
+    ),
     "jukebox.reader.pn532.spi.reset": SettingDefinition(
         path="jukebox.reader.pn532.spi.reset",
         label="PN532 SPI Reset Pin",

--- a/jukebox/settings/entities.py
+++ b/jukebox/settings/entities.py
@@ -72,6 +72,7 @@ class Pn532SpiSettings(StrictModel):
 
 class Pn532ReaderSettings(StrictModel):
     read_timeout_seconds: float = Field(default=0.1, gt=0)
+    protocol: Literal["spi"] = "spi"
     spi: Pn532SpiSettings = Field(default_factory=Pn532SpiSettings)
 
 
@@ -159,6 +160,7 @@ class SparsePn532SpiSettings(StrictModel):
 
 class SparsePn532ReaderSettings(StrictModel):
     read_timeout_seconds: Optional[float] = None
+    protocol: Optional[Literal["spi"]] = None
     spi: Optional[SparsePn532SpiSettings] = None
 
 
@@ -264,6 +266,7 @@ class ResolvedJukeboxRuntimeConfig(StrictModel):
     pause_delay_seconds: float
     loop_interval_seconds: float
     pn532_read_timeout_seconds: float
+    pn532_protocol: Literal["spi"] = "spi"
     pn532_spi_reset: Optional[int] = 20
     pn532_spi_cs: Optional[int] = 4
     pn532_spi_irq: Optional[int] = None

--- a/jukebox/settings/entities.py
+++ b/jukebox/settings/entities.py
@@ -64,8 +64,15 @@ class PlayerSettings(PersistedPlayerSettings):
     sonos: SonosPlayerSettings = Field(default_factory=SonosPlayerSettings)
 
 
+class Pn532SpiSettings(StrictModel):
+    reset: Optional[int] = Field(default=20)
+    cs: Optional[int] = Field(default=4)
+    irq: Optional[int] = Field(default=None)
+
+
 class Pn532ReaderSettings(StrictModel):
     read_timeout_seconds: float = Field(default=0.1, gt=0)
+    spi: Pn532SpiSettings = Field(default_factory=Pn532SpiSettings)
 
 
 class ReaderSettings(StrictModel):
@@ -144,8 +151,15 @@ class SparsePlayerSettings(SparsePersistedPlayerSettings):
     sonos: Optional[SparseSonosPlayerSettings] = None
 
 
+class SparsePn532SpiSettings(StrictModel):
+    reset: Optional[int] = None
+    cs: Optional[int] = None
+    irq: Optional[int] = None
+
+
 class SparsePn532ReaderSettings(StrictModel):
     read_timeout_seconds: Optional[float] = None
+    spi: Optional[SparsePn532SpiSettings] = None
 
 
 class SparseReaderSettings(StrictModel):
@@ -250,6 +264,9 @@ class ResolvedJukeboxRuntimeConfig(StrictModel):
     pause_delay_seconds: float
     loop_interval_seconds: float
     pn532_read_timeout_seconds: float
+    pn532_spi_reset: Optional[int] = 20
+    pn532_spi_cs: Optional[int] = 4
+    pn532_spi_irq: Optional[int] = None
     verbose: bool = False
 
     @model_validator(mode="after")

--- a/jukebox/settings/entities.py
+++ b/jukebox/settings/entities.py
@@ -65,9 +65,9 @@ class PlayerSettings(PersistedPlayerSettings):
 
 
 class Pn532SpiSettings(StrictModel):
-    reset: Optional[int] = Field(default=20)
-    cs: Optional[int] = Field(default=4)
-    irq: Optional[int] = Field(default=None)
+    reset: Optional[int] = Field(default=20, ge=0)
+    cs: Optional[int] = Field(default=4, ge=0)
+    irq: Optional[int] = Field(default=None, ge=0)
 
 
 class Pn532ReaderSettings(StrictModel):
@@ -153,9 +153,9 @@ class SparsePlayerSettings(SparsePersistedPlayerSettings):
 
 
 class SparsePn532SpiSettings(StrictModel):
-    reset: Optional[int] = None
-    cs: Optional[int] = None
-    irq: Optional[int] = None
+    reset: Optional[int] = Field(default=None, ge=0)
+    cs: Optional[int] = Field(default=None, ge=0)
+    irq: Optional[int] = Field(default=None, ge=0)
 
 
 class SparsePn532ReaderSettings(StrictModel):

--- a/jukebox/settings/runtime_resolver.py
+++ b/jukebox/settings/runtime_resolver.py
@@ -36,6 +36,7 @@ class JukeboxRuntimeResolver:
                 pause_delay_seconds=effective_settings.jukebox.playback.pause_delay_seconds,
                 loop_interval_seconds=effective_settings.jukebox.runtime.loop_interval_seconds,
                 pn532_read_timeout_seconds=effective_settings.jukebox.reader.pn532.read_timeout_seconds,
+                pn532_protocol=effective_settings.jukebox.reader.pn532.protocol,
                 pn532_spi_reset=effective_settings.jukebox.reader.pn532.spi.reset,
                 pn532_spi_cs=effective_settings.jukebox.reader.pn532.spi.cs,
                 pn532_spi_irq=effective_settings.jukebox.reader.pn532.spi.irq,

--- a/jukebox/settings/runtime_resolver.py
+++ b/jukebox/settings/runtime_resolver.py
@@ -36,6 +36,9 @@ class JukeboxRuntimeResolver:
                 pause_delay_seconds=effective_settings.jukebox.playback.pause_delay_seconds,
                 loop_interval_seconds=effective_settings.jukebox.runtime.loop_interval_seconds,
                 pn532_read_timeout_seconds=effective_settings.jukebox.reader.pn532.read_timeout_seconds,
+                pn532_spi_reset=effective_settings.jukebox.reader.pn532.spi.reset,
+                pn532_spi_cs=effective_settings.jukebox.reader.pn532.spi.cs,
+                pn532_spi_irq=effective_settings.jukebox.reader.pn532.spi.irq,
                 verbose=verbose,
             )
         except (ValidationError, ValueError) as err:

--- a/tests/jukebox/settings/test_definitions_consistency.py
+++ b/tests/jukebox/settings/test_definitions_consistency.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal, Optional, get_args, get_origin
+from typing import Any, Literal, Optional, Union, get_args, get_origin
 
 from pydantic import BaseModel
 
@@ -63,8 +63,7 @@ def _extract_model_type(annotation: Any) -> Optional[type[BaseModel]]:
 
 
 def _strip_none(annotation: Any) -> Any:
-    origin = get_origin(annotation)
-    if origin is None:
+    if get_origin(annotation) is not Union:
         return annotation
 
     args = tuple(arg for arg in get_args(annotation) if arg is not type(None))

--- a/tests/jukebox/test_jukebox_di_container.py
+++ b/tests/jukebox/test_jukebox_di_container.py
@@ -45,7 +45,12 @@ class TestBuildJukebox:
         mock_library.assert_called_once_with("/test/library.json")
         mock_current_tag.assert_called_once_with("/test/current-tag.txt")
         mock_player.assert_called_once_with(host="192.168.1.100", name=None, group=config.sonos_group)
-        mock_pn532_class.assert_called_once_with(read_timeout_seconds=0.25)
+        mock_pn532_class.assert_called_once_with(
+            read_timeout_seconds=0.25,
+            spi_reset=20,
+            spi_cs=4,
+            spi_irq=None,
+        )
         assert reader == mock_pn532_instance
         assert handle_tag_event is not None
 


### PR DESCRIPTION
## Summary

Part of #152

The PN532 SPI GPIO pins (`reset`, `cs`, `irq`) were hardcoded in the adapter. This makes it impossible to use readers with different wiring, such as the HiLetgo V3.

This PR exposes them as configurable settings and wires them through the full stack: `settings > resolver > DI container > adapter`. A `protocol` field (`spi` only for now) is also introduced to prepare for I2C and UART support.

## Non-goals

Board profile presets (`waveshare_hat`, `hiletgo_v3`, `custom`) are handled in a follow-up PR.
CLI options to override settings.
Support for protocols other than SPI.

## Test plan

- `uv run pytest` — all tests pass
- `uv run jukebox-admin settings show --effective` — `reader.pn532.spi.*` and `protocol` appear in output
- `uv run jukebox-admin settings set jukebox.reader.pn532.spi.reset 25` — persists and is reflected in `--effective`
- `uv run jukebox-admin settings reset jukebox.reader.pn532.spi.reset` — reverts to 4 (spi default)
- On hardware: jukebox starts and reads NFC tags with default pins (20/4/null)
- On hardware: jukebox starts correctly after overriding spi.reset to a custom pin