### PR TITLE
✨ Simplify the configuration of the PN532 reader using predefined profiles

### DIFF
--- a/jukebox/pn532/__init__.py
+++ b/jukebox/pn532/__init__.py
@@ -1,0 +1,8 @@
+from .profiles import PN532_PROFILES, Pn532BoardProfile, Pn532BoardProfileDefaults, resolve_spi_pins
+
+__all__ = [
+    "PN532_PROFILES",
+    "Pn532BoardProfile",
+    "Pn532BoardProfileDefaults",
+    "resolve_spi_pins",
+]

--- a/jukebox/pn532/profiles.py
+++ b/jukebox/pn532/profiles.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+Pn532BoardProfile = Literal["waveshare_hat", "hiletgo_v3", "custom"]
+
+
+@dataclass(frozen=True)
+class Pn532BoardProfileDefaults:
+    reset: Optional[int]
+    cs: Optional[int]
+    irq: Optional[int]
+
+
+PN532_PROFILES: dict[Pn532BoardProfile, Pn532BoardProfileDefaults] = {
+    "waveshare_hat": Pn532BoardProfileDefaults(reset=20, cs=4, irq=None),
+    "hiletgo_v3": Pn532BoardProfileDefaults(reset=None, cs=8, irq=None),
+    "custom": Pn532BoardProfileDefaults(reset=None, cs=None, irq=None),
+}
+
+
+def resolve_spi_pins(
+    board_profile: Pn532BoardProfile,
+    reset: Optional[int],
+    cs: Optional[int],
+    irq: Optional[int],
+) -> Pn532BoardProfileDefaults:
+    profile = PN532_PROFILES[board_profile]
+    return Pn532BoardProfileDefaults(
+        reset=reset if reset is not None else profile.reset,
+        cs=cs if cs is not None else profile.cs,
+        irq=irq if irq is not None else profile.irq,
+    )

--- a/jukebox/settings/definitions.py
+++ b/jukebox/settings/definitions.py
@@ -176,6 +176,19 @@ SETTINGS = {
         section="reader",
         requires_restart=True,
     ),
+    "jukebox.reader.pn532.board_profile": SettingDefinition(
+        path="jukebox.reader.pn532.board_profile",
+        label="PN532 Board Profile",
+        description="Known board preset. Provides default GPIO pins for the selected module.",
+        field_type="string",
+        section="reader",
+        requires_restart=True,
+        choices=(
+            SettingChoice(value="waveshare_hat", label="WaveShare PN532 NFC HAT"),
+            SettingChoice(value="hiletgo_v3", label="HiLetgo PN532 V3"),
+            SettingChoice(value="custom", label="Custom"),
+        ),
+    ),
     "jukebox.reader.pn532.protocol": SettingDefinition(
         path="jukebox.reader.pn532.protocol",
         label="PN532 protocol",

--- a/jukebox/settings/entities.py
+++ b/jukebox/settings/entities.py
@@ -65,13 +65,14 @@ class PlayerSettings(PersistedPlayerSettings):
 
 
 class Pn532SpiSettings(StrictModel):
-    reset: Optional[int] = Field(default=20, ge=0)
-    cs: Optional[int] = Field(default=4, ge=0)
+    reset: Optional[int] = Field(default=None, ge=0)
+    cs: Optional[int] = Field(default=None, ge=0)
     irq: Optional[int] = Field(default=None, ge=0)
 
 
 class Pn532ReaderSettings(StrictModel):
     read_timeout_seconds: float = Field(default=0.1, gt=0)
+    board_profile: Literal["waveshare_hat", "hiletgo_v3", "custom"] = "waveshare_hat"
     protocol: Literal["spi"] = "spi"
     spi: Pn532SpiSettings = Field(default_factory=Pn532SpiSettings)
 
@@ -160,6 +161,7 @@ class SparsePn532SpiSettings(StrictModel):
 
 class SparsePn532ReaderSettings(StrictModel):
     read_timeout_seconds: Optional[float] = None
+    board_profile: Optional[Literal["waveshare_hat", "hiletgo_v3", "custom"]] = None
     protocol: Optional[Literal["spi"]] = None
     spi: Optional[SparsePn532SpiSettings] = None
 
@@ -266,10 +268,11 @@ class ResolvedJukeboxRuntimeConfig(StrictModel):
     pause_delay_seconds: float
     loop_interval_seconds: float
     pn532_read_timeout_seconds: float
+    pn532_board_profile: Literal["waveshare_hat", "hiletgo_v3", "custom"]
     pn532_protocol: Literal["spi"] = "spi"
-    pn532_spi_reset: Optional[int] = 20
-    pn532_spi_cs: Optional[int] = 4
-    pn532_spi_irq: Optional[int] = None
+    pn532_spi_reset: Optional[int]
+    pn532_spi_cs: Optional[int]
+    pn532_spi_irq: Optional[int]
     verbose: bool = False
 
     @model_validator(mode="after")

--- a/jukebox/settings/resolve.py
+++ b/jukebox/settings/resolve.py
@@ -5,6 +5,7 @@ from typing import Optional, Union, cast
 
 from pydantic import ValidationError
 
+from jukebox.pn532.profiles import resolve_spi_pins
 from jukebox.shared.config_utils import get_current_tag_path
 
 from .definitions import (
@@ -84,7 +85,8 @@ class SettingsService:
                 "paths": {
                     "expanded_library_path": _expand_path(effective_settings.paths.library_path),
                     "current_tag_path": get_current_tag_path(effective_settings.paths.library_path),
-                }
+                },
+                **_derive_pn532(effective_settings),
             },
             "settings_metadata": build_settings_metadata_tree(),
         }
@@ -231,6 +233,22 @@ def _format_invalid_settings_message(error: str, env_overrides: JsonObject, cli_
 
 def _expand_path(path: str) -> str:
     return os.path.abspath(os.path.expanduser(path))
+
+
+def _derive_pn532(effective_settings: AppSettings) -> JsonObject:
+    pn532 = effective_settings.jukebox.reader.pn532
+    resolved = resolve_spi_pins(pn532.board_profile, pn532.spi.reset, pn532.spi.cs, pn532.spi.irq)
+    return {
+        "reader": {
+            "pn532": {
+                "spi": {
+                    "reset": resolved.reset,
+                    "cs": resolved.cs,
+                    "irq": resolved.irq,
+                }
+            }
+        }
+    }
 
 
 def _build_provenance_tree(

--- a/jukebox/settings/runtime_resolver.py
+++ b/jukebox/settings/runtime_resolver.py
@@ -1,11 +1,12 @@
 import os
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 from pydantic import ValidationError
 
+from jukebox.pn532.profiles import resolve_spi_pins
 from jukebox.sonos.service import SonosService
 
-from .entities import AppSettings, ResolvedJukeboxRuntimeConfig, ResolvedSonosGroupRuntime
+from .entities import AppSettings, Pn532ReaderSettings, ResolvedJukeboxRuntimeConfig, ResolvedSonosGroupRuntime
 from .errors import InvalidSettingsError
 from .service_protocols import RuntimeSettingsService
 from .validation_rules import validate_settings_rules
@@ -36,6 +37,7 @@ class JukeboxRuntimeResolver:
                 pause_delay_seconds=effective_settings.jukebox.playback.pause_delay_seconds,
                 loop_interval_seconds=effective_settings.jukebox.runtime.loop_interval_seconds,
                 pn532_read_timeout_seconds=effective_settings.jukebox.reader.pn532.read_timeout_seconds,
+                pn532_board_profile=effective_settings.jukebox.reader.pn532.board_profile,
                 pn532_protocol=effective_settings.jukebox.reader.pn532.protocol,
                 pn532_spi_reset=effective_settings.jukebox.reader.pn532.spi.reset,
                 pn532_spi_cs=effective_settings.jukebox.reader.pn532.spi.cs,
@@ -61,3 +63,12 @@ class JukeboxRuntimeResolver:
             return resolved_group.coordinator.host, None, resolved_group
 
         return None, None, None
+
+
+def _resolve_pn532_spi_pins(pn532: Pn532ReaderSettings) -> dict[str, Any]:
+    resolved = resolve_spi_pins(pn532.board_profile, pn532.spi.reset, pn532.spi.cs, pn532.spi.irq)
+    return {
+        "pn532_spi_reset": resolved.reset,
+        "pn532_spi_cs": resolved.cs,
+        "pn532_spi_irq": resolved.irq,
+    }

--- a/jukebox/settings/runtime_resolver.py
+++ b/jukebox/settings/runtime_resolver.py
@@ -39,9 +39,7 @@ class JukeboxRuntimeResolver:
                 pn532_read_timeout_seconds=effective_settings.jukebox.reader.pn532.read_timeout_seconds,
                 pn532_board_profile=effective_settings.jukebox.reader.pn532.board_profile,
                 pn532_protocol=effective_settings.jukebox.reader.pn532.protocol,
-                pn532_spi_reset=effective_settings.jukebox.reader.pn532.spi.reset,
-                pn532_spi_cs=effective_settings.jukebox.reader.pn532.spi.cs,
-                pn532_spi_irq=effective_settings.jukebox.reader.pn532.spi.irq,
+                **_resolve_pn532_spi_pins(effective_settings.jukebox.reader.pn532),
                 verbose=verbose,
             )
         except (ValidationError, ValueError) as err:

--- a/tests/jukebox/pn532/test_pn532_profiles.py
+++ b/tests/jukebox/pn532/test_pn532_profiles.py
@@ -50,7 +50,14 @@ def test_resolve_spi_pins_full_override_ignores_profile():
 
 
 def test_resolve_spi_pins_none_override_is_treated_as_no_override():
-    # None means "no override, use profile default" — it does not force the pin to None.
-    # Use the custom profile if you explicitly need a None pin.
+    # None means "no override, use profile default", it does not force the pin to None.
     resolved = resolve_spi_pins("waveshare_hat", reset=None, cs=None, irq=None)
     assert resolved.reset == 20  # profile default, not None
+
+
+def test_resolve_spi_pins_custom_profile_preserves_none_pins():
+    # Use the custom profile to explicitly keep a pin as None.
+    resolved = resolve_spi_pins("custom", reset=None, cs=None, irq=None)
+    assert resolved.reset is None
+    assert resolved.cs is None
+    assert resolved.irq is None

--- a/tests/jukebox/pn532/test_pn532_profiles.py
+++ b/tests/jukebox/pn532/test_pn532_profiles.py
@@ -1,0 +1,56 @@
+import pytest
+
+from jukebox.pn532.profiles import PN532_PROFILES, resolve_spi_pins
+
+
+def test_waveshare_hat_profile_defaults():
+    profile = PN532_PROFILES["waveshare_hat"]
+    assert profile.reset == 20
+    assert profile.cs == 4
+    assert profile.irq is None
+
+
+def test_hiletgo_v3_profile_defaults():
+    profile = PN532_PROFILES["hiletgo_v3"]
+    assert profile.reset is None
+    assert profile.cs == 8
+    assert profile.irq is None
+
+
+def test_custom_profile_has_no_defaults():
+    profile = PN532_PROFILES["custom"]
+    assert profile.reset is None
+    assert profile.cs is None
+    assert profile.irq is None
+
+
+@pytest.mark.parametrize("profile_name", ["waveshare_hat", "hiletgo_v3", "custom"])
+def test_all_profiles_are_defined(profile_name):
+    assert profile_name in PN532_PROFILES
+
+
+def test_resolve_spi_pins_uses_profile_defaults_when_no_overrides():
+    resolved = resolve_spi_pins("waveshare_hat", reset=None, cs=None, irq=None)
+    assert resolved.reset == 20
+    assert resolved.cs == 4
+    assert resolved.irq is None
+
+
+def test_resolve_spi_pins_partial_override_wins_over_profile_default():
+    resolved = resolve_spi_pins("waveshare_hat", reset=24, cs=None, irq=None)
+    assert resolved.reset == 24  # override
+    assert resolved.cs == 4  # profile default
+
+
+def test_resolve_spi_pins_full_override_ignores_profile():
+    resolved = resolve_spi_pins("waveshare_hat", reset=24, cs=10, irq=25)
+    assert resolved.reset == 24
+    assert resolved.cs == 10
+    assert resolved.irq == 25
+
+
+def test_resolve_spi_pins_none_override_is_treated_as_no_override():
+    # None means "no override, use profile default" — it does not force the pin to None.
+    # Use the custom profile if you explicitly need a None pin.
+    resolved = resolve_spi_pins("waveshare_hat", reset=None, cs=None, irq=None)
+    assert resolved.reset == 20  # profile default, not None

--- a/tests/jukebox/settings/test_settings_service_runtime_resolution.py
+++ b/tests/jukebox/settings/test_settings_service_runtime_resolution.py
@@ -202,3 +202,102 @@ def test_settings_service_rejects_loop_interval_not_lower_than_pause_delay_at_ru
         match="loop_interval_seconds must be lower than jukebox.playback.pause_delay_seconds",
     ):
         resolve_jukebox_runtime(service)
+
+
+def test_runtime_resolver_applies_board_profile_defaults_to_spi_pins(tmp_path):
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "jukebox": {"reader": {"type": "pn532", "pn532": {"board_profile": "waveshare_hat"}}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    service = SettingsService(repository=FileSettingsRepository(str(settings_path)))
+
+    runtime_config = resolve_jukebox_runtime(service)
+
+    # waveshare_hat defaults: reset=20, cs=4, irq=None
+    assert runtime_config.pn532_spi_reset == 20
+    assert runtime_config.pn532_spi_cs == 4
+    assert runtime_config.pn532_spi_irq is None
+
+
+def test_runtime_resolver_spi_pin_override_wins_over_board_profile_default(tmp_path):
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "jukebox": {
+                    "reader": {
+                        "type": "pn532",
+                        "pn532": {
+                            "board_profile": "waveshare_hat",
+                            "spi": {"reset": 24},
+                        },
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    service = SettingsService(repository=FileSettingsRepository(str(settings_path)))
+
+    runtime_config = resolve_jukebox_runtime(service)
+
+    assert runtime_config.pn532_spi_reset == 24  # override
+    assert runtime_config.pn532_spi_cs == 4  # profile default
+
+
+def test_effective_view_derives_spi_pins_from_board_profile(tmp_path):
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "jukebox": {"reader": {"type": "pn532", "pn532": {"board_profile": "waveshare_hat"}}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    service = SettingsService(repository=FileSettingsRepository(str(settings_path)))
+
+    effective_view = service.get_effective_settings_view()
+
+    # Raw settings show None (no explicit pin set)
+    assert lookup_json_value(effective_view, "settings", "jukebox", "reader", "pn532", "spi", "reset") is None
+    assert lookup_json_value(effective_view, "settings", "jukebox", "reader", "pn532", "spi", "cs") is None
+    # Derived section shows profile defaults resolved
+    assert lookup_json_value(effective_view, "derived", "reader", "pn532", "spi", "reset") == 20
+    assert lookup_json_value(effective_view, "derived", "reader", "pn532", "spi", "cs") == 4
+    assert lookup_json_value(effective_view, "derived", "reader", "pn532", "spi", "irq") is None
+
+
+def test_effective_view_derived_spi_pins_reflect_explicit_override(tmp_path):
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "jukebox": {
+                    "reader": {
+                        "type": "pn532",
+                        "pn532": {
+                            "board_profile": "waveshare_hat",
+                            "spi": {"reset": 24},
+                        },
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    service = SettingsService(repository=FileSettingsRepository(str(settings_path)))
+
+    effective_view = service.get_effective_settings_view()
+
+    assert lookup_json_value(effective_view, "derived", "reader", "pn532", "spi", "reset") == 24  # override
+    assert lookup_json_value(effective_view, "derived", "reader", "pn532", "spi", "cs") == 4  # profile default

--- a/tests/jukebox/test_jukebox_app.py
+++ b/tests/jukebox/test_jukebox_app.py
@@ -36,6 +36,10 @@ def test_main_uses_resolved_runtime_config(app_mocks):
         pause_delay_seconds=1.0,
         loop_interval_seconds=0.5,
         pn532_read_timeout_seconds=0.1,
+        pn532_board_profile="waveshare_hat",
+        pn532_spi_reset=20,
+        pn532_spi_cs=4,
+        pn532_spi_irq=None,
         verbose=True,
     )
     settings_service = MagicMock()
@@ -77,6 +81,10 @@ def test_main_exits_on_build_jukebox_settings_error(app_mocks):
         pause_delay_seconds=1.0,
         loop_interval_seconds=0.5,
         pn532_read_timeout_seconds=0.1,
+        pn532_board_profile="waveshare_hat",
+        pn532_spi_reset=20,
+        pn532_spi_cs=4,
+        pn532_spi_irq=None,
         verbose=True,
     )
     settings_service = MagicMock()

--- a/tests/jukebox/test_jukebox_di_container.py
+++ b/tests/jukebox/test_jukebox_di_container.py
@@ -37,6 +37,10 @@ class TestBuildJukebox:
             pause_delay_seconds=3,
             loop_interval_seconds=0.1,
             pn532_read_timeout_seconds=0.25,
+            pn532_board_profile="waveshare_hat",
+            pn532_spi_reset=20,
+            pn532_spi_cs=4,
+            pn532_spi_irq=None,
             verbose=False,
         )
 
@@ -70,6 +74,10 @@ class TestBuildJukebox:
             pause_delay_seconds=3,
             loop_interval_seconds=0.1,
             pn532_read_timeout_seconds=0.25,
+            pn532_board_profile="waveshare_hat",
+            pn532_spi_reset=20,
+            pn532_spi_cs=4,
+            pn532_spi_irq=None,
             verbose=False,
         )
 
@@ -98,6 +106,10 @@ class TestBuildJukebox:
             pause_delay_seconds=3,
             loop_interval_seconds=0.1,
             pn532_read_timeout_seconds=0.25,
+            pn532_board_profile="waveshare_hat",
+            pn532_spi_reset=20,
+            pn532_spi_cs=4,
+            pn532_spi_irq=None,
             verbose=False,
         )
 
@@ -125,6 +137,10 @@ class TestBuildJukebox:
             pause_delay_seconds=5,
             loop_interval_seconds=0.1,
             pn532_read_timeout_seconds=0.1,
+            pn532_board_profile="waveshare_hat",
+            pn532_spi_reset=20,
+            pn532_spi_cs=4,
+            pn532_spi_irq=None,
             verbose=False,
         )
 
@@ -155,6 +171,10 @@ class TestBuildJukebox:
             pause_delay_seconds=0.2,
             loop_interval_seconds=0.1,
             pn532_read_timeout_seconds=0.1,
+            pn532_board_profile="waveshare_hat",
+            pn532_spi_reset=20,
+            pn532_spi_cs=4,
+            pn532_spi_irq=None,
             verbose=False,
         )
 


### PR DESCRIPTION
## Summary

Part of #152

Requires #222 

`board_profile (waveshare_hat | hiletgo_v3 | custom)` lets users select a known board preset instead of manually configuring each GPIO pin. Explicit `spi.*` overrides still take precedence over the profile defaults.

Board profile knowledge lives in a dedicated `jukebox/pn532/` module, following the same pattern as `jukebox/sonos/`. The settings layer imports profile data from there; it does not embed hardware knowledge itself.

The resolved pins are surfaced in the derived section of `settings show --effective` alongside `expanded_library_path`.

## Test plan

- `uv run pytest` — all tests pass
- `uv run jukebox-admin settings reset jukebox.reader` — ⚠️ erases your reader configuration
- `uv run jukebox-admin settings show --effective` — `reader.pn532.spi.*` and `protocol` appear in the "Reader" section as `null` and in the "Derived" section with the default values from the `waveshare_hat` profile
- `uv run jukebox-admin settings set jukebox.reader.pn532.spi.reset 25` — persists and is reflected in `--effective` in both "Reader" and "Derived" sections
- `uv run jukebox-admin settings set jukebox.reader.pn532.board_profile hiletgo_v3` — does not revert to 4 the `reset` field (overrides by previous settings) but changes the `board_profile`
  ➡️ I'm not sure about this behavior. But I don't think either approach is the right one, so I'd rather keep it simple. Let me know what you think. Besides, once the PN532 controls are available (#225), the setup will be more straightforward than going through `settings`.
- On hardware: jukebox starts and reads NFC tags