### PR TITLE
✨ Add CLI override arguments for PN532 settings 

### DIFF
--- a/jukebox/adapters/inbound/config.py
+++ b/jukebox/adapters/inbound/config.py
@@ -15,6 +15,9 @@ class JukeboxCliConfig(BaseModel):
     sonos_name: Optional[str] = None
     pause_duration_seconds: Optional[int] = None
     pause_delay_seconds: Optional[float] = None
+    pn532_spi_reset: Optional[int] = None
+    pn532_spi_cs: Optional[int] = None
+    pn532_spi_irq: Optional[int] = None
 
 
 def parse_config() -> JukeboxCliConfig:
@@ -71,6 +74,25 @@ def parse_config() -> JukeboxCliConfig:
         help="override the grace period in seconds before pausing when a tag is removed",
     )
 
+    parser.add_argument(
+        "--pn532-spi-reset",
+        default=None,
+        type=int,
+        help="override the PN532 SPI reset GPIO pin for this process",
+    )
+    parser.add_argument(
+        "--pn532-spi-cs",
+        default=None,
+        type=int,
+        help="override the PN532 SPI chip select GPIO pin for this process",
+    )
+    parser.add_argument(
+        "--pn532-spi-irq",
+        default=None,
+        type=int,
+        help="override the PN532 SPI IRQ GPIO pin for this process",
+    )
+
     args = parser.parse_args()
 
     return JukeboxCliConfig(
@@ -82,4 +104,7 @@ def parse_config() -> JukeboxCliConfig:
         sonos_name=args.sonos_name,
         pause_duration_seconds=args.pause_duration,
         pause_delay_seconds=args.pause_delay,
+        pn532_spi_reset=args.pn532_spi_reset,
+        pn532_spi_cs=args.pn532_spi_cs,
+        pn532_spi_irq=args.pn532_spi_irq,
     )

--- a/jukebox/app.py
+++ b/jukebox/app.py
@@ -48,6 +48,21 @@ def _build_settings_service(config: JukeboxCliConfig) -> SettingsService:
             config.pause_delay_seconds
         )
 
+    if config.pn532_spi_reset is not None:
+        cli_overrides.setdefault("jukebox", {}).setdefault("reader", {}).setdefault("pn532", {}).setdefault("spi", {})[
+            "reset"
+        ] = config.pn532_spi_reset
+
+    if config.pn532_spi_cs is not None:
+        cli_overrides.setdefault("jukebox", {}).setdefault("reader", {}).setdefault("pn532", {}).setdefault("spi", {})[
+            "cs"
+        ] = config.pn532_spi_cs
+
+    if config.pn532_spi_irq is not None:
+        cli_overrides.setdefault("jukebox", {}).setdefault("reader", {}).setdefault("pn532", {}).setdefault("spi", {})[
+            "irq"
+        ] = config.pn532_spi_irq
+
     return SettingsService(
         repository=FileSettingsRepository(),
         env_overrides=build_environment_settings_overrides(),

--- a/tests/jukebox/adapters/inbound/test_config.py
+++ b/tests/jukebox/adapters/inbound/test_config.py
@@ -62,6 +62,24 @@ def test_parse_config_rejects_sonos_host_and_name_together():
         parse_config()
 
 
+@patch("sys.argv", ["jukebox", "--pn532-spi-reset", "25", "--pn532-spi-cs", "8", "--pn532-spi-irq", "24"])
+def test_parse_config_with_pn532_spi_pin_overrides():
+    config = parse_config()
+
+    assert config.pn532_spi_reset == 25
+    assert config.pn532_spi_cs == 8
+    assert config.pn532_spi_irq == 24
+
+
+@patch("sys.argv", ["jukebox"])
+def test_parse_config_pn532_overrides_default_to_none():
+    config = parse_config()
+
+    assert config.pn532_spi_reset is None
+    assert config.pn532_spi_cs is None
+    assert config.pn532_spi_irq is None
+
+
 @pytest.mark.parametrize("subcommand", ["settings", "api", "ui", "library"])
 def test_parse_config_rejects_admin_subcommands(subcommand):
     with patch("sys.argv", ["jukebox", subcommand]), pytest.raises(SystemExit) as err:

--- a/tests/jukebox/settings/test_settings_service_runtime_resolution.py
+++ b/tests/jukebox/settings/test_settings_service_runtime_resolution.py
@@ -301,3 +301,31 @@ def test_effective_view_derived_spi_pins_reflect_explicit_override(tmp_path):
 
     assert lookup_json_value(effective_view, "derived", "reader", "pn532", "spi", "reset") == 24  # override
     assert lookup_json_value(effective_view, "derived", "reader", "pn532", "spi", "cs") == 4  # profile default
+
+
+def test_settings_service_applies_board_profile_cli_override_at_runtime(tmp_path):
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(json.dumps({"schema_version": 1}), encoding="utf-8")
+    service = SettingsService(
+        repository=FileSettingsRepository(str(settings_path)),
+        cli_overrides={"jukebox": {"reader": {"pn532": {"board_profile": "hiletgo_v3"}}}},
+    )
+
+    runtime_config = resolve_jukebox_runtime(service)
+
+    assert runtime_config.pn532_board_profile == "hiletgo_v3"
+    assert runtime_config.pn532_spi_cs == 8  # hiletgo_v3 default
+
+
+def test_settings_service_applies_spi_pin_cli_override_at_runtime(tmp_path):
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(json.dumps({"schema_version": 1}), encoding="utf-8")
+    service = SettingsService(
+        repository=FileSettingsRepository(str(settings_path)),
+        cli_overrides={"jukebox": {"reader": {"pn532": {"spi": {"reset": 24}}}}},
+    )
+
+    runtime_config = resolve_jukebox_runtime(service)
+
+    assert runtime_config.pn532_spi_reset == 24  # cli override
+    assert runtime_config.pn532_spi_cs == 4  # waveshare_hat default (default profile)

--- a/tests/jukebox/test_jukebox_app.py
+++ b/tests/jukebox/test_jukebox_app.py
@@ -146,6 +146,26 @@ def test_build_settings_service_reads_persisted_reader_and_timing_settings(tmp_p
     assert runtime_config.loop_interval_seconds == 0.2
 
 
+def test_build_settings_service_maps_pn532_overrides():
+    service = app._build_settings_service(
+        JukeboxCliConfig(
+            pn532_spi_reset=25,
+            pn532_spi_cs=10,
+            pn532_spi_irq=24,
+        )
+    )
+
+    assert service.cli_overrides == {
+        "jukebox": {
+            "reader": {
+                "pn532": {
+                    "spi": {"reset": 25, "cs": 10, "irq": 24},
+                }
+            }
+        }
+    }
+
+
 def test_build_settings_service_reads_persisted_selected_group_target(tmp_path, mocker):
     settings_path = tmp_path / "settings.json"
     settings_path.write_text(


### PR DESCRIPTION
## Summary

Part of #152 

Requires #223 

Add the ability to override the default and persisted PN532 configuration with:
- ~~`--pn532-board-profile` to override the PN532 board profile for this process~~(removed)
- ~~`--pn532-protocol` to override the PN532 protocol for this process~~(removed)
- `--pn532-spi-reset` to override the PN532 SPI reset GPIO pin for this process
-  `--pn532-spi-cs` to override the PN532 SPI chip select GPIO pin for this process
- `--pn532-spi-irq` to override the PN532 SPI IRQ GPIO pin for this process
