### PR TITLE
✨ Add PN532 admin commands

### DIFF
--- a/jukebox/adapters/outbound/readers/pn532_reader_adapter.py
+++ b/jukebox/adapters/outbound/readers/pn532_reader_adapter.py
@@ -47,7 +47,12 @@ class Pn532ReaderAdapter(ReaderPort):
         self.read_timeout_seconds = read_timeout_seconds
         ic, ver, rev, support = self.pn532.get_firmware_version()
         LOGGER.info(f"Found PN532 with firmware version: {ver}.{rev}")
+        self._firmware_version: tuple[int, int] = (ver, rev)
         self.pn532.SAM_configuration()
+
+    @property
+    def firmware_version(self) -> tuple[int, int]:
+        return self._firmware_version
 
     def read(self) -> Union[str, None]:
         rawuid = self.pn532.read_passive_target(timeout=self.read_timeout_seconds)

--- a/jukebox/admin/app.py
+++ b/jukebox/admin/app.py
@@ -42,6 +42,8 @@ from .commands import (
     is_sonos_command,
 )
 from .di_container import build_admin_api_app, build_admin_services, build_admin_ui_app, build_settings_service
+from .pn532_command_handlers import execute_pn532_command
+from .pn532_commands import Pn532ProbeCommand, Pn532ProfilesCommand, Pn532SelectCommand, is_pn532_command
 from .sonos_households import GroupedSonosHousehold
 
 
@@ -88,6 +90,15 @@ def _run_command(ctx: typer.Context, command: object) -> None:
                     coordinator_prompt_fn=_prompt_for_sonos_group_coordinator,
                     status_fn=_emit_cli_status,
                 )
+            elif is_pn532_command(command):
+                execute_pn532_command(
+                    command=command,
+                    settings_service=services.settings,
+                    profile_prompt_fn=_prompt_for_pn532_profile,
+                    protocol_prompt_fn=_prompt_for_pn532_protocol,
+                    pin_prompt_fn=_prompt_for_pn532_pin,
+                    stdout_fn=typer.echo,
+                )
             else:
                 execute_server_command(
                     verbose=state.verbose,
@@ -98,6 +109,8 @@ def _run_command(ctx: typer.Context, command: object) -> None:
                     source_command="jukebox-admin",
                 )
         except RuntimeError as err:
+            if state.verbose:
+                raise
             typer.echo(str(err), err=True)
             raise typer.Exit(code=1)
     except SystemExit as err:
@@ -109,6 +122,9 @@ def _run_command(ctx: typer.Context, command: object) -> None:
         raise
     except SettingsError as err:
         typer.echo(render_cli_error(err, verbose=state.verbose), err=True)
+        raise typer.Exit(code=1)
+    except ModuleNotFoundError as err:
+        typer.echo(str(err), err=True)
         raise typer.Exit(code=1)
     except OSError as err:
         typer.echo(str(err), err=True)
@@ -195,6 +211,38 @@ def _prompt_for_sonos_household_selection(households: list[GroupedSonosHousehold
         return None
 
 
+def _prompt_for_pn532_profile(profiles: list[str]) -> Optional[str]:
+    import questionary
+
+    try:
+        return questionary.select("Select a PN532 board profile", choices=profiles).ask()
+    except KeyboardInterrupt:
+        return None
+
+
+def _prompt_for_pn532_protocol(protocols: list[str], default: str) -> Optional[str]:
+    import questionary
+
+    try:
+        return questionary.select("Select a PN532 protocol", choices=protocols, default=default).ask()
+
+    except KeyboardInterrupt:
+        return None
+
+
+def _prompt_for_pn532_pin(pin_name: str, default: Optional[int]) -> Optional[str]:
+    import questionary
+
+    default_str = str(default) if default is not None else ""
+    try:
+        return questionary.text(
+            f"SPI {pin_name} pin (GPIO number, leave blank to clear):",
+            default=default_str,
+        ).ask()
+    except KeyboardInterrupt:
+        return None
+
+
 def _prompt_for_sonos_group_coordinator(speakers: list[DiscoveredSonosSpeaker]) -> Optional[str]:
     import questionary
 
@@ -223,9 +271,11 @@ app = typer.Typer(help="Admin CLI for jukebox")
 settings_app = typer.Typer(help="Inspect and manage application settings")
 library_app = typer.Typer(help="Manage the library")
 sonos_app = typer.Typer(help="Inspect Sonos speakers and manage the saved Sonos selection")
+pn532_app = typer.Typer(help="Inspect and debug the PN532 NFC reader")
 app.add_typer(settings_app, name="settings")
 app.add_typer(library_app, name="library")
 app.add_typer(sonos_app, name="sonos")
+app.add_typer(pn532_app, name="pn532")
 
 
 @app.callback()
@@ -377,6 +427,33 @@ def sonos_select(
 @sonos_app.command("show")
 def sonos_show(ctx: typer.Context) -> None:
     _run_command(ctx, SonosShowCommand(type="sonos_show"))
+
+
+@pn532_app.command("profiles")
+def pn532_profiles(ctx: typer.Context) -> None:
+    """List available board profiles and their default GPIO pins."""
+    _run_command(ctx, Pn532ProfilesCommand(type="pn532_profiles"))
+
+
+@pn532_app.command("select")
+def pn532_select(
+    ctx: typer.Context,
+    profile: Annotated[
+        Optional[str],
+        typer.Option(
+            "--profile",
+            help="board profile to persist (waveshare_hat, hiletgo_v3, custom)",
+        ),
+    ] = None,
+) -> None:
+    """Select a board profile and persist it to settings."""
+    _run_command(ctx, Pn532SelectCommand(type="pn532_select", profile=profile))
+
+
+@pn532_app.command("probe")
+def pn532_probe(ctx: typer.Context) -> None:
+    """Verify the PN532 is connected, show firmware version and attempt one tag read."""
+    _run_command(ctx, Pn532ProbeCommand(type="pn532_probe"))
 
 
 @library_app.command("add")

--- a/jukebox/admin/cli_presentation.py
+++ b/jukebox/admin/cli_presentation.py
@@ -11,6 +11,7 @@ from jukebox.settings.errors import (
 )
 from jukebox.settings.types import JsonObject, JsonValue
 from jukebox.settings.view_utils import MISSING, lookup_object, lookup_optional_dotted_path, lookup_provenance_label
+from jukebox.shared.terminal_ui import table
 from jukebox.sonos.discovery import DiscoveredSonosSpeaker
 from jukebox.sonos.selection import SonosSelectionResult, SonosSelectionStatus
 
@@ -51,26 +52,12 @@ def render_cli_error(err: BaseException, verbose: bool = False) -> str:
 def render_sonos_speakers_output(households: list[GroupedSonosHousehold]) -> str:
     if not households:
         return "No visible Sonos speakers found."
-
-    all_speakers = [speaker for household in households for speaker in household.speakers]
-    name_width = max(len(speaker.name) for speaker in all_speakers)
-    host_width = max(len(speaker.host) for speaker in all_speakers)
-    lines = []
+    headers = ["name", "host", "uid"]
+    sections = []
     for household in households:
-        lines.append(f"Household: {household.household_id}")
-        for index, speaker in enumerate(household.speakers, start=1):
-            lines.append(
-                "  {index}. {name:<{name_width}}   {host:<{host_width}}   {uid}".format(
-                    index=index,
-                    name=speaker.name,
-                    name_width=name_width,
-                    host=speaker.host,
-                    host_width=host_width,
-                    uid=speaker.uid,
-                )
-            )
-        lines.append("")
-    return "\n".join(lines[:-1])
+        rows = [[s.name, s.host, s.uid] for s in household.speakers]
+        sections.append(f"Household: {household.household_id}\n\n" + table(headers, rows, indexed=True))
+    return "Sonos speakers:\n\n" + "\n\n".join(sections)
 
 
 def build_sonos_household_choice_label(household: GroupedSonosHousehold) -> str:

--- a/jukebox/admin/pn532_command_handlers.py
+++ b/jukebox/admin/pn532_command_handlers.py
@@ -32,17 +32,13 @@ def _default_build_pn532_reader(
     raise ValueError(f"Unsupported PN532 protocol: {protocol}")
 
 
-def _parse_pin(raw: Optional[str]) -> "tuple[bool, Optional[int]]":
-    """Returns (ok, value). ok=False means the user cancelled the prompt."""
+def _parse_pin(raw: Optional[str]) -> "tuple[bool, Optional[str]]":
+    """Returns (ok, value). ok=False means the user cancelled the prompt.
+    value=None means blank input (reset to profile default)."""
     if raw is None:
         return False, None
     stripped = raw.strip()
-    if not stripped:
-        return True, None
-    try:
-        return True, int(stripped)
-    except ValueError:
-        return True, None
+    return True, stripped if stripped else None
 
 
 def execute_pn532_command(
@@ -90,7 +86,7 @@ def execute_pn532_command(
             )
 
         if pin_prompt_fn is not None:
-            field_values: dict[str, Optional[int]] = {}
+            field_values: dict[str, Optional[str]] = {}
             for f in dataclasses.fields(pin_defaults):
                 default = getattr(pin_defaults, f.name)
                 raw = pin_prompt_fn(f.name, default)
@@ -107,10 +103,16 @@ def execute_pn532_command(
             for f in dataclasses.fields(pin_defaults):
                 path = f"jukebox.reader.pn532.{selected_protocol}.{f.name}"
                 value = field_values[f.name]
-                if value is not None and value != getattr(pin_defaults, f.name):
-                    settings_service.set_persisted_value(path, str(value))
-                else:
+                profile_default = getattr(pin_defaults, f.name)
+                try:
+                    is_default = value is None or int(value) == profile_default
+                except ValueError:
+                    is_default = False
+                if is_default:
                     settings_service.reset_persisted_value(path)
+                else:
+                    assert value is not None
+                    settings_service.set_persisted_value(path, value)
             stdout_fn(render_pn532_configure_output(selected_profile, selected_protocol, pin_defaults, field_values))
         else:
             settings_service.set_persisted_value("jukebox.reader.pn532.board_profile", selected_profile)

--- a/jukebox/admin/pn532_command_handlers.py
+++ b/jukebox/admin/pn532_command_handlers.py
@@ -9,6 +9,7 @@ from jukebox.pn532.profiles import (
     resolve_connection_params,
 )
 from jukebox.settings.service_protocols import SettingsService
+from jukebox.shared.terminal_ui import table
 
 from .pn532_commands import Pn532ProbeCommand, Pn532ProfilesCommand, Pn532SelectCommand
 
@@ -167,17 +168,20 @@ def render_pn532_probe_setup_output(
 
 
 def render_pn532_profiles_output() -> str:
-    lines = ["Available board profiles:", ""]
-    name_width = max(len(name) for name in PN532_PROFILES)
+    by_protocol: dict[str, list[tuple[str, Any]]] = {}
     for name, profile in PN532_PROFILES.items():
         protocol = profile.default_protocol
-        connection = profile.connections[protocol]
-        fields = "  ".join(
-            f"{f.name}={getattr(connection, f.name) if getattr(connection, f.name) is not None else '-'}"
-            for f in dataclasses.fields(connection)
-        )
-        lines.append(f"  {name:<{name_width}}   protocol={protocol:<4}  {fields}")
-    return "\n".join(lines)
+        by_protocol.setdefault(protocol, []).append((name, profile.connections[protocol]))
+    sections = []
+    for protocol, entries in by_protocol.items():
+        field_names = [f.name for f in dataclasses.fields(entries[0][1])]
+        headers = ["name", *field_names]
+        rows = [
+            [name, *("-" if getattr(conn, f) is None else getattr(conn, f) for f in field_names)]
+            for name, conn in entries
+        ]
+        sections.append(f"Protocol: {protocol}\n\n" + table(headers, rows, indexed=True))
+    return "Available predefined board profiles:\n\n" + "\n\n".join(sections)
 
 
 def render_pn532_select_output(profile: str) -> str:

--- a/jukebox/admin/pn532_command_handlers.py
+++ b/jukebox/admin/pn532_command_handlers.py
@@ -1,0 +1,216 @@
+import dataclasses
+from typing import Any, Callable, Optional, cast
+
+from jukebox.pn532.profiles import (
+    PN532_PROFILES,
+    Pn532ConnectionParams,
+    Pn532Protocol,
+    SpiConnectionParams,
+    resolve_connection_params,
+)
+from jukebox.settings.service_protocols import SettingsService
+
+from .pn532_commands import Pn532ProbeCommand, Pn532ProfilesCommand, Pn532SelectCommand
+
+
+def _default_build_pn532_reader(
+    read_timeout_seconds: float,
+    protocol: Pn532Protocol,
+    connection: Pn532ConnectionParams,
+) -> Any:
+    from jukebox.adapters.outbound.readers.pn532_reader_adapter import Pn532ReaderAdapter
+
+    if protocol == "spi":
+        if not isinstance(connection, SpiConnectionParams):
+            raise ValueError(f"Expected SpiConnectionParams for protocol 'spi', got {type(connection).__name__}")
+        return Pn532ReaderAdapter(
+            read_timeout_seconds=read_timeout_seconds,
+            spi_reset=connection.reset,
+            spi_cs=connection.cs,
+            spi_irq=connection.irq,
+        )
+    raise ValueError(f"Unsupported PN532 protocol: {protocol}")
+
+
+def _parse_pin(raw: Optional[str]) -> "tuple[bool, Optional[int]]":
+    """Returns (ok, value). ok=False means the user cancelled the prompt."""
+    if raw is None:
+        return False, None
+    stripped = raw.strip()
+    if not stripped:
+        return True, None
+    try:
+        return True, int(stripped)
+    except ValueError:
+        return True, None
+
+
+def execute_pn532_command(
+    command: object,
+    settings_service: SettingsService,
+    profile_prompt_fn: Optional[Callable[[list], Optional[str]]] = None,
+    protocol_prompt_fn: Optional[Callable[[list, str], Optional[str]]] = None,
+    pin_prompt_fn: Optional[Callable[[str, Optional[int]], Optional[str]]] = None,
+    build_pn532_reader: Callable[..., Any] = _default_build_pn532_reader,
+    stdout_fn: Callable[[str], None] = print,
+) -> None:
+    if isinstance(command, Pn532ProfilesCommand):
+        stdout_fn(render_pn532_profiles_output())
+        return
+
+    if isinstance(command, Pn532SelectCommand):
+        if command.profile is not None:
+            selected = command.profile
+            settings_service.set_persisted_value("jukebox.reader.pn532.board_profile", selected)
+            stdout_fn(render_pn532_select_output(selected))
+            return
+
+        # Interactive mode
+        if profile_prompt_fn is None:
+            raise RuntimeError("Interactive PN532 profile selection is not available in this context.")
+        selected_profile = profile_prompt_fn(list(PN532_PROFILES.keys()))
+        if selected_profile is None:
+            return
+
+        defaults = PN532_PROFILES.get(cast(Any, selected_profile))
+        if defaults is None:
+            raise RuntimeError(f"Unknown board profile: {selected_profile!r}")
+
+        selected_protocol = defaults.default_protocol
+        if protocol_prompt_fn is not None:
+            prompted = protocol_prompt_fn(list(defaults.connections.keys()), defaults.default_protocol)
+            if prompted is None:
+                return
+            selected_protocol = prompted
+
+        pin_defaults = defaults.connections.get(cast(Pn532Protocol, selected_protocol))
+        if pin_defaults is None:
+            raise RuntimeError(
+                f"Protocol '{selected_protocol}' is not supported by board profile '{selected_profile}'."
+            )
+
+        if pin_prompt_fn is not None:
+            field_values: dict[str, Optional[int]] = {}
+            for f in dataclasses.fields(pin_defaults):
+                default = getattr(pin_defaults, f.name)
+                raw = pin_prompt_fn(f.name, default)
+                ok, value = _parse_pin(raw)
+                if not ok:
+                    return
+                field_values[f.name] = value
+
+            settings_service.set_persisted_value("jukebox.reader.pn532.board_profile", selected_profile)
+            if selected_protocol != defaults.default_protocol:
+                settings_service.set_persisted_value("jukebox.reader.pn532.protocol", selected_protocol)
+            else:
+                settings_service.reset_persisted_value("jukebox.reader.pn532.protocol")
+            for f in dataclasses.fields(pin_defaults):
+                path = f"jukebox.reader.pn532.{selected_protocol}.{f.name}"
+                value = field_values[f.name]
+                if value is not None and value != getattr(pin_defaults, f.name):
+                    settings_service.set_persisted_value(path, str(value))
+                else:
+                    settings_service.reset_persisted_value(path)
+            stdout_fn(render_pn532_configure_output(selected_profile, selected_protocol, pin_defaults, field_values))
+        else:
+            settings_service.set_persisted_value("jukebox.reader.pn532.board_profile", selected_profile)
+            stdout_fn(render_pn532_select_output(selected_profile))
+        return
+
+    if isinstance(command, Pn532ProbeCommand):
+        pn532 = settings_service.get_effective_settings().jukebox.reader.pn532
+        overrides = SpiConnectionParams(reset=pn532.spi.reset, cs=pn532.spi.cs, irq=pn532.spi.irq)
+        resolved = resolve_connection_params(pn532.board_profile, pn532.protocol, overrides)
+
+        stdout_fn(render_pn532_probe_setup_output(pn532.board_profile, pn532.protocol, resolved))
+
+        try:
+            reader = build_pn532_reader(
+                read_timeout_seconds=pn532.read_timeout_seconds,
+                protocol=pn532.protocol,
+                connection=resolved,
+            )
+        except (ModuleNotFoundError, RuntimeError):
+            raise
+        except Exception as err:
+            msg = str(err)
+            if any(s in msg.lower() for s in ("not permitted", "permission", "bad gpio")):
+                raise RuntimeError(
+                    "GPIO error — your pin configuration may be incorrect.\n"
+                    "Update it with: jukebox-admin pn532 select\n"
+                    "Re-run with `--verbose` for details."
+                ) from err
+            raise RuntimeError(msg) from err
+
+        ver, rev = reader.firmware_version
+        stdout_fn(f"PN532 firmware version: {ver}.{rev}")
+
+        uid = reader.read()
+        stdout_fn(f"Tag UID: {uid}" if uid else "No tag detected")
+        return
+
+    raise TypeError("Unsupported PN532 command")
+
+
+def render_pn532_probe_setup_output(
+    board_profile: str,
+    protocol: str,
+    connection: Pn532ConnectionParams,
+) -> str:
+    fields = "  ".join(
+        f"{f.name}={getattr(connection, f.name) if getattr(connection, f.name) is not None else '-'}"
+        for f in dataclasses.fields(connection)
+    )
+    return f"Probing — profile={board_profile}  protocol={protocol}  {fields}"
+
+
+def render_pn532_profiles_output() -> str:
+    lines = ["Available board profiles:", ""]
+    name_width = max(len(name) for name in PN532_PROFILES)
+    for name, profile in PN532_PROFILES.items():
+        protocol = profile.default_protocol
+        connection = profile.connections[protocol]
+        fields = "  ".join(
+            f"{f.name}={getattr(connection, f.name) if getattr(connection, f.name) is not None else '-'}"
+            for f in dataclasses.fields(connection)
+        )
+        lines.append(f"  {name:<{name_width}}   protocol={protocol:<4}  {fields}")
+    return "\n".join(lines)
+
+
+def render_pn532_select_output(profile: str) -> str:
+    defaults = PN532_PROFILES.get(cast(Any, profile))
+    if defaults is None:
+        return f"Board profile saved: {profile}"
+    protocol = defaults.default_protocol
+    connection = defaults.connections[protocol]
+    fields = "  ".join(
+        f"{f.name}={getattr(connection, f.name) if getattr(connection, f.name) is not None else '-'}"
+        for f in dataclasses.fields(connection)
+    )
+    return "\n".join(
+        [
+            f"Board profile saved: {profile}",
+            f"Protocol: {protocol}",
+            f"Default pins — {fields}",
+        ]
+    )
+
+
+def render_pn532_configure_output(
+    profile: str,
+    protocol: str,
+    connection: Pn532ConnectionParams,
+    field_values: dict[str, Optional[str]],
+) -> str:
+    fields = "  ".join(
+        f"{f.name}={field_values[f.name] if field_values[f.name] is not None else '-'}"
+        for f in dataclasses.fields(connection)
+    )
+    return "\n".join(
+        [
+            f"Board profile saved: {profile}",
+            f"Protocol: {protocol}",
+            f"Pins saved — {fields}",
+        ]
+    )

--- a/jukebox/admin/pn532_commands.py
+++ b/jukebox/admin/pn532_commands.py
@@ -1,0 +1,20 @@
+from typing import Literal, Optional
+
+from pydantic import BaseModel
+
+
+class Pn532ProfilesCommand(BaseModel):
+    type: Literal["pn532_profiles"]
+
+
+class Pn532SelectCommand(BaseModel):
+    type: Literal["pn532_select"]
+    profile: Optional[str] = None
+
+
+class Pn532ProbeCommand(BaseModel):
+    type: Literal["pn532_probe"]
+
+
+def is_pn532_command(command: object) -> bool:
+    return isinstance(command, (Pn532ProfilesCommand, Pn532SelectCommand, Pn532ProbeCommand))

--- a/jukebox/di_container.py
+++ b/jukebox/di_container.py
@@ -29,7 +29,8 @@ def build_jukebox(config: ResolvedJukeboxRuntimeConfig):
 
         if config.pn532_protocol == "spi":
             conn = config.pn532_connection
-            assert isinstance(conn, SpiConnectionParams)
+            if not isinstance(conn, SpiConnectionParams):
+                raise ValueError(f"Expected SpiConnectionParams for protocol 'spi', got {type(conn).__name__}")
             reader = Pn532ReaderAdapter(
                 read_timeout_seconds=config.pn532_read_timeout_seconds,
                 spi_reset=conn.reset,

--- a/jukebox/shared/terminal_ui.py
+++ b/jukebox/shared/terminal_ui.py
@@ -1,0 +1,12 @@
+def table(headers, rows, indexed=False):
+    if indexed:
+        headers = ["#"] + headers
+        rows = [[i + 1] + list(row) for i, row in enumerate(rows)]
+
+    cols = list(zip(headers, *rows))
+    widths = [max(len(str(x)) for x in col) for col in cols]
+
+    def fmt(row):
+        return "  ".join(f"{str(val):<{widths[i]}}" for i, val in enumerate(row))
+
+    return "\n".join([fmt(headers), *map(fmt, rows)])

--- a/tests/jukebox/admin/test_app.py
+++ b/tests/jukebox/admin/test_app.py
@@ -287,8 +287,9 @@ def test_prompt_for_sonos_household_selection_prints_full_list_and_uses_short_la
 
     captured = capsys.readouterr()
     assert "Household: household-1" in captured.out
-    assert "1. Kitchen" in captured.out
-    assert "2. Living Room" in captured.out
+    lines = captured.out.splitlines()
+    assert "1  Kitchen      192.168.1.30  speaker-1" in lines
+    assert "2  Living Room  192.168.1.31  speaker-2" in lines
     assert result == "household-1"
     assert [choice.title for choice in select.call_args.kwargs["choices"]] == ["household-1 (2 speakers)"]
 

--- a/tests/jukebox/admin/test_app.py
+++ b/tests/jukebox/admin/test_app.py
@@ -26,6 +26,7 @@ from jukebox.admin.commands import (
     SonosShowCommand,
     UiCommand,
 )
+from jukebox.admin.pn532_commands import Pn532ProbeCommand, Pn532ProfilesCommand, Pn532SelectCommand
 from jukebox.admin.sonos_households import GroupedSonosHousehold
 from jukebox.sonos.discovery import DiscoveredSonosSpeaker
 
@@ -42,6 +43,7 @@ def app_mocks(mocker):
         execute_sonos_command = mocker.patch("jukebox.admin.app.execute_sonos_command")
         execute_server_command = mocker.patch("jukebox.admin.app.execute_server_command")
         execute_library_command = mocker.patch("jukebox.admin.app.execute_library_command")
+        execute_pn532_command = mocker.patch("jukebox.admin.app.execute_pn532_command")
         build_api_app = mocker.patch("jukebox.admin.app.build_admin_api_app")
         build_ui_app = mocker.patch("jukebox.admin.app.build_admin_ui_app")
         build_cli_controller = mocker.patch("jukebox.admin.app.build_cli_controller")
@@ -91,6 +93,13 @@ def app_mocks(mocker):
             "execute_sonos_command",
         ),
         (["sonos", "show"], SonosShowCommand(type="sonos_show"), "execute_sonos_command"),
+        (["pn532", "profiles"], Pn532ProfilesCommand(type="pn532_profiles"), "execute_pn532_command"),
+        (
+            ["pn532", "select", "--profile", "hiletgo_v3"],
+            Pn532SelectCommand(type="pn532_select", profile="hiletgo_v3"),
+            "execute_pn532_command",
+        ),
+        (["pn532", "probe"], Pn532ProbeCommand(type="pn532_probe"), "execute_pn532_command"),
         (["api", "--port", "9000"], ApiCommand(type="api", port=9000), "execute_server_command"),
         (["ui", "--port", "9100"], UiCommand(type="ui", port=9100), "execute_server_command"),
     ],
@@ -128,6 +137,18 @@ def test_jukebox_admin_routes_admin_commands_by_category(app_mocks, args, expect
             status_fn=ANY,
         )
         app_mocks.execute_settings_command.assert_not_called()
+        app_mocks.execute_server_command.assert_not_called()
+    elif executor_name == "execute_pn532_command":
+        executor.assert_called_once_with(
+            command=expected_command,
+            settings_service=services.settings,
+            profile_prompt_fn=ANY,
+            protocol_prompt_fn=ANY,
+            pin_prompt_fn=ANY,
+            stdout_fn=ANY,
+        )
+        app_mocks.execute_settings_command.assert_not_called()
+        app_mocks.execute_sonos_command.assert_not_called()
         app_mocks.execute_server_command.assert_not_called()
     else:
         executor.assert_called_once_with(
@@ -184,6 +205,18 @@ def test_jukebox_admin_preserves_library_validation_errors(app_mocks):
 
     assert result.exit_code == 1
     assert "No current tag is available." in result.output
+    assert "Unexpected error. Re-run with `--verbose` for details." not in result.output
+
+
+def test_jukebox_admin_shows_module_not_found_message_without_verbose_prompt(app_mocks):
+    services = MagicMock(settings=MagicMock(), sonos=MagicMock())
+    app_mocks.build_admin_services.return_value = services
+    app_mocks.execute_pn532_command.side_effect = ModuleNotFoundError("No module named 'pn532_nonexistent_extra'")
+
+    result = runner.invoke(app, ["pn532", "probe"])
+
+    assert result.exit_code == 1
+    assert "No module named 'pn532_nonexistent_extra'" in result.output
     assert "Unexpected error. Re-run with `--verbose` for details." not in result.output
 
 

--- a/tests/jukebox/admin/test_cli_presentation.py
+++ b/tests/jukebox/admin/test_cli_presentation.py
@@ -313,8 +313,52 @@ def test_render_sonos_speakers_output_is_stable_and_human_readable():
     )
 
     assert "Household: household-1" in rendered
-    assert "1. Kitchen   192.168.1.30   speaker-1" in rendered
-    assert "2. Kitchen   192.168.1.40   speaker-2" in rendered
+    lines = rendered.splitlines()
+    assert "1  Kitchen  192.168.1.30  speaker-1" in lines
+    assert "2  Kitchen  192.168.1.40  speaker-2" in lines
+
+
+def test_render_sonos_speakers_output_shows_each_household_as_section():
+    rendered = render_sonos_speakers_output(
+        [
+            GroupedSonosHousehold(
+                household_id="household-1",
+                speakers=(
+                    DiscoveredSonosSpeaker(
+                        uid="speaker-1",
+                        name="Kitchen",
+                        host="192.168.1.30",
+                        household_id="household-1",
+                        is_visible=True,
+                    ),
+                    DiscoveredSonosSpeaker(
+                        uid="speaker-2",
+                        name="Living Room",
+                        host="192.168.1.31",
+                        household_id="household-1",
+                        is_visible=True,
+                    ),
+                ),
+            ),
+            GroupedSonosHousehold(
+                household_id="household-2",
+                speakers=(
+                    DiscoveredSonosSpeaker(
+                        uid="speaker-3", name="Office", host="192.168.1.50", household_id="household-2", is_visible=True
+                    ),
+                ),
+            ),
+        ]
+    )
+
+    assert "Household: household-1" in rendered
+    assert "Household: household-2" in rendered
+    lines = rendered.splitlines()
+    # household-1: padding based on "Living Room" (longest name in this section)
+    assert "1  Kitchen      192.168.1.30  speaker-1" in lines
+    assert "2  Living Room  192.168.1.31  speaker-2" in lines
+    # household-2: padding based on "Office" only (independent section)
+    assert "1  Office  192.168.1.50  speaker-3" in lines
 
 
 def test_render_sonos_speakers_output_handles_empty_results():

--- a/tests/jukebox/admin/test_command_handlers.py
+++ b/tests/jukebox/admin/test_command_handlers.py
@@ -383,8 +383,9 @@ def test_execute_sonos_command_lists_visible_sonos_speakers():
     status_fn.assert_called_once_with("Discovering Sonos speakers...")
     rendered_output = stdout_fn.call_args.args[0]
     assert "Household: household-1" in rendered_output
-    assert "1. Kitchen" in rendered_output
-    assert "speaker-1" in rendered_output
+    lines = rendered_output.splitlines()
+    assert "1  Kitchen      192.168.1.30  speaker-1" in lines
+    assert "2  Living Room  192.168.1.40  speaker-2" in lines
 
 
 def test_execute_sonos_command_preserves_sonos_discovery_failures():

--- a/tests/jukebox/admin/test_pn532_command_handlers.py
+++ b/tests/jukebox/admin/test_pn532_command_handlers.py
@@ -1,0 +1,343 @@
+import dataclasses
+from unittest.mock import MagicMock
+
+import pytest
+
+from jukebox.admin.pn532_command_handlers import (
+    execute_pn532_command,
+    render_pn532_probe_setup_output,
+    render_pn532_profiles_output,
+    render_pn532_select_output,
+)
+from jukebox.admin.pn532_commands import Pn532ProbeCommand, Pn532ProfilesCommand, Pn532SelectCommand
+from jukebox.pn532.profiles import PN532_PROFILES, SpiConnectionParams
+
+
+def _make_settings_service(board_profile="waveshare_hat"):
+    service = MagicMock()
+    pn532 = MagicMock()
+    pn532.board_profile = board_profile
+    pn532.protocol = "spi"
+    pn532.read_timeout_seconds = 0.1
+    pn532.spi.reset = None
+    pn532.spi.cs = None
+    pn532.spi.irq = None
+    service.get_effective_settings.return_value.jukebox.reader.pn532 = pn532
+    return service
+
+
+# ── profiles ──────────────────────────────────────────────────────────────────
+
+
+def test_render_pn532_profiles_output_lists_all_profiles():
+    output = render_pn532_profiles_output()
+    for name in PN532_PROFILES:
+        assert name in output
+
+
+def test_render_pn532_profiles_output_shows_waveshare_hat_pins():
+    output = render_pn532_profiles_output()
+    assert "reset=20" in output
+    assert "cs=4" in output
+
+
+def test_render_pn532_profiles_output_shows_protocol():
+    output = render_pn532_profiles_output()
+    assert "protocol=spi" in output
+
+
+def test_render_pn532_profiles_output_shows_custom_as_dashes():
+    output = render_pn532_profiles_output()
+    assert "-" in output
+
+
+def test_render_pn532_profiles_output_fields_driven_by_connection_dataclass():
+    field_names = [f.name for f in dataclasses.fields(SpiConnectionParams)]
+    output = render_pn532_profiles_output()
+    for field_name in field_names:
+        assert field_name in output
+
+
+def test_execute_pn532_command_profiles_calls_stdout():
+    stdout_fn = MagicMock()
+    execute_pn532_command(
+        command=Pn532ProfilesCommand(type="pn532_profiles"),
+        settings_service=MagicMock(),
+        stdout_fn=stdout_fn,
+    )
+    stdout_fn.assert_called_once()
+    assert "waveshare_hat" in stdout_fn.call_args.args[0]
+
+
+# ── select ─────────────────────────────────────────────────────────────────────
+
+
+def test_execute_pn532_command_select_with_explicit_profile():
+    service = MagicMock()
+    stdout_fn = MagicMock()
+
+    execute_pn532_command(
+        command=Pn532SelectCommand(type="pn532_select", profile="hiletgo_v3"),
+        settings_service=service,
+        stdout_fn=stdout_fn,
+    )
+
+    service.set_persisted_value.assert_called_once_with("jukebox.reader.pn532.board_profile", "hiletgo_v3")
+    stdout_fn.assert_called_once()
+    assert "hiletgo_v3" in stdout_fn.call_args.args[0]
+
+
+def test_execute_pn532_command_select_explicit_shows_protocol():
+    stdout_fn = MagicMock()
+
+    execute_pn532_command(
+        command=Pn532SelectCommand(type="pn532_select", profile="waveshare_hat"),
+        settings_service=MagicMock(),
+        stdout_fn=stdout_fn,
+    )
+
+    assert "spi" in stdout_fn.call_args.args[0].lower()
+
+
+def test_execute_pn532_command_select_interactive_prompts_for_profile():
+    service = MagicMock()
+    profile_prompt_fn = MagicMock(return_value="waveshare_hat")
+
+    execute_pn532_command(
+        command=Pn532SelectCommand(type="pn532_select"),
+        settings_service=service,
+        profile_prompt_fn=profile_prompt_fn,
+    )
+
+    profile_prompt_fn.assert_called_once_with(list(PN532_PROFILES.keys()))
+    service.set_persisted_value.assert_called_once_with("jukebox.reader.pn532.board_profile", "waveshare_hat")
+
+
+def test_execute_pn532_command_select_interactive_fields_driven_by_connection_dataclass():
+    profile_prompt_fn = MagicMock(return_value="waveshare_hat")
+    pin_prompt_fn = MagicMock(side_effect=["20", "4", ""])
+
+    execute_pn532_command(
+        command=Pn532SelectCommand(type="pn532_select"),
+        settings_service=MagicMock(),
+        profile_prompt_fn=profile_prompt_fn,
+        pin_prompt_fn=pin_prompt_fn,
+    )
+
+    profile = PN532_PROFILES["waveshare_hat"]
+    expected_fields = dataclasses.fields(profile.connections[profile.default_protocol])
+    assert pin_prompt_fn.call_count == len(expected_fields)
+    for i, f in enumerate(expected_fields):
+        assert pin_prompt_fn.call_args_list[i].args[0] == f.name
+
+
+def test_execute_pn532_command_select_interactive_resets_defaults_not_persisted():
+    service = MagicMock()
+    profile_prompt_fn = MagicMock(return_value="waveshare_hat")
+    pin_prompt_fn = MagicMock(side_effect=["20", "4", ""])
+
+    execute_pn532_command(
+        command=Pn532SelectCommand(type="pn532_select"),
+        settings_service=service,
+        profile_prompt_fn=profile_prompt_fn,
+        pin_prompt_fn=pin_prompt_fn,
+    )
+
+    # profile is always written explicitly
+    service.set_persisted_value.assert_called_once_with("jukebox.reader.pn532.board_profile", "waveshare_hat")
+    # protocol and all pins match profile defaults: all reset (not persisted)
+    service.reset_persisted_value.assert_any_call("jukebox.reader.pn532.protocol")
+    service.reset_persisted_value.assert_any_call("jukebox.reader.pn532.spi.reset")
+    service.reset_persisted_value.assert_any_call("jukebox.reader.pn532.spi.cs")
+    service.reset_persisted_value.assert_any_call("jukebox.reader.pn532.spi.irq")
+    assert service.reset_persisted_value.call_count == 4
+
+
+def test_execute_pn532_command_select_interactive_writes_only_overrides():
+    service = MagicMock()
+    profile_prompt_fn = MagicMock(return_value="waveshare_hat")
+    pin_prompt_fn = MagicMock(side_effect=["24", "4", ""])
+
+    execute_pn532_command(
+        command=Pn532SelectCommand(type="pn532_select"),
+        settings_service=service,
+        profile_prompt_fn=profile_prompt_fn,
+        pin_prompt_fn=pin_prompt_fn,
+    )
+
+    # reset differs from profile default: written explicitly
+    service.set_persisted_value.assert_any_call("jukebox.reader.pn532.spi.reset", "24")
+    # cs matches default: reset
+    service.reset_persisted_value.assert_any_call("jukebox.reader.pn532.spi.cs")
+    # irq matches default (None): reset
+    service.reset_persisted_value.assert_any_call("jukebox.reader.pn532.spi.irq")
+
+
+def test_execute_pn532_command_select_interactive_protocol_cancel_does_not_write():
+    service = MagicMock()
+    profile_prompt_fn = MagicMock(return_value="waveshare_hat")
+    protocol_prompt_fn = MagicMock(return_value=None)
+
+    execute_pn532_command(
+        command=Pn532SelectCommand(type="pn532_select"),
+        settings_service=service,
+        profile_prompt_fn=profile_prompt_fn,
+        protocol_prompt_fn=protocol_prompt_fn,
+    )
+
+    service.set_persisted_value.assert_not_called()
+
+
+def test_execute_pn532_command_select_interactive_pin_cancel_does_not_write():
+    service = MagicMock()
+    profile_prompt_fn = MagicMock(return_value="waveshare_hat")
+    # User cancels on second pin
+    pin_prompt_fn = MagicMock(side_effect=["20", None])
+
+    execute_pn532_command(
+        command=Pn532SelectCommand(type="pn532_select"),
+        settings_service=service,
+        profile_prompt_fn=profile_prompt_fn,
+        pin_prompt_fn=pin_prompt_fn,
+    )
+
+    service.set_persisted_value.assert_not_called()
+
+
+def test_execute_pn532_command_select_cancel_does_not_write_settings():
+    service = MagicMock()
+    profile_prompt_fn = MagicMock(return_value=None)
+    stdout_fn = MagicMock()
+
+    execute_pn532_command(
+        command=Pn532SelectCommand(type="pn532_select"),
+        settings_service=service,
+        profile_prompt_fn=profile_prompt_fn,
+        stdout_fn=stdout_fn,
+    )
+
+    service.set_persisted_value.assert_not_called()
+    stdout_fn.assert_not_called()
+
+
+def test_render_pn532_select_output_shows_profile_and_pins():
+    output = render_pn532_select_output("waveshare_hat")
+    assert "waveshare_hat" in output
+    assert "reset=20" in output
+    assert "cs=4" in output
+
+
+def test_render_pn532_select_output_shows_protocol():
+    output = render_pn532_select_output("waveshare_hat")
+    assert "spi" in output.lower()
+
+
+def test_render_pn532_select_output_unknown_profile_shows_name_only():
+    output = render_pn532_select_output("unknown_board")
+    assert "unknown_board" in output
+
+
+def test_render_pn532_probe_setup_output_shows_profile_protocol_and_pins():
+    output = render_pn532_probe_setup_output("waveshare_hat", "spi", SpiConnectionParams(reset=20, cs=4, irq=None))
+    assert "waveshare_hat" in output
+    assert "spi" in output
+    assert "reset=20" in output
+    assert "cs=4" in output
+    assert "irq=-" in output
+
+
+def test_render_pn532_probe_setup_output_shows_dash_for_none_pin():
+    output = render_pn532_probe_setup_output("custom", "spi", SpiConnectionParams(reset=None, cs=None, irq=None))
+    assert "reset=-" in output
+    assert "cs=-" in output
+
+
+# ── probe ──────────────────────────────────────────────────────────────────────
+
+
+def _make_reader(firmware_version=(1, 6), uid=None):
+    mock_reader = MagicMock()
+    mock_reader.firmware_version = firmware_version
+    mock_reader.read.return_value = uid
+    return MagicMock(return_value=mock_reader)
+
+
+def test_execute_pn532_command_probe_shows_setup_firmware_and_uid():
+    service = _make_settings_service()
+    stdout_fn = MagicMock()
+
+    execute_pn532_command(
+        command=Pn532ProbeCommand(type="pn532_probe"),
+        settings_service=service,
+        build_pn532_reader=_make_reader(firmware_version=(1, 6), uid="04:ab:cd:ef"),
+        stdout_fn=stdout_fn,
+    )
+
+    calls = [call.args[0] for call in stdout_fn.call_args_list]
+    assert any("waveshare_hat" in c for c in calls)
+    assert any("spi" in c for c in calls)
+    assert any("1.6" in c for c in calls)
+    assert any("04:ab:cd:ef" in c for c in calls)
+
+
+def test_execute_pn532_command_probe_build_reader_receives_protocol_and_connection():
+    service = _make_settings_service()
+    build_fn = _make_reader()
+
+    execute_pn532_command(
+        command=Pn532ProbeCommand(type="pn532_probe"),
+        settings_service=service,
+        build_pn532_reader=build_fn,
+    )
+
+    call_kwargs = build_fn.call_args.kwargs
+    assert "protocol" in call_kwargs
+    assert "connection" in call_kwargs
+    assert isinstance(call_kwargs["connection"], SpiConnectionParams)
+    assert "spi_reset" not in call_kwargs
+    assert "spi_cs" not in call_kwargs
+    assert "spi_irq" not in call_kwargs
+
+
+def test_execute_pn532_command_probe_shows_no_tag_detected():
+    service = _make_settings_service()
+    stdout_fn = MagicMock()
+
+    execute_pn532_command(
+        command=Pn532ProbeCommand(type="pn532_probe"),
+        settings_service=service,
+        build_pn532_reader=_make_reader(uid=None),
+        stdout_fn=stdout_fn,
+    )
+
+    calls = [call.args[0] for call in stdout_fn.call_args_list]
+    assert any("No tag detected" in c for c in calls)
+
+
+def test_execute_pn532_command_probe_propagates_missing_extra():
+    service = _make_settings_service()
+
+    def failing_builder(**_kwargs):
+        raise ModuleNotFoundError("pn532 extra not installed")
+
+    with pytest.raises(ModuleNotFoundError):
+        execute_pn532_command(
+            command=Pn532ProbeCommand(type="pn532_probe"),
+            settings_service=service,
+            build_pn532_reader=failing_builder,
+        )
+
+
+@pytest.mark.parametrize("raw_error", ["GPIO operation not permitted", "bad GPIO number"])
+def test_execute_pn532_command_probe_gpio_error_shows_friendly_message(raw_error):
+    service = _make_settings_service()
+
+    def failing_builder(**_kwargs):
+        raise Exception(raw_error)
+
+    with pytest.raises(RuntimeError, match="GPIO error"):
+        execute_pn532_command(
+            command=Pn532ProbeCommand(type="pn532_probe"),
+            settings_service=service,
+            build_pn532_reader=failing_builder,
+        )

--- a/tests/jukebox/admin/test_pn532_command_handlers.py
+++ b/tests/jukebox/admin/test_pn532_command_handlers.py
@@ -38,14 +38,13 @@ def test_render_pn532_profiles_output_lists_all_profiles():
 
 
 def test_render_pn532_profiles_output_shows_waveshare_hat_pins():
-    output = render_pn532_profiles_output()
-    assert "reset=20" in output
-    assert "cs=4" in output
+    lines = render_pn532_profiles_output().splitlines()
+    assert "1  waveshare_hat  20     4   -  " in lines
 
 
 def test_render_pn532_profiles_output_shows_protocol():
-    output = render_pn532_profiles_output()
-    assert "protocol=spi" in output
+    lines = render_pn532_profiles_output().splitlines()
+    assert lines[2] == "Protocol: spi"
 
 
 def test_render_pn532_profiles_output_shows_custom_as_dashes():

--- a/tests/jukebox/admin/test_pn532_command_handlers.py
+++ b/tests/jukebox/admin/test_pn532_command_handlers.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from jukebox.admin.pn532_command_handlers import (
+    _parse_pin,
     execute_pn532_command,
     render_pn532_probe_setup_output,
     render_pn532_profiles_output,
@@ -11,6 +12,7 @@ from jukebox.admin.pn532_command_handlers import (
 )
 from jukebox.admin.pn532_commands import Pn532ProbeCommand, Pn532ProfilesCommand, Pn532SelectCommand
 from jukebox.pn532.profiles import PN532_PROFILES, SpiConnectionParams
+from jukebox.settings.errors import InvalidSettingsError
 
 
 def _make_settings_service(board_profile="waveshare_hat"):
@@ -218,6 +220,45 @@ def test_execute_pn532_command_select_cancel_does_not_write_settings():
 
     service.set_persisted_value.assert_not_called()
     stdout_fn.assert_not_called()
+
+
+def test_execute_pn532_command_select_interactive_invalid_pin_propagates_settings_error():
+    service = MagicMock()
+    service.set_persisted_value.side_effect = InvalidSettingsError("invalid value for spi.cs")
+    profile_prompt_fn = MagicMock(return_value="waveshare_hat")
+    pin_prompt_fn = MagicMock(side_effect=["20", "not_a_number", ""])
+
+    with pytest.raises(InvalidSettingsError):
+        execute_pn532_command(
+            command=Pn532SelectCommand(type="pn532_select"),
+            settings_service=service,
+            profile_prompt_fn=profile_prompt_fn,
+            pin_prompt_fn=pin_prompt_fn,
+        )
+
+
+def test_parse_pin_blank_returns_none():
+    ok, value = _parse_pin("")
+    assert ok is True
+    assert value is None
+
+
+def test_parse_pin_cancel_returns_not_ok():
+    ok, value = _parse_pin(None)
+    assert ok is False
+
+
+def test_parse_pin_valid_input_returns_raw_string():
+    ok, value = _parse_pin("24")
+    assert ok is True
+    assert value == "24"
+
+
+def test_parse_pin_invalid_input_returns_raw_string():
+    # _parse_pin does not validate — type checking is delegated to the settings layer
+    ok, value = _parse_pin("not_a_number")
+    assert ok is True
+    assert value == "not_a_number"
 
 
 def test_render_pn532_select_output_shows_profile_and_pins():

--- a/tests/jukebox/shared/test_terminal_ui.py
+++ b/tests/jukebox/shared/test_terminal_ui.py
@@ -1,0 +1,76 @@
+from jukebox.shared.terminal_ui import table
+
+
+def test_table_renders_header_and_single_row():
+    result = table(["col"], [["val"]])
+    lines = result.splitlines()
+    assert lines[0] == "col"
+    assert lines[1] == "val"
+
+
+def test_table_columns_separated_by_two_spaces():
+    result = table(["a", "b"], [["x", "y"]])
+    lines = result.splitlines()
+    assert lines[0] == "a  b"
+    assert lines[1] == "x  y"
+
+
+def test_table_header_padded_to_data_width():
+    result = table(["n"], [["Alice"]])
+    lines = result.splitlines()
+    assert lines[0] == "n    "
+    assert lines[1] == "Alice"
+
+
+def test_table_data_padded_to_header_width():
+    result = table(["identifier"], [["x"]])
+    lines = result.splitlines()
+    assert lines[0] == "identifier"
+    assert lines[1] == "x         "
+
+
+def test_table_widths_computed_across_all_rows():
+    result = table(["n"], [["Al"], ["Alexander"]])
+    lines = result.splitlines()
+    assert lines[0] == "n        "
+    assert lines[1] == "Al       "
+    assert lines[2] == "Alexander"
+
+
+def test_table_indexed_adds_hash_column():
+    result = table(["name"], [["Alice"]], indexed=True)
+    lines = result.splitlines()
+    assert lines[0] == "#  name "
+    assert lines[1] == "1  Alice"
+
+
+def test_table_indexed_numbers_rows_from_one():
+    result = table(["v"], [["a"], ["b"], ["c"]], indexed=True)
+    lines = result.splitlines()
+    assert lines[0] == "#  v"
+    assert lines[1] == "1  a"
+    assert lines[2] == "2  b"
+    assert lines[3] == "3  c"
+
+
+def test_table_indexed_table_row_number_padding():
+    result = table(["v"], [["x"]] * 100, indexed=True)
+    lines = result.splitlines()
+    assert lines[0] == "#    v"
+    assert lines[1] == "1    x"
+    assert lines[10] == "10   x"
+    assert lines[100] == "100  x"
+
+
+def test_table_empty_rows_renders_header_only():
+    result = table(["name", "host"], [])
+    lines = result.splitlines()
+    assert len(lines) == 1
+    assert lines[0] == "name  host"
+
+
+def test_table_stringifies_integer_values():
+    result = table(["count"], [[42]])
+    lines = result.splitlines()
+    assert lines[0] == "count"
+    assert lines[1] == "42   "


### PR DESCRIPTION
## Summary

Part of #152 

Requires #231 

Add three commands for `jukebox-admin pn532`:
- `profiles` to list available board profiles and their default GPIO pins
- `select` to select a board profile and persist it to settings
- `probe` to verify the PN532 is connected, show firmware version and attempt one tag read

Pin settings that match profile defaults are not persisted by the `select` command.

