### PR TITLE
🐛 Create parent directory when writing library.json for the first time

### DIFF
--- a/jukebox/adapters/outbound/json_library_adapter.py
+++ b/jukebox/adapters/outbound/json_library_adapter.py
@@ -37,6 +37,7 @@ class JsonLibraryAdapter(LibraryRepository):
 
     def _write_library(self, library: Library) -> None:
         directory = os.path.dirname(self.filepath) or "."
+        os.makedirs(directory, exist_ok=True)
         temp_fd, temp_path = tempfile.mkstemp(dir=directory, prefix=".library-", suffix=".json")
 
         try:

--- a/jukebox/adapters/outbound/json_library_adapter.py
+++ b/jukebox/adapters/outbound/json_library_adapter.py
@@ -26,8 +26,8 @@ class JsonLibraryAdapter(LibraryRepository):
             with open(self.filepath, "r", encoding="utf-8") as f:
                 data = json.load(f)
                 return Library.model_validate(data)
-        except FileNotFoundError as err:
-            LOGGER.warning(f"File not found, continuing with an empty library: filepath: {self.filepath}, error: {err}")
+        except FileNotFoundError:
+            LOGGER.warning(f"No library file found, starting with an empty library: {self.filepath}")
             return Library()
         except (json.JSONDecodeError, ValidationError) as err:
             LOGGER.warning(

--- a/tests/jukebox/adapters/outbound/test_json_library_adapter.py
+++ b/tests/jukebox/adapters/outbound/test_json_library_adapter.py
@@ -48,6 +48,18 @@ def test_list_discs_returns_empty_when_file_does_not_exist(tmp_path):
     assert adapter.list_discs() == {}
 
 
+def test_add_disc_creates_parent_directory_when_it_does_not_exist(tmp_path):
+    filepath = tmp_path / "nested" / "dir" / "library.json"
+    adapter = JsonLibraryAdapter(str(filepath))
+
+    assert not filepath.exists()
+
+    adapter.add_disc("new-tag", Disc(uri="new.mp3", metadata=DiscMetadata()))
+
+    assert filepath.exists()
+    assert adapter.get_disc("new-tag") is not None
+
+
 def test_list_discs_returns_empty_when_json_is_corrupted(tmp_path):
     filepath = tmp_path / "library.json"
     filepath.write_text("{invalid json content", encoding="utf-8")

--- a/tests/jukebox/adapters/outbound/test_json_library_adapter.py
+++ b/tests/jukebox/adapters/outbound/test_json_library_adapter.py
@@ -48,16 +48,26 @@ def test_list_discs_returns_empty_when_file_does_not_exist(tmp_path):
     assert adapter.list_discs() == {}
 
 
-def test_add_disc_creates_parent_directory_when_it_does_not_exist(tmp_path):
+def test_add_disc_creates_parent_directory_when_it_does_not_exist(tmp_path, caplog):
     filepath = tmp_path / "nested" / "dir" / "library.json"
     adapter = JsonLibraryAdapter(str(filepath))
 
     assert not filepath.exists()
-
-    adapter.add_disc("new-tag", Disc(uri="new.mp3", metadata=DiscMetadata()))
+    with caplog.at_level("INFO", logger="discstore"):
+        adapter.add_disc("new-tag", Disc(uri="new.mp3", metadata=DiscMetadata()))
 
     assert filepath.exists()
     assert adapter.get_disc("new-tag") is not None
+
+
+def test_missing_file_logs_info_message(tmp_path, caplog):
+    filepath = tmp_path / "missing" / "dir" / "missing-library.json"
+    adapter = JsonLibraryAdapter(str(filepath))
+
+    with caplog.at_level("WARNING", logger="jukebox"):
+        adapter.list_discs()
+
+    assert "No library file found, starting with an empty library" in caplog.text
 
 
 def test_list_discs_returns_empty_when_json_is_corrupted(tmp_path):

--- a/tests/jukebox/adapters/outbound/test_json_library_adapter.py
+++ b/tests/jukebox/adapters/outbound/test_json_library_adapter.py
@@ -42,22 +42,48 @@ def test_list_discs_returns_existing_library(tmp_path):
     assert discs["tag:123"].metadata.artist == "Test Artist"
 
 
-def test_list_discs_returns_empty_when_file_does_not_exist(tmp_path):
-    adapter = JsonLibraryAdapter(str(tmp_path / "missing-library.json"))
-
-    assert adapter.list_discs() == {}
-
-
-def test_add_disc_creates_parent_directory_when_it_does_not_exist(tmp_path, caplog):
-    filepath = tmp_path / "nested" / "dir" / "library.json"
+@pytest.mark.parametrize(
+    "operation,expected",
+    [
+        pytest.param(lambda adapter: adapter.list_discs(), {}, id="list_discs"),
+        pytest.param(lambda adapter: adapter.get_disc("missing"), None, id="get_disc"),
+    ],
+)
+def test_read_returns_empty_when_file_does_not_exist(tmp_path, operation, expected):
+    filepath = tmp_path / "missing" / "dir" / "missing-library.json"
     adapter = JsonLibraryAdapter(str(filepath))
 
-    assert not filepath.exists()
-    with caplog.at_level("INFO", logger="discstore"):
-        adapter.add_disc("new-tag", Disc(uri="new.mp3", metadata=DiscMetadata()))
+    assert operation(adapter) == expected
 
+
+@pytest.mark.parametrize(
+    "pre_existing_discs,operation",
+    [
+        pytest.param(
+            {},
+            lambda adapter: adapter.add_disc("new-tag", Disc(uri="new.mp3", metadata=DiscMetadata())),
+            id="add_disc",
+        ),
+        pytest.param(
+            {"existing-tag": Disc(uri="before.mp3", metadata=DiscMetadata())},
+            lambda adapter: adapter.update_disc("existing-tag", Disc(uri="new.mp3", metadata=DiscMetadata())),
+            id="update_disc",
+        ),
+        pytest.param(
+            {"existing-tag": Disc(uri="before.mp3", metadata=DiscMetadata())},
+            lambda adapter: adapter.remove_disc("existing-tag"),
+            id="remove_disc",
+        ),
+    ],
+)
+def test_write_creates_parent_directory_when_it_does_not_exist(tmp_path, mocker, pre_existing_discs, operation):
+    filepath = tmp_path / "missing" / "dir" / "missing-library.json"
+    adapter = JsonLibraryAdapter(str(filepath))
+    mocker.patch.object(adapter, "_get_cached_library", return_value=Library(discs=pre_existing_discs))
+
+    assert not filepath.exists()
+    operation(adapter)
     assert filepath.exists()
-    assert adapter.get_disc("new-tag") is not None
 
 
 def test_missing_file_logs_info_message(tmp_path, caplog):


### PR DESCRIPTION
Closes #122

## Context

`JsonLibraryAdapter._write_library()` called `mkstemp` without ensuring the parent directory existed, causing a `FileNotFoundError` on first write when `~/.config/jukebox/` had never been created

## What changed

- Added `os.makedirs(directory, exist_ok=True)` before `mkstemp`, mirroring the pattern already used in `FileSettingsRepository` and `TextCurrentTagAdapter`
- Print a less alarming message when the library file does not yet exist

`settings.json` and `current-tag.txt` were already handled correctly,  only `library.json` was affected

## Test plan

- Preparation before the test:
  ```shell
  mv ~/.config/jukebox/ ~/.config/jukebox-backup/
  ```
- Before fix: 
  ```shell
  git switch main
  uv run jukebox-admin library add hello --uri world
  ```
  Result:
  ```
  File not found, continuing with an empty library: filepath: ~/.config/jukebox/library.json, error: [Errno 2] No such file or directory: '~/.config/jukebox/library.json'
  [Errno 2] No such file or directory: '~/.config/jukebox/.library-f9qcje67.json'
  ```
- After fix:
  ```shell
  git switch feature/create-default-directory
  uv run jukebox-admin library add hello --uri world
  ```
  Result: No errors, and the file `~/.config/jukebox/library.json` is created
- Custom path:
  ```shell
  JUKEBOX_LIBRARY_PATH=/tmp/jukebox-test/library.json uv run jukebox-admin library add hello --uri world
  ```
  Result: No errors, and the file `~/.config/jukebox/library.json` is created
- Restore after the test:
  ```shell
  mv ~/.config/jukebox-backup/ ~/.config/jukebox/
  ```
