### PR TITLE
♻️ Replace flat spi parameters on a SpiConnectionParams

### DIFF
--- a/jukebox/di_container.py
+++ b/jukebox/di_container.py
@@ -25,13 +25,16 @@ def build_jukebox(config: ResolvedJukeboxRuntimeConfig):
 
     if config.reader_type == "pn532":
         from jukebox.adapters.outbound.readers.pn532_reader_adapter import Pn532ReaderAdapter
+        from jukebox.pn532.profiles import SpiConnectionParams
 
         if config.pn532_protocol == "spi":
+            conn = config.pn532_connection
+            assert isinstance(conn, SpiConnectionParams)
             reader = Pn532ReaderAdapter(
                 read_timeout_seconds=config.pn532_read_timeout_seconds,
-                spi_reset=config.pn532_spi_reset,
-                spi_cs=config.pn532_spi_cs,
-                spi_irq=config.pn532_spi_irq,
+                spi_reset=conn.reset,
+                spi_cs=conn.cs,
+                spi_irq=conn.irq,
             )
         else:
             raise ValueError(f"Unsupported PN532 protocol: {config.pn532_protocol}")

--- a/jukebox/pn532/__init__.py
+++ b/jukebox/pn532/__init__.py
@@ -3,6 +3,7 @@ from .profiles import (
     Pn532BoardProfile,
     Pn532BoardProfileDefaults,
     Pn532ConnectionParams,
+    Pn532Protocol,
     SpiConnectionParams,
     resolve_connection_params,
 )
@@ -12,6 +13,7 @@ __all__ = [
     "Pn532BoardProfile",
     "Pn532BoardProfileDefaults",
     "Pn532ConnectionParams",
+    "Pn532Protocol",
     "SpiConnectionParams",
     "resolve_connection_params",
 ]

--- a/jukebox/pn532/__init__.py
+++ b/jukebox/pn532/__init__.py
@@ -1,8 +1,17 @@
-from .profiles import PN532_PROFILES, Pn532BoardProfile, Pn532BoardProfileDefaults, resolve_spi_pins
+from .profiles import (
+    PN532_PROFILES,
+    Pn532BoardProfile,
+    Pn532BoardProfileDefaults,
+    Pn532ConnectionParams,
+    SpiConnectionParams,
+    resolve_connection_params,
+)
 
 __all__ = [
     "PN532_PROFILES",
     "Pn532BoardProfile",
     "Pn532BoardProfileDefaults",
-    "resolve_spi_pins",
+    "Pn532ConnectionParams",
+    "SpiConnectionParams",
+    "resolve_connection_params",
 ]

--- a/jukebox/pn532/profiles.py
+++ b/jukebox/pn532/profiles.py
@@ -4,6 +4,8 @@ from typing import Literal, Optional
 
 Pn532BoardProfile = Literal["waveshare_hat", "hiletgo_v3", "custom"]
 
+Pn532Protocol = Literal["spi"]
+
 
 @dataclass(frozen=True)
 class SpiConnectionParams:
@@ -19,36 +21,48 @@ Pn532ConnectionParams = SpiConnectionParams
 
 @dataclass(frozen=True)
 class Pn532BoardProfileDefaults:
-    protocol: Literal["spi"]
-    connection: Pn532ConnectionParams
+    default_protocol: Pn532Protocol
+    connections: dict[Pn532Protocol, Pn532ConnectionParams]
 
 
 PN532_PROFILES: dict[Pn532BoardProfile, Pn532BoardProfileDefaults] = {
     "waveshare_hat": Pn532BoardProfileDefaults(
-        protocol="spi",
-        connection=SpiConnectionParams(reset=20, cs=4, irq=None),
+        default_protocol="spi",
+        connections={"spi": SpiConnectionParams(reset=20, cs=4, irq=None)},
     ),
     "hiletgo_v3": Pn532BoardProfileDefaults(
-        protocol="spi",
-        connection=SpiConnectionParams(reset=None, cs=8, irq=None),
+        default_protocol="spi",
+        connections={"spi": SpiConnectionParams(reset=None, cs=8, irq=None)},
     ),
     "custom": Pn532BoardProfileDefaults(
-        protocol="spi",
-        connection=SpiConnectionParams(reset=None, cs=None, irq=None),
+        default_protocol="spi",
+        connections={"spi": SpiConnectionParams(reset=None, cs=None, irq=None)},
     ),
 }
 
 
 def resolve_connection_params(
     board_profile: Pn532BoardProfile,
+    protocol: Pn532Protocol,
     overrides: Pn532ConnectionParams,
 ) -> Pn532ConnectionParams:
-    """Merge per-field overrides with the profile defaults.
+    """Merge per-field overrides with the profile defaults for the given protocol.
 
     A field value of None in *overrides* means "use the profile default".
     The custom profile has None as its own default, so None is preserved.
     """
-    defaults = PN532_PROFILES[board_profile].connection
+    profile = PN532_PROFILES[board_profile]
+    if protocol not in profile.connections:
+        supported = list(profile.connections.keys())
+        raise ValueError(
+            f"Protocol '{protocol}' is not supported by board profile '{board_profile}' (supported: {supported})"
+        )
+    defaults = profile.connections[protocol]
+    if not isinstance(overrides, type(defaults)):
+        raise ValueError(
+            f"Expected overrides of type {type(defaults).__name__} for protocol '{protocol}', "
+            f"got {type(overrides).__name__}"
+        )
     merged = {
         f.name: getattr(overrides, f.name) if getattr(overrides, f.name) is not None else getattr(defaults, f.name)
         for f in dataclasses.fields(defaults)

--- a/jukebox/pn532/profiles.py
+++ b/jukebox/pn532/profiles.py
@@ -1,3 +1,4 @@
+import dataclasses
 from dataclasses import dataclass
 from typing import Literal, Optional
 
@@ -5,28 +6,51 @@ Pn532BoardProfile = Literal["waveshare_hat", "hiletgo_v3", "custom"]
 
 
 @dataclass(frozen=True)
-class Pn532BoardProfileDefaults:
+class SpiConnectionParams:
     reset: Optional[int]
     cs: Optional[int]
     irq: Optional[int]
 
 
+# Today SpiConnectionParams only; Union[SpiConnectionParams, UartConnectionParams, ...]
+# will be introduced when additional protocols are added.
+Pn532ConnectionParams = SpiConnectionParams
+
+
+@dataclass(frozen=True)
+class Pn532BoardProfileDefaults:
+    protocol: Literal["spi"]
+    connection: Pn532ConnectionParams
+
+
 PN532_PROFILES: dict[Pn532BoardProfile, Pn532BoardProfileDefaults] = {
-    "waveshare_hat": Pn532BoardProfileDefaults(reset=20, cs=4, irq=None),
-    "hiletgo_v3": Pn532BoardProfileDefaults(reset=None, cs=8, irq=None),
-    "custom": Pn532BoardProfileDefaults(reset=None, cs=None, irq=None),
+    "waveshare_hat": Pn532BoardProfileDefaults(
+        protocol="spi",
+        connection=SpiConnectionParams(reset=20, cs=4, irq=None),
+    ),
+    "hiletgo_v3": Pn532BoardProfileDefaults(
+        protocol="spi",
+        connection=SpiConnectionParams(reset=None, cs=8, irq=None),
+    ),
+    "custom": Pn532BoardProfileDefaults(
+        protocol="spi",
+        connection=SpiConnectionParams(reset=None, cs=None, irq=None),
+    ),
 }
 
 
-def resolve_spi_pins(
+def resolve_connection_params(
     board_profile: Pn532BoardProfile,
-    reset: Optional[int],
-    cs: Optional[int],
-    irq: Optional[int],
-) -> Pn532BoardProfileDefaults:
-    profile = PN532_PROFILES[board_profile]
-    return Pn532BoardProfileDefaults(
-        reset=reset if reset is not None else profile.reset,
-        cs=cs if cs is not None else profile.cs,
-        irq=irq if irq is not None else profile.irq,
-    )
+    overrides: Pn532ConnectionParams,
+) -> Pn532ConnectionParams:
+    """Merge per-field overrides with the profile defaults.
+
+    A field value of None in *overrides* means "use the profile default".
+    The custom profile has None as its own default, so None is preserved.
+    """
+    defaults = PN532_PROFILES[board_profile].connection
+    merged = {
+        f.name: getattr(overrides, f.name) if getattr(overrides, f.name) is not None else getattr(defaults, f.name)
+        for f in dataclasses.fields(defaults)
+    }
+    return type(defaults)(**merged)

--- a/jukebox/settings/entities.py
+++ b/jukebox/settings/entities.py
@@ -3,6 +3,7 @@ from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from jukebox.pn532.profiles import SpiConnectionParams
 from jukebox.shared.timing import MIN_PAUSE_DELAY_SECONDS
 
 from .runtime_validation import validate_resolved_jukebox_runtime_rules
@@ -272,9 +273,7 @@ class ResolvedJukeboxRuntimeConfig(StrictModel):
     pn532_read_timeout_seconds: float
     pn532_board_profile: Literal["waveshare_hat", "hiletgo_v3", "custom"]
     pn532_protocol: Literal["spi"] = "spi"
-    pn532_spi_reset: Optional[int]
-    pn532_spi_cs: Optional[int]
-    pn532_spi_irq: Optional[int]
+    pn532_connection: SpiConnectionParams
     verbose: bool = False
 
     @model_validator(mode="after")

--- a/jukebox/settings/resolve.py
+++ b/jukebox/settings/resolve.py
@@ -238,7 +238,7 @@ def _expand_path(path: str) -> str:
 def _derive_pn532(effective_settings: AppSettings) -> JsonObject:
     pn532 = effective_settings.jukebox.reader.pn532
     overrides = SpiConnectionParams(reset=pn532.spi.reset, cs=pn532.spi.cs, irq=pn532.spi.irq)
-    resolved = resolve_connection_params(pn532.board_profile, overrides)
+    resolved = resolve_connection_params(pn532.board_profile, pn532.protocol, overrides)
     return {
         "reader": {
             "pn532": {

--- a/jukebox/settings/resolve.py
+++ b/jukebox/settings/resolve.py
@@ -5,7 +5,7 @@ from typing import Optional, Union, cast
 
 from pydantic import ValidationError
 
-from jukebox.pn532.profiles import resolve_spi_pins
+from jukebox.pn532.profiles import SpiConnectionParams, resolve_connection_params
 from jukebox.shared.config_utils import get_current_tag_path
 
 from .definitions import (
@@ -237,7 +237,8 @@ def _expand_path(path: str) -> str:
 
 def _derive_pn532(effective_settings: AppSettings) -> JsonObject:
     pn532 = effective_settings.jukebox.reader.pn532
-    resolved = resolve_spi_pins(pn532.board_profile, pn532.spi.reset, pn532.spi.cs, pn532.spi.irq)
+    overrides = SpiConnectionParams(reset=pn532.spi.reset, cs=pn532.spi.cs, irq=pn532.spi.irq)
+    resolved = resolve_connection_params(pn532.board_profile, overrides)
     return {
         "reader": {
             "pn532": {

--- a/jukebox/settings/runtime_resolver.py
+++ b/jukebox/settings/runtime_resolver.py
@@ -1,9 +1,9 @@
 import os
-from typing import Any, Optional, Tuple
+from typing import Optional, Tuple
 
 from pydantic import ValidationError
 
-from jukebox.pn532.profiles import resolve_spi_pins
+from jukebox.pn532.profiles import SpiConnectionParams, resolve_connection_params
 from jukebox.sonos.service import SonosService
 
 from .entities import AppSettings, Pn532ReaderSettings, ResolvedJukeboxRuntimeConfig, ResolvedSonosGroupRuntime
@@ -39,7 +39,7 @@ class JukeboxRuntimeResolver:
                 pn532_read_timeout_seconds=effective_settings.jukebox.reader.pn532.read_timeout_seconds,
                 pn532_board_profile=effective_settings.jukebox.reader.pn532.board_profile,
                 pn532_protocol=effective_settings.jukebox.reader.pn532.protocol,
-                **_resolve_pn532_spi_pins(effective_settings.jukebox.reader.pn532),
+                pn532_connection=_resolve_pn532_connection(effective_settings.jukebox.reader.pn532),
                 verbose=verbose,
             )
         except (ValidationError, ValueError) as err:
@@ -63,10 +63,6 @@ class JukeboxRuntimeResolver:
         return None, None, None
 
 
-def _resolve_pn532_spi_pins(pn532: Pn532ReaderSettings) -> dict[str, Any]:
-    resolved = resolve_spi_pins(pn532.board_profile, pn532.spi.reset, pn532.spi.cs, pn532.spi.irq)
-    return {
-        "pn532_spi_reset": resolved.reset,
-        "pn532_spi_cs": resolved.cs,
-        "pn532_spi_irq": resolved.irq,
-    }
+def _resolve_pn532_connection(pn532: Pn532ReaderSettings) -> SpiConnectionParams:
+    overrides = SpiConnectionParams(reset=pn532.spi.reset, cs=pn532.spi.cs, irq=pn532.spi.irq)
+    return resolve_connection_params(pn532.board_profile, overrides)

--- a/jukebox/settings/runtime_resolver.py
+++ b/jukebox/settings/runtime_resolver.py
@@ -65,4 +65,4 @@ class JukeboxRuntimeResolver:
 
 def _resolve_pn532_connection(pn532: Pn532ReaderSettings) -> SpiConnectionParams:
     overrides = SpiConnectionParams(reset=pn532.spi.reset, cs=pn532.spi.cs, irq=pn532.spi.irq)
-    return resolve_connection_params(pn532.board_profile, overrides)
+    return resolve_connection_params(pn532.board_profile, pn532.protocol, overrides)

--- a/tests/jukebox/pn532/test_pn532_profiles.py
+++ b/tests/jukebox/pn532/test_pn532_profiles.py
@@ -1,3 +1,6 @@
+from dataclasses import dataclass
+from typing import Optional
+
 import pytest
 
 from jukebox.pn532.profiles import PN532_PROFILES, SpiConnectionParams, resolve_connection_params
@@ -5,29 +8,32 @@ from jukebox.pn532.profiles import PN532_PROFILES, SpiConnectionParams, resolve_
 
 def test_waveshare_hat_profile_defaults():
     profile = PN532_PROFILES["waveshare_hat"]
-    assert profile.protocol == "spi"
-    assert isinstance(profile.connection, SpiConnectionParams)
-    assert profile.connection.reset == 20
-    assert profile.connection.cs == 4
-    assert profile.connection.irq is None
+    assert profile.default_protocol == "spi"
+    conn = profile.connections.get("spi")
+    assert isinstance(conn, SpiConnectionParams)
+    assert conn.reset == 20
+    assert conn.cs == 4
+    assert conn.irq is None
 
 
 def test_hiletgo_v3_profile_defaults():
     profile = PN532_PROFILES["hiletgo_v3"]
-    assert profile.protocol == "spi"
-    assert isinstance(profile.connection, SpiConnectionParams)
-    assert profile.connection.reset is None
-    assert profile.connection.cs == 8
-    assert profile.connection.irq is None
+    assert profile.default_protocol == "spi"
+    conn = profile.connections.get("spi")
+    assert isinstance(conn, SpiConnectionParams)
+    assert conn.reset is None
+    assert conn.cs == 8
+    assert conn.irq is None
 
 
 def test_custom_profile_has_no_defaults():
     profile = PN532_PROFILES["custom"]
-    assert profile.protocol == "spi"
-    assert isinstance(profile.connection, SpiConnectionParams)
-    assert profile.connection.reset is None
-    assert profile.connection.cs is None
-    assert profile.connection.irq is None
+    assert profile.default_protocol == "spi"
+    conn = profile.connections.get("spi")
+    assert isinstance(conn, SpiConnectionParams)
+    assert conn.reset is None
+    assert conn.cs is None
+    assert conn.irq is None
 
 
 @pytest.mark.parametrize("profile_name", ["waveshare_hat", "hiletgo_v3", "custom"])
@@ -36,7 +42,7 @@ def test_all_profiles_are_defined(profile_name):
 
 
 def test_resolve_connection_params_uses_profile_defaults_when_overrides_are_none():
-    resolved = resolve_connection_params("waveshare_hat", SpiConnectionParams(reset=None, cs=None, irq=None))
+    resolved = resolve_connection_params("waveshare_hat", "spi", SpiConnectionParams(reset=None, cs=None, irq=None))
     assert isinstance(resolved, SpiConnectionParams)
     assert resolved.reset == 20
     assert resolved.cs == 4
@@ -44,13 +50,13 @@ def test_resolve_connection_params_uses_profile_defaults_when_overrides_are_none
 
 
 def test_resolve_connection_params_override_wins_over_default():
-    resolved = resolve_connection_params("waveshare_hat", SpiConnectionParams(reset=24, cs=None, irq=None))
+    resolved = resolve_connection_params("waveshare_hat", "spi", SpiConnectionParams(reset=24, cs=None, irq=None))
     assert resolved.reset == 24
     assert resolved.cs == 4  # profile default
 
 
 def test_resolve_connection_params_full_override_ignores_profile():
-    resolved = resolve_connection_params("waveshare_hat", SpiConnectionParams(reset=24, cs=10, irq=25))
+    resolved = resolve_connection_params("waveshare_hat", "spi", SpiConnectionParams(reset=24, cs=10, irq=25))
     assert resolved.reset == 24
     assert resolved.cs == 10
     assert resolved.irq == 25
@@ -58,13 +64,36 @@ def test_resolve_connection_params_full_override_ignores_profile():
 
 def test_resolve_connection_params_none_override_is_treated_as_no_override():
     # None means "no override, use profile default", it does not force the pin to None.
-    resolved = resolve_connection_params("waveshare_hat", SpiConnectionParams(reset=None, cs=None, irq=None))
+    resolved = resolve_connection_params("waveshare_hat", "spi", SpiConnectionParams(reset=None, cs=None, irq=None))
     assert resolved.reset == 20  # profile default, not None
 
 
 def test_resolve_connection_params_custom_profile_preserves_none_pins():
     # Use the custom profile to explicitly keep a pin as None.
-    resolved = resolve_connection_params("custom", SpiConnectionParams(reset=None, cs=None, irq=None))
+    resolved = resolve_connection_params("custom", "spi", SpiConnectionParams(reset=None, cs=None, irq=None))
     assert resolved.reset is None
     assert resolved.cs is None
     assert resolved.irq is None
+
+
+def test_resolve_connection_params_raises_for_unsupported_protocol():
+    with pytest.raises(ValueError, match="not supported by board profile"):
+        resolve_connection_params(
+            "waveshare_hat",
+            "unsupported",  # ty: ignore[invalid-argument-type]
+            SpiConnectionParams(reset=None, cs=None, irq=None),
+        )
+
+
+def test_resolve_connection_params_raises_for_mismatched_override_type():
+    @dataclass(frozen=True)
+    class UartConnectionParams:
+        tx: Optional[int]
+        rx: Optional[int]
+
+    with pytest.raises(ValueError, match="Expected overrides of type SpiConnectionParams"):
+        resolve_connection_params(
+            "waveshare_hat",
+            "spi",
+            UartConnectionParams(tx=None, rx=None),  # ty: ignore[invalid-argument-type]
+        )

--- a/tests/jukebox/pn532/test_pn532_profiles.py
+++ b/tests/jukebox/pn532/test_pn532_profiles.py
@@ -1,27 +1,33 @@
 import pytest
 
-from jukebox.pn532.profiles import PN532_PROFILES, resolve_spi_pins
+from jukebox.pn532.profiles import PN532_PROFILES, SpiConnectionParams, resolve_connection_params
 
 
 def test_waveshare_hat_profile_defaults():
     profile = PN532_PROFILES["waveshare_hat"]
-    assert profile.reset == 20
-    assert profile.cs == 4
-    assert profile.irq is None
+    assert profile.protocol == "spi"
+    assert isinstance(profile.connection, SpiConnectionParams)
+    assert profile.connection.reset == 20
+    assert profile.connection.cs == 4
+    assert profile.connection.irq is None
 
 
 def test_hiletgo_v3_profile_defaults():
     profile = PN532_PROFILES["hiletgo_v3"]
-    assert profile.reset is None
-    assert profile.cs == 8
-    assert profile.irq is None
+    assert profile.protocol == "spi"
+    assert isinstance(profile.connection, SpiConnectionParams)
+    assert profile.connection.reset is None
+    assert profile.connection.cs == 8
+    assert profile.connection.irq is None
 
 
 def test_custom_profile_has_no_defaults():
     profile = PN532_PROFILES["custom"]
-    assert profile.reset is None
-    assert profile.cs is None
-    assert profile.irq is None
+    assert profile.protocol == "spi"
+    assert isinstance(profile.connection, SpiConnectionParams)
+    assert profile.connection.reset is None
+    assert profile.connection.cs is None
+    assert profile.connection.irq is None
 
 
 @pytest.mark.parametrize("profile_name", ["waveshare_hat", "hiletgo_v3", "custom"])
@@ -29,35 +35,36 @@ def test_all_profiles_are_defined(profile_name):
     assert profile_name in PN532_PROFILES
 
 
-def test_resolve_spi_pins_uses_profile_defaults_when_no_overrides():
-    resolved = resolve_spi_pins("waveshare_hat", reset=None, cs=None, irq=None)
+def test_resolve_connection_params_uses_profile_defaults_when_overrides_are_none():
+    resolved = resolve_connection_params("waveshare_hat", SpiConnectionParams(reset=None, cs=None, irq=None))
+    assert isinstance(resolved, SpiConnectionParams)
     assert resolved.reset == 20
     assert resolved.cs == 4
     assert resolved.irq is None
 
 
-def test_resolve_spi_pins_partial_override_wins_over_profile_default():
-    resolved = resolve_spi_pins("waveshare_hat", reset=24, cs=None, irq=None)
-    assert resolved.reset == 24  # override
+def test_resolve_connection_params_override_wins_over_default():
+    resolved = resolve_connection_params("waveshare_hat", SpiConnectionParams(reset=24, cs=None, irq=None))
+    assert resolved.reset == 24
     assert resolved.cs == 4  # profile default
 
 
-def test_resolve_spi_pins_full_override_ignores_profile():
-    resolved = resolve_spi_pins("waveshare_hat", reset=24, cs=10, irq=25)
+def test_resolve_connection_params_full_override_ignores_profile():
+    resolved = resolve_connection_params("waveshare_hat", SpiConnectionParams(reset=24, cs=10, irq=25))
     assert resolved.reset == 24
     assert resolved.cs == 10
     assert resolved.irq == 25
 
 
-def test_resolve_spi_pins_none_override_is_treated_as_no_override():
+def test_resolve_connection_params_none_override_is_treated_as_no_override():
     # None means "no override, use profile default", it does not force the pin to None.
-    resolved = resolve_spi_pins("waveshare_hat", reset=None, cs=None, irq=None)
+    resolved = resolve_connection_params("waveshare_hat", SpiConnectionParams(reset=None, cs=None, irq=None))
     assert resolved.reset == 20  # profile default, not None
 
 
-def test_resolve_spi_pins_custom_profile_preserves_none_pins():
+def test_resolve_connection_params_custom_profile_preserves_none_pins():
     # Use the custom profile to explicitly keep a pin as None.
-    resolved = resolve_spi_pins("custom", reset=None, cs=None, irq=None)
+    resolved = resolve_connection_params("custom", SpiConnectionParams(reset=None, cs=None, irq=None))
     assert resolved.reset is None
     assert resolved.cs is None
     assert resolved.irq is None

--- a/tests/jukebox/settings/test_settings_service_runtime_resolution.py
+++ b/tests/jukebox/settings/test_settings_service_runtime_resolution.py
@@ -3,6 +3,7 @@ import os
 
 import pytest
 
+from jukebox.pn532.profiles import SpiConnectionParams
 from jukebox.settings.errors import InvalidSettingsError
 from jukebox.settings.file_settings_repository import FileSettingsRepository
 from jukebox.settings.resolve import SettingsService, build_environment_settings_overrides
@@ -220,9 +221,11 @@ def test_runtime_resolver_applies_board_profile_defaults_to_spi_pins(tmp_path):
     runtime_config = resolve_jukebox_runtime(service)
 
     # waveshare_hat defaults: reset=20, cs=4, irq=None
-    assert runtime_config.pn532_spi_reset == 20
-    assert runtime_config.pn532_spi_cs == 4
-    assert runtime_config.pn532_spi_irq is None
+    assert runtime_config.pn532_protocol == "spi"
+    assert isinstance(runtime_config.pn532_connection, SpiConnectionParams)
+    assert runtime_config.pn532_connection.reset == 20
+    assert runtime_config.pn532_connection.cs == 4
+    assert runtime_config.pn532_connection.irq is None
 
 
 def test_runtime_resolver_spi_pin_override_wins_over_board_profile_default(tmp_path):
@@ -248,8 +251,10 @@ def test_runtime_resolver_spi_pin_override_wins_over_board_profile_default(tmp_p
 
     runtime_config = resolve_jukebox_runtime(service)
 
-    assert runtime_config.pn532_spi_reset == 24  # override
-    assert runtime_config.pn532_spi_cs == 4  # profile default
+    assert runtime_config.pn532_protocol == "spi"
+    assert isinstance(runtime_config.pn532_connection, SpiConnectionParams)
+    assert runtime_config.pn532_connection.reset == 24  # override
+    assert runtime_config.pn532_connection.cs == 4  # profile default
 
 
 def test_effective_view_derives_spi_pins_from_board_profile(tmp_path):
@@ -314,7 +319,9 @@ def test_settings_service_applies_board_profile_cli_override_at_runtime(tmp_path
     runtime_config = resolve_jukebox_runtime(service)
 
     assert runtime_config.pn532_board_profile == "hiletgo_v3"
-    assert runtime_config.pn532_spi_cs == 8  # hiletgo_v3 default
+    assert runtime_config.pn532_protocol == "spi"
+    assert isinstance(runtime_config.pn532_connection, SpiConnectionParams)
+    assert runtime_config.pn532_connection.cs == 8  # hiletgo_v3 default
 
 
 def test_settings_service_applies_spi_pin_cli_override_at_runtime(tmp_path):
@@ -327,5 +334,7 @@ def test_settings_service_applies_spi_pin_cli_override_at_runtime(tmp_path):
 
     runtime_config = resolve_jukebox_runtime(service)
 
-    assert runtime_config.pn532_spi_reset == 24  # cli override
-    assert runtime_config.pn532_spi_cs == 4  # waveshare_hat default (default profile)
+    assert runtime_config.pn532_protocol == "spi"
+    assert isinstance(runtime_config.pn532_connection, SpiConnectionParams)
+    assert runtime_config.pn532_connection.reset == 24  # cli override
+    assert runtime_config.pn532_connection.cs == 4  # waveshare_hat default (default profile)

--- a/tests/jukebox/test_jukebox_app.py
+++ b/tests/jukebox/test_jukebox_app.py
@@ -4,6 +4,7 @@ import pytest
 
 from jukebox import app
 from jukebox.adapters.inbound.config import JukeboxCliConfig
+from jukebox.pn532.profiles import SpiConnectionParams
 from jukebox.settings.entities import ResolvedJukeboxRuntimeConfig
 from jukebox.settings.errors import InvalidSettingsError
 from jukebox.settings.file_settings_repository import FileSettingsRepository
@@ -37,9 +38,7 @@ def test_main_uses_resolved_runtime_config(app_mocks):
         loop_interval_seconds=0.5,
         pn532_read_timeout_seconds=0.1,
         pn532_board_profile="waveshare_hat",
-        pn532_spi_reset=20,
-        pn532_spi_cs=4,
-        pn532_spi_irq=None,
+        pn532_connection=SpiConnectionParams(reset=20, cs=4, irq=None),
         verbose=True,
     )
     settings_service = MagicMock()
@@ -82,9 +81,7 @@ def test_main_exits_on_build_jukebox_settings_error(app_mocks):
         loop_interval_seconds=0.5,
         pn532_read_timeout_seconds=0.1,
         pn532_board_profile="waveshare_hat",
-        pn532_spi_reset=20,
-        pn532_spi_cs=4,
-        pn532_spi_irq=None,
+        pn532_connection=SpiConnectionParams(reset=20, cs=4, irq=None),
         verbose=True,
     )
     settings_service = MagicMock()

--- a/tests/jukebox/test_jukebox_di_container.py
+++ b/tests/jukebox/test_jukebox_di_container.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 from jukebox.di_container import build_jukebox
+from jukebox.pn532.profiles import SpiConnectionParams
 from jukebox.settings.entities import ResolvedJukeboxRuntimeConfig
 from jukebox.shared.config_utils import get_current_tag_path
 from tests.jukebox.settings._helpers import build_resolved_sonos_group_runtime
@@ -38,9 +39,7 @@ class TestBuildJukebox:
             loop_interval_seconds=0.1,
             pn532_read_timeout_seconds=0.25,
             pn532_board_profile="waveshare_hat",
-            pn532_spi_reset=20,
-            pn532_spi_cs=4,
-            pn532_spi_irq=None,
+            pn532_connection=SpiConnectionParams(reset=20, cs=4, irq=None),
             verbose=False,
         )
 
@@ -75,9 +74,7 @@ class TestBuildJukebox:
             loop_interval_seconds=0.1,
             pn532_read_timeout_seconds=0.25,
             pn532_board_profile="waveshare_hat",
-            pn532_spi_reset=20,
-            pn532_spi_cs=4,
-            pn532_spi_irq=None,
+            pn532_connection=SpiConnectionParams(reset=20, cs=4, irq=None),
             verbose=False,
         )
 
@@ -107,9 +104,7 @@ class TestBuildJukebox:
             loop_interval_seconds=0.1,
             pn532_read_timeout_seconds=0.25,
             pn532_board_profile="waveshare_hat",
-            pn532_spi_reset=20,
-            pn532_spi_cs=4,
-            pn532_spi_irq=None,
+            pn532_connection=SpiConnectionParams(reset=20, cs=4, irq=None),
             verbose=False,
         )
 
@@ -138,9 +133,7 @@ class TestBuildJukebox:
             loop_interval_seconds=0.1,
             pn532_read_timeout_seconds=0.1,
             pn532_board_profile="waveshare_hat",
-            pn532_spi_reset=20,
-            pn532_spi_cs=4,
-            pn532_spi_irq=None,
+            pn532_connection=SpiConnectionParams(reset=20, cs=4, irq=None),
             verbose=False,
         )
 
@@ -172,9 +165,7 @@ class TestBuildJukebox:
             loop_interval_seconds=0.1,
             pn532_read_timeout_seconds=0.1,
             pn532_board_profile="waveshare_hat",
-            pn532_spi_reset=20,
-            pn532_spi_cs=4,
-            pn532_spi_irq=None,
+            pn532_connection=SpiConnectionParams(reset=20, cs=4, irq=None),
             verbose=False,
         )
 


### PR DESCRIPTION
## Summary

Requires #224 

The initial implementation of PN532 settings was designed around SPI as if it were the only protocol. Pin fields (`reset`, `cs`, `irq`) were hardcoded throughout: in `Pn532BoardProfileDefaults`, etc.
Adding UART or I2C would have required touching all of these.

- Replace flat reset/cs/irq fields on Pn532BoardProfileDefaults with a typed SpiConnectionParams dataclass. Add resolve_connection_params() which merges per-field overrides using dataclasses.fields(), making the logic generic across future protocols (UART, I2C).
- ResolvedJukeboxRuntimeConfig now holds a SpiConnectionParams instead of three flat fields. runtime_resolver and di_container updated accordingly.
- settings/resolve.py: use resolve_connection_params instead of resolve_spi_pins