### PR TITLE
💥⬆️ Bump minimum Python version to 3.11

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -44,7 +44,7 @@ jobs:
         python-version: ${{ fromJson(
           github.event_name == 'workflow_dispatch' && github.event.inputs.python-version != ''
           && format('["{0}"]', github.event.inputs.python-version)
-          || '["3.9", "3.10", "3.11", "3.12", "3.13"]'
+          || '["3.11", "3.12", "3.13"]'
           ) }}
         extras: ["--all-extras"]
         include:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -80,21 +80,11 @@ jobs:
       - name: Test with pytest
         run: uv run pytest
 
-      - name: Set ty_args based on Python version
-        # Check the missig-argument rule for Python versions >= 3.10
-        # Exclude the opt/ directory as it is not part of the project
-        run: |
-          if [[ "${{ matrix.python-version }}" == "3.9" ]]; then
-            echo "ty_args=--ignore missing-argument --exclude opt/" >> $GITHUB_ENV
-          else
-            echo "ty_args=--error missing-argument" >> $GITHUB_ENV
-          fi
-
       - name: Type check with ty
         # TODO: remove `grep -v || true` once ty supports a flag to suppress warnings (https://github.com/astral-sh/ty/issues/2169)
         # grep -v filters out warnings from the GitHub annotations output to keep the PR review
         # interface readable. Warnings are still visible locally and should not be forgotten.
-        run: uv run ty check $ty_args --output-format github | grep -v "::warning " || true
+        run: uv run ty check --output-format github | grep -v "::warning " || true
 
   build:
     name: Build Package

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,6 @@ The library is stored as `library.json` via `json_library_adapter.py`. No databa
 ### Type Annotations
 
 - Use type hints for function parameters and return types
-- Use `Optional[X]` over `X | None` for Python 3.9 compatibility
 
 ## Testing Patterns
 

--- a/README.md
+++ b/README.md
@@ -33,15 +33,17 @@
 - [The library file](#the-library-file)
 - [Developer setup](#developer-setup)
 
-## Notes
+## Python Compatibility
 
-Python 3.7 is supported by Jukebox up to version 0.4.1.
+Jukebox 1.0+ requires Python 3.11 or newer.
 
-Python 3.8 is supported by Jukebox up to version 0.5.4.
-
-Python 3.9 and Python 3.10 are supported by Jukebox up to version 0.9.0.
-
-The `ui` extension is only available for Python versions 3.10 and above.
+| Python version | Compatible Jukebox versions | Notes |
+|----------------|-----------------------------|-------|
+| 3.7            | 0.4.0 – 0.4.1               | Legacy |
+| 3.8            | 0.4.0 – 0.5.4               | Legacy |
+| 3.9 – 3.10     | 0.4.0 – 0.9.0 (incl. 1.0.0.dev13) | Legacy |
+| 3.11 – 3.12    | 0.4.0 – latest              | Actively supported |
+| 3.13           | 0.5.3 – latest              | Actively supported (see installation notes) |
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Python 3.7 is supported by Jukebox up to version 0.4.1.
 
 Python 3.8 is supported by Jukebox up to version 0.5.4.
 
+Python 3.9 and Python 3.10 are supported by Jukebox up to version 0.9.0.
+
 The `ui` extension is only available for Python versions 3.10 and above.
 
 ## Install
@@ -132,10 +134,9 @@ jukebox-admin settings show --effective
 To use the `api` and `ui` commands, additional packages are required. You can install the `package[extra]` syntax regardless of the package manager you use, for example:
 
 ```shell
-# Python 3.9+ required
 uv tool install gukebox[api]
 
-# Python 3.10+ required, ui includes the api extra
+# ui includes the api extra
 uv tool install gukebox[ui]
 ```
 

--- a/discstore/adapters/inbound/api/current_tag_router.py
+++ b/discstore/adapters/inbound/api/current_tag_router.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from fastapi import APIRouter, HTTPException, Response, status
 from pydantic import ValidationError
@@ -27,11 +27,11 @@ def build_current_tag_router(
 ) -> APIRouter:
     router = APIRouter(prefix="/api/v1", tags=["current-tag"])
 
-    def read_current_tag_status() -> Optional[CurrentTagStatus]:
+    def read_current_tag_status() -> CurrentTagStatus | None:
         return get_current_tag_status.execute()
 
     def ensure_expected_tag_id_matches(
-        expected_tag_id: Optional[str], current_tag_status: Optional[CurrentTagStatus]
+        expected_tag_id: str | None, current_tag_status: CurrentTagStatus | None
     ) -> None:
         if expected_tag_id is None:
             return
@@ -84,7 +84,7 @@ def build_current_tag_router(
     )
     def create_current_tag_disc(
         disc: DiscInput,
-        expected_tag_id: Optional[str] = None,
+        expected_tag_id: str | None = None,
     ) -> Any:
         current_tag_status = read_current_tag_status()
         ensure_expected_tag_id_matches(expected_tag_id, current_tag_status)
@@ -112,7 +112,7 @@ def build_current_tag_router(
     )
     def update_current_tag_disc(
         disc_patch: DiscPatchInput,
-        expected_tag_id: Optional[str] = None,
+        expected_tag_id: str | None = None,
     ) -> Any:
         current_tag_status = read_current_tag_status()
         ensure_expected_tag_id_matches(expected_tag_id, current_tag_status)
@@ -147,7 +147,7 @@ def build_current_tag_router(
         },
         summary="Delete the current tag disc",
     )
-    def delete_current_tag_disc(expected_tag_id: Optional[str] = None) -> Response:
+    def delete_current_tag_disc(expected_tag_id: str | None = None) -> Response:
         current_tag_status = read_current_tag_status()
         ensure_expected_tag_id_matches(expected_tag_id, current_tag_status)
         if current_tag_status is None:

--- a/discstore/adapters/inbound/api/discs_router.py
+++ b/discstore/adapters/inbound/api/discs_router.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from fastapi import APIRouter, HTTPException, Response, status
 from pydantic import ValidationError
 
@@ -21,8 +19,8 @@ def build_discs_router(
 ) -> APIRouter:
     router = APIRouter(prefix="/api/v1", tags=["discs"])
 
-    @router.get("/discs", response_model=Dict[str, DiscOutput], summary="List discs")
-    def list_discs_route() -> Dict[str, Disc]:
+    @router.get("/discs", response_model=dict[str, DiscOutput], summary="List discs")
+    def list_discs_route() -> dict[str, Disc]:
         return list_discs.execute()
 
     @router.get("/discs/{tag_id}", response_model=DiscOutput, summary="Get a disc")

--- a/discstore/adapters/inbound/api/models.py
+++ b/discstore/adapters/inbound/api/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any
 
 from pydantic import BaseModel, RootModel
 
@@ -14,21 +14,21 @@ class DiscOutput(Disc):
 
 
 class DiscPatchMetadataInput(BaseModel):
-    artist: Optional[str] = None
-    album: Optional[str] = None
-    track: Optional[str] = None
-    playlist: Optional[str] = None
+    artist: str | None = None
+    album: str | None = None
+    track: str | None = None
+    playlist: str | None = None
 
 
 class DiscPatchOptionInput(BaseModel):
-    shuffle: Optional[bool] = None
-    is_test: Optional[bool] = None
+    shuffle: bool | None = None
+    is_test: bool | None = None
 
 
 class DiscPatchInput(BaseModel):
-    uri: Optional[str] = None
-    metadata: Optional[DiscPatchMetadataInput] = None
-    option: Optional[DiscPatchOptionInput] = None
+    uri: str | None = None
+    metadata: DiscPatchMetadataInput | None = None
+    option: DiscPatchOptionInput | None = None
 
 
 class CurrentTagStatusOutput(CurrentTagStatus):
@@ -44,5 +44,5 @@ class SettingsResetInput(BaseModel):
     path: str
 
 
-class SettingsPatchInput(RootModel[Dict[str, Any]]):
+class SettingsPatchInput(RootModel[dict[str, Any]]):
     pass

--- a/discstore/adapters/inbound/api/settings_router.py
+++ b/discstore/adapters/inbound/api/settings_router.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, cast
+from typing import Any, cast
 
 from fastapi import APIRouter, HTTPException
 
@@ -11,21 +11,21 @@ from jukebox.settings.types import JsonObject
 def build_settings_router(settings_service: SettingsService) -> APIRouter:
     router = APIRouter(prefix="/api/v1", tags=["settings"])
 
-    @router.get("/settings", response_model=Dict[str, Any], summary="Get persisted settings")
+    @router.get("/settings", response_model=dict[str, Any], summary="Get persisted settings")
     def get_settings() -> JsonObject:
         try:
             return settings_service.get_persisted_settings_view()
         except Exception as err:
             raise HTTPException(status_code=500, detail=f"Server error: {str(err)}")
 
-    @router.get("/settings/effective", response_model=Dict[str, Any], summary="Get effective settings")
+    @router.get("/settings/effective", response_model=dict[str, Any], summary="Get effective settings")
     def get_effective_settings() -> JsonObject:
         try:
             return settings_service.get_effective_settings_view()
         except Exception as err:
             raise HTTPException(status_code=500, detail=f"Server error: {str(err)}")
 
-    @router.patch("/settings", response_model=Dict[str, Any], summary="Patch persisted settings")
+    @router.patch("/settings", response_model=dict[str, Any], summary="Patch persisted settings")
     def patch_settings(patch: SettingsPatchInput) -> JsonObject:
         try:
             return settings_service.patch_persisted_settings(cast(JsonObject, patch.root))
@@ -34,7 +34,7 @@ def build_settings_router(settings_service: SettingsService) -> APIRouter:
         except Exception as err:
             raise HTTPException(status_code=500, detail=f"Server error: {str(err)}")
 
-    @router.post("/settings/reset", response_model=Dict[str, Any], summary="Reset a persisted setting")
+    @router.post("/settings/reset", response_model=dict[str, Any], summary="Reset a persisted setting")
     def reset_settings(payload: SettingsResetInput) -> JsonObject:
         try:
             return settings_service.reset_persisted_value(payload.path)

--- a/discstore/adapters/inbound/api_controller.py
+++ b/discstore/adapters/inbound/api_controller.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from pydantic import BaseModel
 
 from jukebox.shared.dependency_messages import optional_extra_dependency_message
@@ -62,7 +60,7 @@ class SelectedSonosGroupOutput(SelectedSonosGroupSettings):
 class SonosSelectionMemberAvailabilityOutput(BaseModel):
     uid: str
     status: str
-    speaker: Optional[SonosSpeakerOutput] = None
+    speaker: SonosSpeakerOutput | None = None
 
 
 class SonosSelectionAvailabilityOutput(BaseModel):
@@ -71,13 +69,13 @@ class SonosSelectionAvailabilityOutput(BaseModel):
 
 
 class SonosSelectionOutput(BaseModel):
-    selected_group: Optional[SelectedSonosGroupOutput] = None
+    selected_group: SelectedSonosGroupOutput | None = None
     availability: SonosSelectionAvailabilityOutput
 
 
 class SonosSelectionInput(BaseModel):
     uids: list[str]
-    coordinator_uid: Optional[str] = None
+    coordinator_uid: str | None = None
 
 
 class SonosSelectionUpdateOutput(BaseModel):

--- a/discstore/adapters/inbound/cli_controller.py
+++ b/discstore/adapters/inbound/cli_controller.py
@@ -44,20 +44,21 @@ class CLIController:
         self,
         command: CliAddCommand | CliListCommand | CliRemoveCommand | CliEditCommand | CliGetCommand | CliSearchCommand,
     ) -> None:
-        if isinstance(command, CliAddCommand):
-            self.add_disc_flow(command)
-        elif isinstance(command, CliListCommand):
-            self.list_discs_flow(command)
-        elif isinstance(command, CliRemoveCommand):
-            self.remove_disc_flow(command)
-        elif isinstance(command, CliEditCommand):
-            self.edit_disc_flow(command)
-        elif isinstance(command, CliGetCommand):
-            self.get_disc_flow(command)
-        elif isinstance(command, CliSearchCommand):
-            self.search_discs_flow(command)
-        else:
-            LOGGER.error("Command not implemented yet: command='%s'", command)
+        match command:
+            case CliAddCommand():
+                self.add_disc_flow(command)
+            case CliListCommand():
+                self.list_discs_flow(command)
+            case CliRemoveCommand():
+                self.remove_disc_flow(command)
+            case CliEditCommand():
+                self.edit_disc_flow(command)
+            case CliGetCommand():
+                self.get_disc_flow(command)
+            case CliSearchCommand():
+                self.search_discs_flow(command)
+            case _:
+                LOGGER.error("Command not implemented yet: command='%s'", command)
 
     def add_disc_flow(self, command: CliAddCommand) -> None:
         tag = self.resolve_tag_id.execute(command.tag, command.use_current_tag)

--- a/discstore/adapters/inbound/cli_controller.py
+++ b/discstore/adapters/inbound/cli_controller.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Union
 
 from discstore.adapters.inbound.cli_display import display_library_line, display_library_table
 from discstore.commands import (
@@ -43,9 +42,7 @@ class CLIController:
 
     def run(
         self,
-        command: Union[
-            CliAddCommand, CliListCommand, CliRemoveCommand, CliEditCommand, CliGetCommand, CliSearchCommand
-        ],
+        command: CliAddCommand | CliListCommand | CliRemoveCommand | CliEditCommand | CliGetCommand | CliSearchCommand,
     ) -> None:
         if isinstance(command, CliAddCommand):
             self.add_disc_flow(command)

--- a/discstore/adapters/inbound/cli_display.py
+++ b/discstore/adapters/inbound/cli_display.py
@@ -1,11 +1,9 @@
-from typing import Dict
-
 from discstore.domain.entities import Disc
 
 MAX_COL_WIDTH = 20
 
 
-def display_library_line(discs: Dict[str, Disc]) -> None:
+def display_library_line(discs: dict[str, Disc]) -> None:
     if not discs:
         print("The library is empty")
         return
@@ -28,7 +26,7 @@ def truncate(text: str, max_length: int) -> str:
     return text[: max_length - 3] + "..."
 
 
-def display_library_table(discs: Dict[str, Disc]) -> None:
+def display_library_table(discs: dict[str, Disc]) -> None:
     if not discs:
         print("The library is empty")
         return

--- a/discstore/adapters/inbound/interactive_cli_controller.py
+++ b/discstore/adapters/inbound/interactive_cli_controller.py
@@ -37,24 +37,25 @@ class InteractiveCLIController:
 
     def handle_command(self, command: str) -> None:
         try:
-            if command == "add":
-                self.add_disc_flow()
-            elif command == "remove":
-                self.remove_disc_flow()
-            elif command == "list":
-                self.list_discs_flow()
-            elif command == "edit":
-                self.edit_disc_flow()
-            elif command == "current":
-                self.current_tag_flow()
-            elif command == "exit":
-                print("See you soon!")
-                exit(0)
-            elif command == "help":
-                print(self.help_message)
-            else:
-                print(f"Invalid command `{command}`")
-                print(self.help_message)
+            match command:
+                case "add":
+                    self.add_disc_flow()
+                case "remove":
+                    self.remove_disc_flow()
+                case "list":
+                    self.list_discs_flow()
+                case "edit":
+                    self.edit_disc_flow()
+                case "current":
+                    self.current_tag_flow()
+                case "exit":
+                    print("See you soon!")
+                    exit(0)
+                case "help":
+                    print(self.help_message)
+                case _:
+                    print(f"Invalid command `{command}`")
+                    print(self.help_message)
         except Exception as err:
             print(f"Error: {err}")
             LOGGER.error("Error during handling command: %s", err)

--- a/discstore/adapters/inbound/interactive_cli_controller.py
+++ b/discstore/adapters/inbound/interactive_cli_controller.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional
 
 from discstore.adapters.inbound.cli_display import display_library_line, display_library_table
 from discstore.domain.entities import CurrentTagStatus, Disc, DiscMetadata, DiscOption
@@ -112,7 +111,7 @@ class InteractiveCLIController:
         print(f"Tag ID           : {current_tag_status.tag_id}")
         print(f"Known in library : {'yes' if current_tag_status.known_in_library else 'no'}")
 
-    def _prompt_for_tag(self, current_tag_status: Optional[CurrentTagStatus], action: str) -> str:
+    def _prompt_for_tag(self, current_tag_status: CurrentTagStatus | None, action: str) -> str:
         default_tag = ""
         if current_tag_status is not None and (
             (action == "add" and not current_tag_status.known_in_library)

--- a/discstore/adapters/inbound/ui_controller.py
+++ b/discstore/adapters/inbound/ui_controller.py
@@ -3,7 +3,8 @@ import sys
 if sys.version_info < (3, 10):
     raise RuntimeError("The `ui_controller` module requires Python 3.10+.")
 
-from typing import Annotated, AsyncIterator, List, Optional
+from collections.abc import AsyncIterator
+from typing import Annotated
 
 from jukebox.shared.dependency_messages import optional_extra_dependency_message
 
@@ -84,7 +85,7 @@ class UIController(APIController):
         super().register_routes()
 
         @self.app.get("/api/ui/", response_model=FastUI, response_model_exclude_none=True)
-        def list_discs(toast: Optional[str] = None) -> List[AnyComponent]:
+        def list_discs(toast: str | None = None) -> list[AnyComponent]:
             return self._build_index_page_components(toast=toast)
 
         @self.app.get("/api/ui/current-tag-banner/events")
@@ -100,7 +101,7 @@ class UIController(APIController):
             )
 
         @self.app.get("/api/ui/discs/new", response_model=FastUI, response_model_exclude_none=True)
-        def new_disc_form(prefill: Optional[str] = None) -> List[AnyComponent]:
+        def new_disc_form(prefill: str | None = None) -> list[AnyComponent]:
             return self._build_form_page_components(
                 title="Add disc",
                 form_components=self._build_new_disc_form_components(prefill_current=(prefill == "current")),
@@ -127,7 +128,7 @@ class UIController(APIController):
             return self._build_success_response("toast-add-disc-success")
 
         @self.app.get("/api/ui/discs/{tag_id}/edit", response_model=FastUI, response_model_exclude_none=True)
-        def edit_disc_form(tag_id: str) -> List[AnyComponent]:
+        def edit_disc_form(tag_id: str) -> list[AnyComponent]:
             return self._build_form_page_components(
                 title=f"Edit disc {tag_id}",
                 form_components=self._build_edit_disc_form_components(tag_id),
@@ -169,7 +170,7 @@ class UIController(APIController):
             return self._build_success_response("toast-edit-disc-success")
 
         @self.app.get("/api/ui/discs/{tag_id}/delete", response_model=FastUI, response_model_exclude_none=True)
-        def delete_disc_confirmation(tag_id: str) -> List[AnyComponent]:
+        def delete_disc_confirmation(tag_id: str) -> list[AnyComponent]:
             return self._build_form_page_components(
                 title=f"Delete disc {tag_id}",
                 form_components=self._build_delete_disc_form_components(tag_id),
@@ -189,11 +190,11 @@ class UIController(APIController):
             return self._build_success_response("toast-remove-disc-success")
 
         @self.app.get("/api/ui/settings", response_model=FastUI, response_model_exclude_none=True)
-        def settings_page(toast: Optional[str] = None, toast_message: Optional[str] = None) -> List[AnyComponent]:
+        def settings_page(toast: str | None = None, toast_message: str | None = None) -> list[AnyComponent]:
             return self._build_settings_page_components(toast=toast, toast_message=toast_message)
 
         @self.app.get("/api/ui/settings/{setting_path}/edit", response_model=FastUI, response_model_exclude_none=True)
-        def edit_setting_form(setting_path: str) -> List[AnyComponent]:
+        def edit_setting_form(setting_path: str) -> list[AnyComponent]:
             return self._build_settings_edit_page_components(setting_path)
 
         @self.app.post("/api/ui/settings/{setting_path}", response_model=FastUI, response_model_exclude_none=True)
@@ -228,15 +229,15 @@ class UIController(APIController):
             return self._reset_setting(setting_path)
 
         @self.app.get("/api/ui/sonos", response_model=FastUI, response_model_exclude_none=True)
-        def sonos_page(toast: Optional[str] = None, toast_message: Optional[str] = None) -> List[AnyComponent]:
+        def sonos_page(toast: str | None = None, toast_message: str | None = None) -> list[AnyComponent]:
             return self._build_sonos_page_components(toast=toast, toast_message=toast_message)
 
         @self.app.get("/api/ui/sonos/edit", response_model=FastUI, response_model_exclude_none=True)
         def edit_sonos_form(
-            error_message: Optional[str] = None,
-            uids: Optional[List[str]] = None,
-            coordinator_uid: Optional[str] = None,
-        ) -> List[AnyComponent]:
+            error_message: str | None = None,
+            uids: list[str] | None = None,
+            coordinator_uid: str | None = None,
+        ) -> list[AnyComponent]:
             field_errors = None
             if error_message:
                 field_errors = {self._sonos_field_name_for_error(error_message): error_message}
@@ -304,10 +305,10 @@ class UIController(APIController):
 
     def _build_sonos_page_components(
         self,
-        toast: Optional[str] = None,
-        toast_message: Optional[str] = None,
-        error_message: Optional[str] = None,
-    ) -> List[AnyComponent]:
+        toast: str | None = None,
+        toast_message: str | None = None,
+        error_message: str | None = None,
+    ) -> list[AnyComponent]:
         return self.sonos_pages.build_sonos_page_components(
             toast=toast,
             toast_message=toast_message,
@@ -316,11 +317,11 @@ class UIController(APIController):
 
     def _build_sonos_edit_page_components(
         self,
-        error_message: Optional[str] = None,
-        field_errors: Optional[dict[str, str]] = None,
-        submitted_uids: Optional[List[str]] = None,
-        submitted_coordinator_uid: Optional[str] = None,
-    ) -> List[AnyComponent]:
+        error_message: str | None = None,
+        field_errors: dict[str, str] | None = None,
+        submitted_uids: list[str] | None = None,
+        submitted_coordinator_uid: str | None = None,
+    ) -> list[AnyComponent]:
         return self.sonos_pages.build_sonos_edit_page_components(
             error_message=error_message,
             field_errors=field_errors,
@@ -345,7 +346,7 @@ class UIController(APIController):
 
         return self.sonos_pages.build_sonos_success_response(str(result.get("message", "Settings saved.")))
 
-    def _persisted_sonos_selection_matches(self, uids: List[str], coordinator_uid: Optional[str]) -> bool:
+    def _persisted_sonos_selection_matches(self, uids: list[str], coordinator_uid: str | None) -> bool:
         try:
             selected_group = SettingsSelectedSonosGroupRepository(self.settings_service).get_selected_group()
         except Exception:
@@ -360,7 +361,7 @@ class UIController(APIController):
             and [member.uid for member in selected_group.members] == uids
         )
 
-    def _build_sonos_error_message(self, message: str, coordinator_uid: Optional[str]) -> str:
+    def _build_sonos_error_message(self, message: str, coordinator_uid: str | None) -> str:
         prefix = "Selected Sonos coordinator must be one of the selected speakers: "
         if coordinator_uid is None or not message.startswith(prefix):
             return message
@@ -376,21 +377,21 @@ class UIController(APIController):
 
         return f"{prefix}{speaker.name} [{speaker.uid}]"
 
-    def _build_index_page_components(self, toast: Optional[str] = None) -> List[AnyComponent]:
+    def _build_index_page_components(self, toast: str | None = None) -> list[AnyComponent]:
         return self.library_pages.build_index_page_components(toast=toast)
 
     def _build_settings_page_components(
         self,
-        toast: Optional[str] = None,
-        toast_message: Optional[str] = None,
-    ) -> List[AnyComponent]:
+        toast: str | None = None,
+        toast_message: str | None = None,
+    ) -> list[AnyComponent]:
         return self.settings_pages.build_settings_page_components(toast=toast, toast_message=toast_message)
 
     def _build_settings_section_components(
         self,
         section: str,
-        settings: List[EditableSettingDisplay],
-    ) -> List[AnyComponent]:
+        settings: list[EditableSettingDisplay],
+    ) -> list[AnyComponent]:
         return self.settings_pages.build_settings_section_components(section, settings)
 
     def _build_settings_row(self, setting: EditableSettingDisplay, index: int) -> AnyComponent:
@@ -399,8 +400,8 @@ class UIController(APIController):
     def _build_settings_edit_page_components(
         self,
         setting_path: str,
-        reset_error: Optional[str] = None,
-    ) -> List[AnyComponent]:
+        reset_error: str | None = None,
+    ) -> list[AnyComponent]:
         return self.settings_pages.build_settings_edit_page_components(setting_path, reset_error=reset_error)
 
     def _build_settings_edit_form(self, setting: EditableSettingDisplay) -> AnyComponent:
@@ -409,7 +410,7 @@ class UIController(APIController):
     def _build_settings_reset_form(self, setting_path: str) -> AnyComponent:
         return self.settings_pages.build_settings_reset_form(setting_path)
 
-    def _get_settings_displays(self) -> tuple[List[EditableSettingDisplay], Optional[str]]:
+    def _get_settings_displays(self) -> tuple[list[EditableSettingDisplay], str | None]:
         return self.settings_pages.get_settings_displays()
 
     def _build_settings_badges(self, setting: EditableSettingDisplay) -> list[AnyComponent]:
@@ -445,15 +446,13 @@ class UIController(APIController):
     def _format_settings_provenance(self, provenance: str) -> str:
         return self.settings_pages.format_settings_provenance(provenance)
 
-    def _build_form_page_components(self, title: str, form_components: List[AnyComponent]) -> List[AnyComponent]:
+    def _build_form_page_components(self, title: str, form_components: list[AnyComponent]) -> list[AnyComponent]:
         return self.library_pages.build_form_page_components(title=title, form_components=form_components)
 
-    def _build_current_tag_banner_components(
-        self, current_tag_status: Optional[CurrentTagStatus]
-    ) -> List[AnyComponent]:
+    def _build_current_tag_banner_components(self, current_tag_status: CurrentTagStatus | None) -> list[AnyComponent]:
         return self.library_pages.build_current_tag_banner_components(current_tag_status)
 
-    def _build_disc_library_components(self, discs: List[DiscTable]) -> List[AnyComponent]:
+    def _build_disc_library_components(self, discs: list[DiscTable]) -> list[AnyComponent]:
         return self.library_pages.build_disc_library_components(discs)
 
     def _build_disc_library_header(self) -> AnyComponent:
@@ -465,16 +464,16 @@ class UIController(APIController):
     def _build_disc_header_cell(self, label: str, class_name: str) -> AnyComponent:
         return self.library_pages._build_disc_header_cell(label, class_name)
 
-    def _build_disc_value_cell(self, label: str, value: Optional[str], class_name: str) -> AnyComponent:
+    def _build_disc_value_cell(self, label: str, value: str | None, class_name: str) -> AnyComponent:
         return self.library_pages._build_disc_value_cell(label, value, class_name)
 
-    def _build_new_disc_form_components(self, prefill_current: bool) -> List[AnyComponent]:
+    def _build_new_disc_form_components(self, prefill_current: bool) -> list[AnyComponent]:
         return self.library_pages.build_new_disc_form_components(prefill_current)
 
-    def _build_edit_disc_form_components(self, tag_id: str) -> List[AnyComponent]:
+    def _build_edit_disc_form_components(self, tag_id: str) -> list[AnyComponent]:
         return self.library_pages.build_edit_disc_form_components(tag_id)
 
-    def _build_delete_disc_form_components(self, tag_id: str) -> List[AnyComponent]:
+    def _build_delete_disc_form_components(self, tag_id: str) -> list[AnyComponent]:
         return self.library_pages.build_delete_disc_form_components(tag_id)
 
     async def _current_tag_banner_event_stream(
@@ -485,7 +484,7 @@ class UIController(APIController):
         async for payload in self.library_pages.current_tag_banner_event_stream(request, poll_interval_seconds):
             yield payload
 
-    def _serialize_current_tag_components(self, components: List[AnyComponent]) -> str:
+    def _serialize_current_tag_components(self, components: list[AnyComponent]) -> str:
         return self.library_pages.serialize_current_tag_components(components)
 
     @staticmethod

--- a/discstore/adapters/inbound/ui_controller.py
+++ b/discstore/adapters/inbound/ui_controller.py
@@ -35,7 +35,7 @@ from jukebox.settings.definitions import (
 from jukebox.settings.errors import SettingsError
 from jukebox.settings.selected_sonos_group_repository import SettingsSelectedSonosGroupRepository
 from jukebox.settings.service_protocols import SettingsService
-from jukebox.settings.types import JsonObject
+from jukebox.settings.types import JsonObject, JsonValue
 from jukebox.sonos.discovery import SonosDiscoveryError
 from jukebox.sonos.selection import SaveSonosSelection
 from jukebox.sonos.service import SonosService
@@ -423,7 +423,7 @@ class UIController(APIController):
     def _build_settings_patch(self, setting_path: str, raw_value: str) -> JsonObject:
         return self.settings_pages.build_settings_patch(setting_path, raw_value)
 
-    def _build_dotted_patch(self, dotted_path: str, value: object) -> JsonObject:
+    def _build_dotted_patch(self, dotted_path: str, value: JsonValue) -> JsonObject:
         return self.settings_pages.build_dotted_patch(dotted_path, value)
 
     def _persisted_value_matches(self, dotted_path: str, expected_value: object) -> bool:

--- a/discstore/adapters/inbound/ui_controller.py
+++ b/discstore/adapters/inbound/ui_controller.py
@@ -1,8 +1,3 @@
-import sys
-
-if sys.version_info < (3, 10):
-    raise RuntimeError("The `ui_controller` module requires Python 3.10+.")
-
 from collections.abc import AsyncIterator
 from typing import Annotated
 

--- a/discstore/adapters/inbound/ui_pages/library.py
+++ b/discstore/adapters/inbound/ui_pages/library.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-from typing import AsyncIterator, List, Optional
+from collections.abc import AsyncIterator
 
 from fastapi import Request
 from fastui import AnyComponent
@@ -22,9 +22,9 @@ class DiscTable(DiscMetadata, DiscOption):
 class DiscForm(BaseModel):
     tag: str = Field(title="Tag ID")
     uri: str = Field(title="URI / Path")
-    artist: Optional[str] = Field(None, title="Artist")
-    album: Optional[str] = Field(None, title="Album")
-    track: Optional[str] = Field(None, title="Track")
+    artist: str | None = Field(None, title="Artist")
+    album: str | None = Field(None, title="Album")
+    track: str | None = Field(None, title="Track")
     shuffle: bool = Field(False, title="Shuffle")
 
 
@@ -39,7 +39,7 @@ class LibraryUIPageBuilder:
         self.get_disc = get_disc
         self.get_current_tag_status = get_current_tag_status
 
-    def build_index_page_components(self, toast: Optional[str] = None) -> List[AnyComponent]:
+    def build_index_page_components(self, toast: str | None = None) -> list[AnyComponent]:
         discs = self.list_discs.execute()
         discs_list = [
             DiscTable(tag=tag, uri=disc.uri, **disc.metadata.model_dump(), **disc.option.model_dump())
@@ -94,7 +94,7 @@ class LibraryUIPageBuilder:
 
         return page_components
 
-    def build_form_page_components(self, title: str, form_components: List[AnyComponent]) -> List[AnyComponent]:
+    def build_form_page_components(self, title: str, form_components: list[AnyComponent]) -> list[AnyComponent]:
         return [
             c.Page(
                 components=[
@@ -115,8 +115,8 @@ class LibraryUIPageBuilder:
 
     def build_current_tag_banner_components(
         self,
-        current_tag_status: Optional[CurrentTagStatus],
-    ) -> List[AnyComponent]:
+        current_tag_status: CurrentTagStatus | None,
+    ) -> list[AnyComponent]:
         if current_tag_status is None:
             return []
 
@@ -156,7 +156,7 @@ class LibraryUIPageBuilder:
             )
         ]
 
-    def build_disc_library_components(self, discs: List[DiscTable]) -> List[AnyComponent]:
+    def build_disc_library_components(self, discs: list[DiscTable]) -> list[AnyComponent]:
         if not discs:
             return [c.Paragraph(text="No disc found")]
 
@@ -170,7 +170,7 @@ class LibraryUIPageBuilder:
             )
         ]
 
-    def build_new_disc_form_components(self, prefill_current: bool) -> List[AnyComponent]:
+    def build_new_disc_form_components(self, prefill_current: bool) -> list[AnyComponent]:
         initial = None
 
         if prefill_current:
@@ -200,7 +200,7 @@ class LibraryUIPageBuilder:
             )
         ]
 
-    def build_edit_disc_form_components(self, tag_id: str) -> List[AnyComponent]:
+    def build_edit_disc_form_components(self, tag_id: str) -> list[AnyComponent]:
         if not tag_id:
             return [
                 c.Error(
@@ -239,7 +239,7 @@ class LibraryUIPageBuilder:
             ),
         ]
 
-    def build_delete_disc_form_components(self, tag_id: str) -> List[AnyComponent]:
+    def build_delete_disc_form_components(self, tag_id: str) -> list[AnyComponent]:
         if not tag_id:
             return [c.Error(title="No disc selected", description="Delete mode requires an existing disc tag ID.")]
         try:
@@ -275,7 +275,7 @@ class LibraryUIPageBuilder:
         request: Request,
         poll_interval_seconds: float = 0.5,
     ) -> AsyncIterator[bytes]:
-        previous_payload: Optional[str] = None
+        previous_payload: str | None = None
 
         while True:
             payload = self.serialize_current_tag_components(
@@ -283,7 +283,7 @@ class LibraryUIPageBuilder:
             )
             if payload != previous_payload:
                 previous_payload = payload
-                yield f"data: {payload}\n\n".encode("utf-8")
+                yield f"data: {payload}\n\n".encode()
 
             if await request.is_disconnected():
                 break
@@ -291,7 +291,7 @@ class LibraryUIPageBuilder:
             await asyncio.sleep(poll_interval_seconds)
 
     @staticmethod
-    def serialize_current_tag_components(components: List[AnyComponent]) -> str:
+    def serialize_current_tag_components(components: list[AnyComponent]) -> str:
         return json.dumps([component.model_dump(by_alias=True, exclude_none=True) for component in components])
 
     def _build_disc_library_header(self) -> AnyComponent:
@@ -365,7 +365,7 @@ class LibraryUIPageBuilder:
             ],
         )
 
-    def _build_disc_value_cell(self, label: str, value: Optional[str], class_name: str) -> AnyComponent:
+    def _build_disc_value_cell(self, label: str, value: str | None, class_name: str) -> AnyComponent:
         return c.Div(
             class_name=class_name,
             components=[

--- a/discstore/adapters/inbound/ui_pages/settings.py
+++ b/discstore/adapters/inbound/ui_pages/settings.py
@@ -1,6 +1,6 @@
 import json
 from itertools import groupby
-from typing import List, Optional, cast
+from typing import cast
 from urllib.parse import urlencode
 
 from fastapi import HTTPException
@@ -59,9 +59,9 @@ class SettingsUIPageBuilder:
 
     def build_settings_page_components(
         self,
-        toast: Optional[str] = None,
-        toast_message: Optional[str] = None,
-    ) -> List[AnyComponent]:
+        toast: str | None = None,
+        toast_message: str | None = None,
+    ) -> list[AnyComponent]:
         settings, effective_settings_error = self.get_settings_displays()
         components: list[AnyComponent] = [
             c.Heading(text="Settings", level=1),
@@ -105,8 +105,8 @@ class SettingsUIPageBuilder:
     def build_settings_section_components(
         self,
         section: str,
-        settings: List[EditableSettingDisplay],
-    ) -> List[AnyComponent]:
+        settings: list[EditableSettingDisplay],
+    ) -> list[AnyComponent]:
         first_setting = settings[0]
         section_components: list[AnyComponent] = [
             c.Heading(text=first_setting.section_label, level=2),
@@ -171,8 +171,8 @@ class SettingsUIPageBuilder:
     def build_settings_edit_page_components(
         self,
         setting_path: str,
-        reset_error: Optional[str] = None,
-    ) -> List[AnyComponent]:
+        reset_error: str | None = None,
+    ) -> list[AnyComponent]:
         settings, effective_settings_error = self.get_settings_displays()
         setting = next((candidate for candidate in settings if candidate.path == setting_path), None)
         if setting is None:
@@ -339,9 +339,9 @@ class SettingsUIPageBuilder:
             footer=[c.Button(text="Reset", html_type="submit", class_name="btn btn-outline-danger text-nowrap px-3")],
         )
 
-    def get_settings_displays(self) -> tuple[List[EditableSettingDisplay], Optional[str]]:
+    def get_settings_displays(self) -> tuple[list[EditableSettingDisplay], str | None]:
         persisted_settings = self.settings_service.get_persisted_settings_view()
-        effective_settings_error: Optional[str] = None
+        effective_settings_error: str | None = None
         try:
             effective_settings_view = self.settings_service.get_effective_settings_view()
         except SettingsError as err:

--- a/discstore/adapters/inbound/ui_pages/sonos.py
+++ b/discstore/adapters/inbound/ui_pages/sonos.py
@@ -1,4 +1,3 @@
-from typing import List, Optional
 from urllib.parse import urlencode
 
 from fastui import AnyComponent
@@ -20,8 +19,8 @@ from jukebox.sonos.service import SonosService
 
 
 class SonosSelectionForm(BaseModel):
-    uids: List[str] = Field(default_factory=list, title="Speakers")
-    coordinator_uid: Optional[str] = Field(None, title="Coordinator")
+    uids: list[str] = Field(default_factory=list, title="Speakers")
+    coordinator_uid: str | None = Field(None, title="Coordinator")
 
     @field_validator("uids", mode="before")
     @classmethod
@@ -50,8 +49,8 @@ class SonosUIPageBuilder:
     def build_sonos_edit_error_response(
         self,
         message: str,
-        uids: List[str],
-        coordinator_uid: Optional[str],
+        uids: list[str],
+        coordinator_uid: str | None,
     ) -> list[AnyComponent]:
         query = urlencode(
             [
@@ -66,12 +65,12 @@ class SonosUIPageBuilder:
 
     def build_sonos_page_components(
         self,
-        toast: Optional[str] = None,
-        toast_message: Optional[str] = None,
-        error_message: Optional[str] = None,
-    ) -> List[AnyComponent]:
+        toast: str | None = None,
+        toast_message: str | None = None,
+        error_message: str | None = None,
+    ) -> list[AnyComponent]:
         selected_group = self._get_selected_group()
-        status: Optional[SonosSelectionStatus] = None
+        status: SonosSelectionStatus | None = None
         speakers: list[DiscoveredSonosSpeaker] = []
         discovery_error = error_message
 
@@ -139,11 +138,11 @@ class SonosUIPageBuilder:
 
     def build_sonos_edit_page_components(
         self,
-        error_message: Optional[str] = None,
-        field_errors: Optional[dict[str, str]] = None,
-        submitted_uids: Optional[List[str]] = None,
-        submitted_coordinator_uid: Optional[str] = None,
-    ) -> List[AnyComponent]:
+        error_message: str | None = None,
+        field_errors: dict[str, str] | None = None,
+        submitted_uids: list[str] | None = None,
+        submitted_coordinator_uid: str | None = None,
+    ) -> list[AnyComponent]:
         selected_group = self._get_selected_group()
         components: list[AnyComponent] = [
             c.Heading(text="Edit Sonos Selection", level=1),
@@ -197,7 +196,7 @@ class SonosUIPageBuilder:
         components.extend(self._build_navigation_links())
         return [c.Page(components=components)]
 
-    def _build_edit_error_components(self, error_message: Optional[str]) -> list[AnyComponent]:
+    def _build_edit_error_components(self, error_message: str | None) -> list[AnyComponent]:
         if not error_message:
             return []
 
@@ -213,7 +212,7 @@ class SonosUIPageBuilder:
 
     def _build_edit_saved_selection_components(
         self,
-        selected_group: Optional[SelectedSonosGroupSettings],
+        selected_group: SelectedSonosGroupSettings | None,
         speakers: list[DiscoveredSonosSpeaker],
     ) -> list[AnyComponent]:
         if selected_group is None:
@@ -243,10 +242,10 @@ class SonosUIPageBuilder:
     def _build_selection_form(
         self,
         speakers: list[DiscoveredSonosSpeaker],
-        selected_group: Optional[SelectedSonosGroupSettings],
-        field_errors: Optional[dict[str, str]] = None,
-        submitted_uids: Optional[List[str]] = None,
-        submitted_coordinator_uid: Optional[str] = None,
+        selected_group: SelectedSonosGroupSettings | None,
+        field_errors: dict[str, str] | None = None,
+        submitted_uids: list[str] | None = None,
+        submitted_coordinator_uid: str | None = None,
     ) -> AnyComponent:
         selected_uids = (
             list(submitted_uids)
@@ -306,8 +305,8 @@ class SonosUIPageBuilder:
 
     def _build_saved_selection_components(
         self,
-        status: Optional[SonosSelectionStatus],
-        selected_group: Optional[SelectedSonosGroupSettings],
+        status: SonosSelectionStatus | None,
+        selected_group: SelectedSonosGroupSettings | None,
     ) -> list[AnyComponent]:
         if selected_group is None:
             return [
@@ -359,7 +358,7 @@ class SonosUIPageBuilder:
     def _build_discovered_speakers_components(
         self,
         speakers: list[DiscoveredSonosSpeaker],
-        selected_group: Optional[SelectedSonosGroupSettings],
+        selected_group: SelectedSonosGroupSettings | None,
     ) -> list[AnyComponent]:
         if not speakers:
             return [
@@ -478,7 +477,7 @@ class SonosUIPageBuilder:
             ],
         )
 
-    def _get_selected_group(self) -> Optional[SelectedSonosGroupSettings]:
+    def _get_selected_group(self) -> SelectedSonosGroupSettings | None:
         return SettingsSelectedSonosGroupRepository(self.settings_service).get_selected_group()
 
     @staticmethod

--- a/discstore/command_handlers.py
+++ b/discstore/command_handlers.py
@@ -1,4 +1,5 @@
-from typing import Callable, Protocol
+from collections.abc import Callable
+from typing import Protocol
 
 from jukebox.settings.service_protocols import SettingsService
 

--- a/discstore/commands.py
+++ b/discstore/commands.py
@@ -1,5 +1,5 @@
 from enum import StrEnum
-from typing import Literal
+from typing import Literal, Self
 
 from pydantic import BaseModel, model_validator
 
@@ -9,7 +9,7 @@ class CliTagSourceCommand(BaseModel):
     use_current_tag: bool = False
 
     @model_validator(mode="after")
-    def validate_tag_source(self):
+    def validate_tag_source(self) -> Self:
         has_explicit_tag = bool(self.tag)
         if has_explicit_tag == self.use_current_tag:
             raise ValueError("Exactly one tag source must be provided: explicit tag or --from-current.")

--- a/discstore/commands.py
+++ b/discstore/commands.py
@@ -1,11 +1,11 @@
 from enum import Enum
-from typing import Literal, Optional
+from typing import Literal
 
 from pydantic import BaseModel, model_validator
 
 
 class CliTagSourceCommand(BaseModel):
-    tag: Optional[str] = None
+    tag: str | None = None
     use_current_tag: bool = False
 
     @model_validator(mode="after")
@@ -19,9 +19,9 @@ class CliTagSourceCommand(BaseModel):
 class CliAddCommand(CliTagSourceCommand):
     type: Literal["add"]
     uri: str
-    track: Optional[str] = None
-    artist: Optional[str] = None
-    album: Optional[str] = None
+    track: str | None = None
+    artist: str | None = None
+    album: str | None = None
 
 
 class CliListCommandModes(str, Enum):
@@ -40,10 +40,10 @@ class CliRemoveCommand(CliTagSourceCommand):
 
 class CliEditCommand(CliTagSourceCommand):
     type: Literal["edit"]
-    uri: Optional[str] = None
-    track: Optional[str] = None
-    artist: Optional[str] = None
-    album: Optional[str] = None
+    uri: str | None = None
+    track: str | None = None
+    artist: str | None = None
+    album: str | None = None
 
 
 class CliGetCommand(CliTagSourceCommand):

--- a/discstore/commands.py
+++ b/discstore/commands.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import StrEnum
 from typing import Literal
 
 from pydantic import BaseModel, model_validator
@@ -24,7 +24,7 @@ class CliAddCommand(CliTagSourceCommand):
     album: str | None = None
 
 
-class CliListCommandModes(str, Enum):
+class CliListCommandModes(StrEnum):
     table = "table"
     line = "line"
 

--- a/discstore/domain/use_cases/edit_disc.py
+++ b/discstore/domain/use_cases/edit_disc.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from discstore.domain.entities import Disc, DiscMetadata, DiscOption
 from discstore.domain.repositories import LibraryRepository
 
@@ -11,9 +9,9 @@ class EditDisc:
     def execute(
         self,
         tag_id: str,
-        uri: Optional[str] = None,
-        metadata: Optional[DiscMetadata] = None,
-        option: Optional[DiscOption] = None,
+        uri: str | None = None,
+        metadata: DiscMetadata | None = None,
+        option: DiscOption | None = None,
     ) -> Disc:
         current_disc = self.repository.get_disc(tag_id)
         if current_disc is None:

--- a/discstore/domain/use_cases/get_current_tag_status.py
+++ b/discstore/domain/use_cases/get_current_tag_status.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from discstore.domain.entities import CurrentTagStatus
 from discstore.domain.repositories import CurrentTagRepository, LibraryRepository
 
@@ -9,7 +7,7 @@ class GetCurrentTagStatus:
         self.current_tag_repository = current_tag_repository
         self.library = library
 
-    def execute(self) -> Optional[CurrentTagStatus]:
+    def execute(self) -> CurrentTagStatus | None:
         tag_id = self.current_tag_repository.get()
         if tag_id is None:
             return None

--- a/discstore/domain/use_cases/list_discs.py
+++ b/discstore/domain/use_cases/list_discs.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from discstore.domain.entities import Disc
 from discstore.domain.repositories import LibraryRepository
 
@@ -8,5 +6,5 @@ class ListDiscs:
     def __init__(self, repository: LibraryRepository):
         self.repository = repository
 
-    def execute(self) -> Dict[str, Disc]:
+    def execute(self) -> dict[str, Disc]:
         return self.repository.list_discs()

--- a/discstore/domain/use_cases/resolve_tag_id.py
+++ b/discstore/domain/use_cases/resolve_tag_id.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from discstore.domain.use_cases.get_current_tag_status import GetCurrentTagStatus
 
 
@@ -7,7 +5,7 @@ class ResolveTagId:
     def __init__(self, get_current_tag_status: GetCurrentTagStatus):
         self.get_current_tag_status = get_current_tag_status
 
-    def execute(self, tag_id: Optional[str], use_current_tag: bool) -> str:
+    def execute(self, tag_id: str | None, use_current_tag: bool) -> str:
         has_explicit_tag_id = bool(tag_id)
         if has_explicit_tag_id == use_current_tag:
             raise ValueError("Exactly one tag source must be provided: explicit tag or --from-current.")

--- a/discstore/domain/use_cases/search_discs.py
+++ b/discstore/domain/use_cases/search_discs.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from discstore.domain.entities import Disc
 from discstore.domain.repositories import LibraryRepository
 
@@ -8,7 +6,7 @@ class SearchDiscs:
     def __init__(self, repository: LibraryRepository):
         self.repository = repository
 
-    def execute(self, query: str) -> Dict[str, Disc]:
+    def execute(self, query: str) -> dict[str, Disc]:
         query_lower = query.lower()
         results = {}
 

--- a/jukebox/adapters/inbound/config.py
+++ b/jukebox/adapters/inbound/config.py
@@ -1,5 +1,5 @@
 import argparse
-from typing import Literal, Optional
+from typing import Literal
 
 from pydantic import BaseModel
 
@@ -7,17 +7,17 @@ from jukebox.shared.config_utils import add_verbose_arg, add_version_arg
 
 
 class JukeboxCliConfig(BaseModel):
-    library: Optional[str] = None
+    library: str | None = None
     verbose: bool = False
-    player: Optional[Literal["dryrun", "sonos"]] = None
-    reader: Optional[Literal["dryrun", "pn532"]] = None
-    sonos_host: Optional[str] = None
-    sonos_name: Optional[str] = None
-    pause_duration_seconds: Optional[int] = None
-    pause_delay_seconds: Optional[float] = None
-    pn532_spi_reset: Optional[int] = None
-    pn532_spi_cs: Optional[int] = None
-    pn532_spi_irq: Optional[int] = None
+    player: Literal["dryrun", "sonos"] | None = None
+    reader: Literal["dryrun", "pn532"] | None = None
+    sonos_host: str | None = None
+    sonos_name: str | None = None
+    pause_duration_seconds: int | None = None
+    pause_delay_seconds: float | None = None
+    pn532_spi_reset: int | None = None
+    pn532_spi_cs: int | None = None
+    pn532_spi_irq: int | None = None
 
 
 def parse_config() -> JukeboxCliConfig:

--- a/jukebox/adapters/outbound/json_library_adapter.py
+++ b/jukebox/adapters/outbound/json_library_adapter.py
@@ -3,7 +3,6 @@ import logging
 import os
 import tempfile
 from contextlib import suppress
-from typing import Optional
 
 from pydantic import ValidationError
 
@@ -18,12 +17,12 @@ class JsonLibraryAdapter(LibraryRepository):
 
     def __init__(self, filepath: str):
         self.filepath = filepath
-        self._cached_library: Optional[Library] = None
-        self._cached_file_state: Optional[tuple[int, int]] = None
+        self._cached_library: Library | None = None
+        self._cached_file_state: tuple[int, int] | None = None
 
     def _load_from_disk(self) -> Library:
         try:
-            with open(self.filepath, "r", encoding="utf-8") as f:
+            with open(self.filepath, encoding="utf-8") as f:
                 data = json.load(f)
                 return Library.model_validate(data)
         except FileNotFoundError:
@@ -60,7 +59,7 @@ class JsonLibraryAdapter(LibraryRepository):
                 os.unlink(temp_path)
             raise
 
-    def _get_file_state(self) -> Optional[tuple[int, int]]:
+    def _get_file_state(self) -> tuple[int, int] | None:
         try:
             stat_result = os.stat(self.filepath)
         except FileNotFoundError:
@@ -93,7 +92,7 @@ class JsonLibraryAdapter(LibraryRepository):
     def list_discs(self) -> dict[str, Disc]:
         return {tag_id: self._copy_disc(disc) for tag_id, disc in self._get_cached_library().discs.items()}
 
-    def get_disc(self, tag_id: str) -> Optional[Disc]:
+    def get_disc(self, tag_id: str) -> Disc | None:
         disc = self._get_cached_library().discs.get(tag_id)
         if disc is None:
             return None

--- a/jukebox/adapters/outbound/players/sonos_player_adapter.py
+++ b/jukebox/adapters/outbound/players/sonos_player_adapter.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional
 
 import soco
 from requests.exceptions import RequestException
@@ -42,9 +41,9 @@ class SonosPlayerAdapter(PlayerPort):
 
     def __init__(
         self,
-        host: Optional[str] = None,
-        name: Optional[str] = None,
-        group: Optional[ResolvedSonosGroupRuntime] = None,
+        host: str | None = None,
+        name: str | None = None,
+        group: ResolvedSonosGroupRuntime | None = None,
     ):
         try:
             if group is not None:
@@ -70,7 +69,7 @@ class SonosPlayerAdapter(PlayerPort):
         self.sharelink = ShareLinkPlugin(self.speaker)
 
     @staticmethod
-    def _discover(name: Optional[str] = None) -> SoCo:
+    def _discover(name: str | None = None) -> SoCo:
         discovered = soco.discover()
         if not discovered:
             raise RuntimeError("No Sonos speakers found on the network")
@@ -175,7 +174,7 @@ class SonosPlayerAdapter(PlayerPort):
         return getattr(speaker, "is_visible", True) is False
 
     @staticmethod
-    def _get_rollback_coordinator_for_join(speaker: SoCo) -> Optional[SoCo]:
+    def _get_rollback_coordinator_for_join(speaker: SoCo) -> SoCo | None:
         current_group = speaker.group
         if current_group is None:
             return None

--- a/jukebox/adapters/outbound/readers/dryrun_reader_adapter.py
+++ b/jukebox/adapters/outbound/readers/dryrun_reader_adapter.py
@@ -2,7 +2,6 @@ import logging
 import select
 import sys
 import time
-from typing import Union
 
 from jukebox.domain.ports import ReaderPort
 from jukebox.shared.timing import DEFAULT_LOOP_INTERVAL_SECONDS
@@ -18,7 +17,7 @@ class DryrunReaderAdapter(ReaderPort):
         self.uid = None
         self.hold_until = None
 
-    def read(self) -> Union[str, None]:
+    def read(self) -> str | None:
         if self.uid is not None and self.hold_until is not None and time.monotonic() < self.hold_until:
             LOGGER.info("Reading tag %s", self.uid)
             return self.uid

--- a/jukebox/adapters/outbound/readers/pn532_reader_adapter.py
+++ b/jukebox/adapters/outbound/readers/pn532_reader_adapter.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import os
 

--- a/jukebox/adapters/outbound/readers/pn532_reader_adapter.py
+++ b/jukebox/adapters/outbound/readers/pn532_reader_adapter.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Optional, Union
 
 from jukebox.shared.dependency_messages import optional_extra_dependency_message
 
@@ -31,9 +30,9 @@ class Pn532ReaderAdapter(ReaderPort):
     def __init__(
         self,
         read_timeout_seconds: float = DEFAULT_NFC_READ_TIMEOUT_SECONDS,
-        spi_reset: Optional[int] = None,
-        spi_cs: Optional[int] = None,
-        spi_irq: Optional[int] = None,
+        spi_reset: int | None = None,
+        spi_cs: int | None = None,
+        spi_irq: int | None = None,
     ):
         if not spi_active():
             error_message = (
@@ -54,7 +53,7 @@ class Pn532ReaderAdapter(ReaderPort):
     def firmware_version(self) -> tuple[int, int]:
         return self._firmware_version
 
-    def read(self) -> Union[str, None]:
+    def read(self) -> str | None:
         rawuid = self.pn532.read_passive_target(timeout=self.read_timeout_seconds)
         if rawuid is None:
             return None

--- a/jukebox/adapters/outbound/sonos_discovery_adapter.py
+++ b/jukebox/adapters/outbound/sonos_discovery_adapter.py
@@ -5,7 +5,7 @@ import socket
 import struct
 import time
 from dataclasses import dataclass
-from typing import Any, Optional, Protocol
+from typing import Any, Protocol
 
 from jukebox.sonos.discovery import (
     DiscoveredSonosSpeaker,
@@ -35,7 +35,7 @@ _PLAYER_SEARCH = (
     "MX: 1\r\n"
     "ST: urn:schemas-upnp-org:device:ZonePlayer:1\r\n"
     "\r\n"
-).encode("utf-8")
+).encode()
 
 
 class SoCoSonosDiscoveryAdapter(SonosDiscoveryPort):
@@ -280,7 +280,7 @@ class SoCoSonosDiscoveryAdapter(SonosDiscoveryPort):
 
     @staticmethod
     def _choose_preferred(
-        existing: Optional[DiscoveredSonosSpeaker],
+        existing: DiscoveredSonosSpeaker | None,
         candidate: DiscoveredSonosSpeaker,
     ) -> DiscoveredSonosSpeaker:
         if existing is None:
@@ -296,7 +296,7 @@ class SoCoSonosDiscoveryAdapter(SonosDiscoveryPort):
     @staticmethod
     def _normalize_speaker(
         speaker: "_SonosSpeakerLike",
-    ) -> tuple[Optional[DiscoveredSonosSpeaker], Optional[str]]:
+    ) -> tuple[DiscoveredSonosSpeaker | None, str | None]:
         from requests.exceptions import RequestException
         from soco.exceptions import SoCoException, SoCoUPnPException
         from urllib3.exceptions import HTTPError
@@ -340,7 +340,7 @@ def _safe_speaker_identifier(speaker: "_SonosSpeakerLike") -> str:
     return str(uid)
 
 
-def _safe_speaker_host(speaker: "_SonosSpeakerLike") -> Optional[str]:
+def _safe_speaker_host(speaker: "_SonosSpeakerLike") -> str | None:
     try:
         ip_address = getattr(speaker, "ip_address", None)
     except Exception:
@@ -351,14 +351,14 @@ def _safe_speaker_host(speaker: "_SonosSpeakerLike") -> Optional[str]:
     return None
 
 
-def _safe_speaker_uid(speaker: "_SonosSpeakerLike") -> Optional[str]:
+def _safe_speaker_uid(speaker: "_SonosSpeakerLike") -> str | None:
     try:
         return str(getattr(speaker, "uid"))
     except Exception:
         return None
 
 
-def _extract_sonos_household_id(response: bytes) -> Optional[str]:
+def _extract_sonos_household_id(response: bytes) -> str | None:
     match = _HOUSEHOLD_HEADER_RE.search(response)
     if match is None:
         return None

--- a/jukebox/adapters/outbound/text_current_tag_adapter.py
+++ b/jukebox/adapters/outbound/text_current_tag_adapter.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import tempfile
-from typing import Optional
 
 from jukebox.domain.repositories import CurrentTagRepository
 
@@ -18,7 +17,7 @@ class TextCurrentTagAdapter(CurrentTagRepository):
     def __init__(self, filepath: str):
         self.filepath = filepath
 
-    def get(self) -> Optional[str]:
+    def get(self) -> str | None:
         return self._read_current_tag()
 
     def set(self, tag_id: str) -> None:
@@ -49,9 +48,9 @@ class TextCurrentTagAdapter(CurrentTagRepository):
     def clear(self) -> None:
         self._clear_unlocked()
 
-    def _read_current_tag(self) -> Optional[str]:
+    def _read_current_tag(self) -> str | None:
         try:
-            with open(self.filepath, "r", encoding="utf-8") as current_tag_file:
+            with open(self.filepath, encoding="utf-8") as current_tag_file:
                 tag_id = current_tag_file.read().strip()
         except FileNotFoundError:
             return None

--- a/jukebox/admin/app.py
+++ b/jukebox/admin/app.py
@@ -1,6 +1,6 @@
 import sys
 import traceback
-from typing import Annotated, Optional
+from typing import Annotated
 
 import typer
 from pydantic import ValidationError
@@ -48,7 +48,7 @@ from .sonos_households import GroupedSonosHousehold
 
 
 class AdminCliState:
-    def __init__(self, library: Optional[str], verbose: bool):
+    def __init__(self, library: str | None, verbose: bool):
         self.library = library
         self.verbose = verbose
 
@@ -174,7 +174,7 @@ def _exit_on_command_validation_error(err: ValidationError) -> None:
     raise SystemExit(str(err)) from err
 
 
-def _prompt_for_sonos_speaker_selection(speakers: list[DiscoveredSonosSpeaker]) -> Optional[list[str]]:
+def _prompt_for_sonos_speaker_selection(speakers: list[DiscoveredSonosSpeaker]) -> list[str] | None:
     import questionary
 
     try:
@@ -192,7 +192,7 @@ def _prompt_for_sonos_speaker_selection(speakers: list[DiscoveredSonosSpeaker]) 
         return None
 
 
-def _prompt_for_sonos_household_selection(households: list[GroupedSonosHousehold]) -> Optional[str]:
+def _prompt_for_sonos_household_selection(households: list[GroupedSonosHousehold]) -> str | None:
     import questionary
 
     try:
@@ -211,7 +211,7 @@ def _prompt_for_sonos_household_selection(households: list[GroupedSonosHousehold
         return None
 
 
-def _prompt_for_pn532_profile(profiles: list[str]) -> Optional[str]:
+def _prompt_for_pn532_profile(profiles: list[str]) -> str | None:
     import questionary
 
     try:
@@ -220,7 +220,7 @@ def _prompt_for_pn532_profile(profiles: list[str]) -> Optional[str]:
         return None
 
 
-def _prompt_for_pn532_protocol(protocols: list[str], default: str) -> Optional[str]:
+def _prompt_for_pn532_protocol(protocols: list[str], default: str) -> str | None:
     import questionary
 
     try:
@@ -230,7 +230,7 @@ def _prompt_for_pn532_protocol(protocols: list[str], default: str) -> Optional[s
         return None
 
 
-def _prompt_for_pn532_pin(pin_name: str, default: Optional[int]) -> Optional[str]:
+def _prompt_for_pn532_pin(pin_name: str, default: int | None) -> str | None:
     import questionary
 
     default_str = str(default) if default is not None else ""
@@ -243,7 +243,7 @@ def _prompt_for_pn532_pin(pin_name: str, default: Optional[int]) -> Optional[str
         return None
 
 
-def _prompt_for_sonos_group_coordinator(speakers: list[DiscoveredSonosSpeaker]) -> Optional[str]:
+def _prompt_for_sonos_group_coordinator(speakers: list[DiscoveredSonosSpeaker]) -> str | None:
     import questionary
 
     try:
@@ -282,7 +282,7 @@ app.add_typer(pn532_app, name="pn532")
 def main_callback(
     ctx: typer.Context,
     library: Annotated[
-        Optional[str],
+        str | None,
         typer.Option("--library", "-l", help="override the library JSON path for this process"),
     ] = None,
     verbose: Annotated[
@@ -363,7 +363,7 @@ def settings_reset(
 def api(
     ctx: typer.Context,
     port: Annotated[
-        Optional[int],
+        int | None,
         typer.Option("--port", help="override the configured API port"),
     ] = None,
 ) -> None:
@@ -374,7 +374,7 @@ def api(
 def ui(
     ctx: typer.Context,
     port: Annotated[
-        Optional[int],
+        int | None,
         typer.Option("--port", help="override the configured UI port"),
     ] = None,
 ) -> None:
@@ -390,7 +390,7 @@ def sonos_list(ctx: typer.Context) -> None:
 def sonos_select(
     ctx: typer.Context,
     uids: Annotated[
-        Optional[list[str]],
+        list[str] | None,
         typer.Option(
             "--uids",
             help=(
@@ -400,11 +400,11 @@ def sonos_select(
         ),
     ] = None,
     coordinator: Annotated[
-        Optional[str],
+        str | None,
         typer.Option("--coordinator", help="coordinator UID for the selected Sonos group"),
     ] = None,
     household: Annotated[
-        Optional[str],
+        str | None,
         typer.Option("--household", help="household ID to use for interactive Sonos speaker selection"),
     ] = None,
 ) -> None:
@@ -439,7 +439,7 @@ def pn532_profiles(ctx: typer.Context) -> None:
 def pn532_select(
     ctx: typer.Context,
     profile: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "--profile",
             help="board profile to persist (waveshare_hat, hiletgo_v3, custom)",
@@ -460,10 +460,10 @@ def pn532_probe(ctx: typer.Context) -> None:
 def library_add(
     ctx: typer.Context,
     uri: Annotated[str, typer.Option("--uri", help="Path or URI of the media file")],
-    tag: Annotated[Optional[str], typer.Argument(help="Tag to be associated with the disc")] = None,
-    track: Annotated[Optional[str], typer.Option("--track", help="Name of the track")] = None,
-    artist: Annotated[Optional[str], typer.Option("--artist", help="Name of the artist or band")] = None,
-    album: Annotated[Optional[str], typer.Option("--album", help="Name of the album")] = None,
+    tag: Annotated[str | None, typer.Argument(help="Tag to be associated with the disc")] = None,
+    track: Annotated[str | None, typer.Option("--track", help="Name of the track")] = None,
+    artist: Annotated[str | None, typer.Option("--artist", help="Name of the artist or band")] = None,
+    album: Annotated[str | None, typer.Option("--album", help="Name of the album")] = None,
     use_current_tag: Annotated[
         bool,
         typer.Option("--from-current", help="Resolve the tag ID from shared current-tag.txt state"),
@@ -496,7 +496,7 @@ def library_list(
 @library_app.command("remove")
 def library_remove(
     ctx: typer.Context,
-    tag: Annotated[Optional[str], typer.Argument(help="Tag to remove")] = None,
+    tag: Annotated[str | None, typer.Argument(help="Tag to remove")] = None,
     use_current_tag: Annotated[
         bool,
         typer.Option("--from-current", help="Resolve the tag ID from shared current-tag.txt state"),
@@ -513,11 +513,11 @@ def library_remove(
 @library_app.command("edit")
 def library_edit(
     ctx: typer.Context,
-    tag: Annotated[Optional[str], typer.Argument(help="Tag to be edited")] = None,
-    uri: Annotated[Optional[str], typer.Option("--uri", help="Path or URI of the media file")] = None,
-    track: Annotated[Optional[str], typer.Option("--track", help="Name of the track")] = None,
-    artist: Annotated[Optional[str], typer.Option("--artist", help="Name of the artist or band")] = None,
-    album: Annotated[Optional[str], typer.Option("--album", help="Name of the album")] = None,
+    tag: Annotated[str | None, typer.Argument(help="Tag to be edited")] = None,
+    uri: Annotated[str | None, typer.Option("--uri", help="Path or URI of the media file")] = None,
+    track: Annotated[str | None, typer.Option("--track", help="Name of the track")] = None,
+    artist: Annotated[str | None, typer.Option("--artist", help="Name of the artist or band")] = None,
+    album: Annotated[str | None, typer.Option("--album", help="Name of the album")] = None,
     use_current_tag: Annotated[
         bool,
         typer.Option("--from-current", help="Resolve the tag ID from shared current-tag.txt state"),
@@ -542,7 +542,7 @@ def library_edit(
 @library_app.command("get")
 def library_get(
     ctx: typer.Context,
-    tag: Annotated[Optional[str], typer.Argument(help="Tag to retrieve")] = None,
+    tag: Annotated[str | None, typer.Argument(help="Tag to retrieve")] = None,
     use_current_tag: Annotated[
         bool,
         typer.Option("--from-current", help="Resolve the tag ID from shared current-tag.txt state"),
@@ -569,5 +569,5 @@ def library_interactive(ctx: typer.Context) -> None:
     _run_library_command(ctx, InteractiveCliCommand(type="interactive"))
 
 
-def main(args: Optional[list[str]] = None) -> None:
+def main(args: list[str] | None = None) -> None:
     app(args=args, prog_name="jukebox-admin")

--- a/jukebox/admin/cli_presentation.py
+++ b/jukebox/admin/cli_presentation.py
@@ -318,19 +318,21 @@ def _format_entry_label(dotted_path: str) -> str:
 def _format_value(dotted_path: str, value: object) -> str:
     if dotted_path == "jukebox.player.sonos.selected_group":
         return _format_selected_group(value)
-    if value is None:
-        return "null"
-    if isinstance(value, bool):
-        return "true" if value else "false"
-    if isinstance(value, (int, float)):
-        return str(value)
-    if isinstance(value, str):
-        return value
-    if isinstance(value, list):
-        return ", ".join(_format_value(dotted_path, item) for item in value)
-    if isinstance(value, dict):
-        return json.dumps(value, sort_keys=True, separators=(", ", ": "))
-    return str(value)
+    match value:
+        case None:
+            return "null"
+        case bool():
+            return "true" if value else "false"
+        case int() | float():
+            return str(value)
+        case str():
+            return value
+        case list():
+            return ", ".join(_format_value(dotted_path, item) for item in value)
+        case dict():
+            return json.dumps(value, sort_keys=True, separators=(", ", ": "))
+        case _:
+            return str(value)
 
 
 def _format_selected_group(value: object) -> str:
@@ -363,25 +365,22 @@ def _format_selected_group(value: object) -> str:
 
 
 def _render_cli_error_message(err: BaseException) -> str:
-    if isinstance(err, MalformedSettingsFileError):
-        filepath = _extract_quoted_path(str(err))
-        if filepath is not None:
-            return f"Malformed settings file at '{filepath}'. Fix the JSON syntax and try again."
-        return "Malformed settings file. Fix the JSON syntax and try again."
-
-    if isinstance(err, UnsupportedSettingsVersionError):
-        return f"Unsupported settings file version. {str(err)}"
-
-    if isinstance(err, InvalidSettingsError):
-        return _render_invalid_settings_error(err)
-
-    if isinstance(err, SettingsError):
-        return str(err)
-
-    if isinstance(err, SystemExit) and isinstance(err.code, str):
-        return _render_system_exit_message(err.code)
-
-    return "Unexpected error. Re-run with `--verbose` for details."
+    match err:
+        case MalformedSettingsFileError():
+            filepath = _extract_quoted_path(str(err))
+            if filepath is not None:
+                return f"Malformed settings file at '{filepath}'. Fix the JSON syntax and try again."
+            return "Malformed settings file. Fix the JSON syntax and try again."
+        case UnsupportedSettingsVersionError():
+            return f"Unsupported settings file version. {str(err)}"
+        case InvalidSettingsError():
+            return _render_invalid_settings_error(err)
+        case SettingsError():
+            return str(err)
+        case SystemExit() if isinstance(err.code, str):
+            return _render_system_exit_message(err.code)
+        case _:
+            return "Unexpected error. Re-run with `--verbose` for details."
 
 
 def _render_invalid_settings_error(err: InvalidSettingsError) -> str:

--- a/jukebox/admin/cli_presentation.py
+++ b/jukebox/admin/cli_presentation.py
@@ -252,8 +252,7 @@ def _collect_persisted_entries(node: JsonObject, prefix: str | None = None) -> I
 
         dotted_path = f"{prefix}.{key}" if prefix else key
         if isinstance(value, dict) and not is_editable_setting_path(dotted_path):
-            for child_entry in _collect_persisted_entries(value, dotted_path):
-                yield child_entry
+            yield from _collect_persisted_entries(value, dotted_path)
             continue
 
         yield dotted_path, value
@@ -263,8 +262,7 @@ def _collect_generic_entries(node: JsonObject, prefix: str) -> Iterable[tuple[st
     for key, value in sorted(node.items()):
         dotted_path = f"{prefix}.{key}"
         if isinstance(value, dict):
-            for child_entry in _collect_generic_entries(value, dotted_path):
-                yield child_entry
+            yield from _collect_generic_entries(value, dotted_path)
             continue
         yield dotted_path, value
 
@@ -273,8 +271,7 @@ def _collect_leaf_entries(node: JsonObject, prefix: str | None = None) -> Iterab
     for key, value in sorted(node.items()):
         dotted_path = f"{prefix}.{key}" if prefix else key
         if isinstance(value, dict) and not is_editable_setting_path(dotted_path):
-            for child_entry in _collect_leaf_entries(value, dotted_path):
-                yield child_entry
+            yield from _collect_leaf_entries(value, dotted_path)
             continue
         yield dotted_path, value
 

--- a/jukebox/admin/cli_presentation.py
+++ b/jukebox/admin/cli_presentation.py
@@ -1,6 +1,7 @@
 import json
 import re
-from typing import Dict, Iterable, List, Mapping, Optional, Tuple, cast
+from collections.abc import Iterable, Mapping
+from typing import cast
 
 from jukebox.settings.definitions import SETTINGS, get_setting_definition, is_editable_setting_path
 from jukebox.settings.errors import (
@@ -244,7 +245,7 @@ def _format_effective_suffix(provenance: str, requires_restart: bool) -> str:
     return f" ({'; '.join(suffix_parts)})"
 
 
-def _collect_persisted_entries(node: JsonObject, prefix: Optional[str] = None) -> Iterable[Tuple[str, JsonValue]]:
+def _collect_persisted_entries(node: JsonObject, prefix: str | None = None) -> Iterable[tuple[str, JsonValue]]:
     for key, value in sorted(node.items()):
         if key == "schema_version":
             continue
@@ -258,7 +259,7 @@ def _collect_persisted_entries(node: JsonObject, prefix: Optional[str] = None) -
         yield dotted_path, value
 
 
-def _collect_generic_entries(node: JsonObject, prefix: str) -> Iterable[Tuple[str, JsonValue]]:
+def _collect_generic_entries(node: JsonObject, prefix: str) -> Iterable[tuple[str, JsonValue]]:
     for key, value in sorted(node.items()):
         dotted_path = f"{prefix}.{key}"
         if isinstance(value, dict):
@@ -268,7 +269,7 @@ def _collect_generic_entries(node: JsonObject, prefix: str) -> Iterable[Tuple[st
         yield dotted_path, value
 
 
-def _collect_leaf_entries(node: JsonObject, prefix: Optional[str] = None) -> Iterable[Tuple[str, JsonValue]]:
+def _collect_leaf_entries(node: JsonObject, prefix: str | None = None) -> Iterable[tuple[str, JsonValue]]:
     for key, value in sorted(node.items()):
         dotted_path = f"{prefix}.{key}" if prefix else key
         if isinstance(value, dict) and not is_editable_setting_path(dotted_path):
@@ -278,7 +279,7 @@ def _collect_leaf_entries(node: JsonObject, prefix: Optional[str] = None) -> Ite
         yield dotted_path, value
 
 
-def _group_entries_by_section(entries: Iterable[Tuple[str, JsonValue]]) -> Dict[str, List[Tuple[str, JsonValue]]]:
+def _group_entries_by_section(entries: Iterable[tuple[str, JsonValue]]) -> dict[str, list[tuple[str, JsonValue]]]:
     grouped_entries = {}
     for dotted_path, value in entries:
         section = _section_for_path(dotted_path)
@@ -341,7 +342,7 @@ def _format_selected_group(value: object) -> str:
     if not isinstance(value, dict):
         return str(value)
 
-    selected_group = cast(Dict[str, object], value)
+    selected_group = cast(dict[str, object], value)
     household_id = selected_group.get("household_id")
     members = selected_group.get("members")
     coordinator_uid = selected_group.get("coordinator_uid")
@@ -352,7 +353,7 @@ def _format_selected_group(value: object) -> str:
     for member in members:
         if not isinstance(member, dict):
             continue
-        selected_member = cast(Dict[str, object], member)
+        selected_member = cast(dict[str, object], member)
         uid = selected_member.get("uid")
         if not isinstance(uid, str):
             continue
@@ -470,7 +471,7 @@ def _extract_compact_detail(message: str) -> str:
     return detail_lines[-1]
 
 
-def _extract_quoted_path(message: str) -> Optional[str]:
+def _extract_quoted_path(message: str) -> str | None:
     match = re.search(r"'([^']+)'", message)
     if match is None:
         return None

--- a/jukebox/admin/command_handlers.py
+++ b/jukebox/admin/command_handlers.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable
 from importlib import import_module
-from typing import Callable, Optional, Protocol
+from typing import Protocol
 
 from jukebox.settings.selected_sonos_group_repository import SettingsSelectedSonosGroupRepository
 from jukebox.settings.service_protocols import SettingsService
@@ -97,12 +98,12 @@ def execute_settings_command(
 def execute_sonos_command(
     command: object,
     sonos_service: SonosService,
-    settings_service: Optional[SettingsService] = None,
-    household_prompt_fn: Optional[Callable[[list[GroupedSonosHousehold]], Optional[str]]] = None,
-    speaker_prompt_fn: Optional[Callable[[list[DiscoveredSonosSpeaker]], Optional[list[str]]]] = None,
-    coordinator_prompt_fn: Optional[Callable[[list[DiscoveredSonosSpeaker]], Optional[str]]] = None,
+    settings_service: SettingsService | None = None,
+    household_prompt_fn: Callable[[list[GroupedSonosHousehold]], str | None] | None = None,
+    speaker_prompt_fn: Callable[[list[DiscoveredSonosSpeaker]], list[str] | None] | None = None,
+    coordinator_prompt_fn: Callable[[list[DiscoveredSonosSpeaker]], str | None] | None = None,
     stdout_fn: Callable[[str], None] = print,
-    status_fn: Optional[Callable[[str], None]] = None,
+    status_fn: Callable[[str], None] | None = None,
 ) -> None:
     if isinstance(command, SonosListCommand):
         _emit_status(status_fn, "Discovering Sonos speakers...")
@@ -181,16 +182,16 @@ def execute_sonos_command(
     raise TypeError("Unsupported Sonos command")
 
 
-def _emit_status(status_fn: Optional[Callable[[str], None]], message: str) -> None:
+def _emit_status(status_fn: Callable[[str], None] | None, message: str) -> None:
     if status_fn is not None:
         status_fn(message)
 
 
 def _select_available_household(
     households: list[GroupedSonosHousehold],
-    requested_household_id: Optional[str],
-    household_prompt_fn: Optional[Callable[[list[GroupedSonosHousehold]], Optional[str]]],
-) -> Optional[GroupedSonosHousehold]:
+    requested_household_id: str | None,
+    household_prompt_fn: Callable[[list[GroupedSonosHousehold]], str | None] | None,
+) -> GroupedSonosHousehold | None:
     if requested_household_id is not None:
         return _get_available_household(households, requested_household_id)
 

--- a/jukebox/admin/commands.py
+++ b/jukebox/admin/commands.py
@@ -1,16 +1,16 @@
-from typing import Literal, Optional, Union
+from typing import Literal, Union
 
 from pydantic import BaseModel, model_validator
 
 
 class ApiCommand(BaseModel):
     type: Literal["api"]
-    port: Optional[int] = None
+    port: int | None = None
 
 
 class UiCommand(BaseModel):
     type: Literal["ui"]
-    port: Optional[int] = None
+    port: int | None = None
 
 
 class SonosListCommand(BaseModel):
@@ -19,9 +19,9 @@ class SonosListCommand(BaseModel):
 
 class SonosSelectCommand(BaseModel):
     type: Literal["sonos_select"]
-    uids: Optional[list[str]] = None
-    coordinator: Optional[str] = None
-    household: Optional[str] = None
+    uids: list[str] | None = None
+    coordinator: str | None = None
+    household: str | None = None
 
     @model_validator(mode="after")
     def validate_coordinator_requires_uids(self):

--- a/jukebox/admin/commands.py
+++ b/jukebox/admin/commands.py
@@ -1,4 +1,4 @@
-from typing import Literal, Union
+from typing import Literal
 
 from pydantic import BaseModel, model_validator
 
@@ -53,16 +53,16 @@ class SettingsResetCommand(BaseModel):
     json_output: bool = False
 
 
-AdminCommand = Union[
-    ApiCommand,
-    SettingsResetCommand,
-    SettingsSetCommand,
-    SettingsShowCommand,
-    SonosListCommand,
-    SonosSelectCommand,
-    SonosShowCommand,
-    UiCommand,
-]
+AdminCommand = (
+    ApiCommand
+    | SettingsResetCommand
+    | SettingsSetCommand
+    | SettingsShowCommand
+    | SonosListCommand
+    | SonosSelectCommand
+    | SonosShowCommand
+    | UiCommand
+)
 
 
 def is_admin_command(command: object) -> bool:

--- a/jukebox/admin/commands.py
+++ b/jukebox/admin/commands.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, Self, TypeAlias
 
 from pydantic import BaseModel, model_validator
 
@@ -24,7 +24,7 @@ class SonosSelectCommand(BaseModel):
     household: str | None = None
 
     @model_validator(mode="after")
-    def validate_coordinator_requires_uids(self):
+    def validate_coordinator_requires_uids(self) -> Self:
         if self.coordinator is not None and not self.uids:
             raise ValueError("--coordinator requires --uids")
         return self
@@ -53,7 +53,7 @@ class SettingsResetCommand(BaseModel):
     json_output: bool = False
 
 
-AdminCommand = (
+AdminCommand: TypeAlias = (
     ApiCommand
     | SettingsResetCommand
     | SettingsSetCommand

--- a/jukebox/admin/di_container.py
+++ b/jukebox/admin/di_container.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from discstore.adapters.outbound.json_library_adapter import JsonLibraryAdapter
 from discstore.adapters.outbound.text_current_tag_adapter import TextCurrentTagAdapter
 from discstore.domain.use_cases.add_disc import AddDisc
@@ -21,8 +19,8 @@ from .services import AdminServices
 
 
 def build_settings_service(
-    library: Optional[str],
-    command: Optional[object],
+    library: str | None,
+    command: object | None,
 ) -> SettingsService:
     cli_overrides = {}
 
@@ -43,8 +41,8 @@ def build_settings_service(
 
 
 def build_admin_services(
-    library: Optional[str],
-    command: Optional[object],
+    library: str | None,
+    command: object | None,
 ) -> AdminServices:
     sonos_service = build_sonos_service()
     settings_service = build_settings_service(

--- a/jukebox/admin/pn532_command_handlers.py
+++ b/jukebox/admin/pn532_command_handlers.py
@@ -1,5 +1,6 @@
 import dataclasses
-from typing import Any, Callable, Optional, cast
+from collections.abc import Callable
+from typing import Any, cast
 
 from jukebox.pn532.profiles import (
     PN532_PROFILES,
@@ -33,7 +34,7 @@ def _default_build_pn532_reader(
     raise ValueError(f"Unsupported PN532 protocol: {protocol}")
 
 
-def _parse_pin(raw: Optional[str]) -> "tuple[bool, Optional[str]]":
+def _parse_pin(raw: str | None) -> "tuple[bool, str | None]":
     """Returns (ok, value). ok=False means the user cancelled the prompt.
     value=None means blank input (reset to profile default)."""
     if raw is None:
@@ -45,9 +46,9 @@ def _parse_pin(raw: Optional[str]) -> "tuple[bool, Optional[str]]":
 def execute_pn532_command(
     command: object,
     settings_service: SettingsService,
-    profile_prompt_fn: Optional[Callable[[list], Optional[str]]] = None,
-    protocol_prompt_fn: Optional[Callable[[list, str], Optional[str]]] = None,
-    pin_prompt_fn: Optional[Callable[[str, Optional[int]], Optional[str]]] = None,
+    profile_prompt_fn: Callable[[list], str | None] | None = None,
+    protocol_prompt_fn: Callable[[list, str], str | None] | None = None,
+    pin_prompt_fn: Callable[[str, int | None], str | None] | None = None,
     build_pn532_reader: Callable[..., Any] = _default_build_pn532_reader,
     stdout_fn: Callable[[str], None] = print,
 ) -> None:
@@ -87,7 +88,7 @@ def execute_pn532_command(
             )
 
         if pin_prompt_fn is not None:
-            field_values: dict[str, Optional[str]] = {}
+            field_values: dict[str, str | None] = {}
             for f in dataclasses.fields(pin_defaults):
                 default = getattr(pin_defaults, f.name)
                 raw = pin_prompt_fn(f.name, default)
@@ -207,7 +208,7 @@ def render_pn532_configure_output(
     profile: str,
     protocol: str,
     connection: Pn532ConnectionParams,
-    field_values: dict[str, Optional[str]],
+    field_values: dict[str, str | None],
 ) -> str:
     fields = "  ".join(
         f"{f.name}={field_values[f.name] if field_values[f.name] is not None else '-'}"

--- a/jukebox/admin/pn532_commands.py
+++ b/jukebox/admin/pn532_commands.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional
+from typing import Literal
 
 from pydantic import BaseModel
 
@@ -9,7 +9,7 @@ class Pn532ProfilesCommand(BaseModel):
 
 class Pn532SelectCommand(BaseModel):
     type: Literal["pn532_select"]
-    profile: Optional[str] = None
+    profile: str | None = None
 
 
 class Pn532ProbeCommand(BaseModel):

--- a/jukebox/di_container.py
+++ b/jukebox/di_container.py
@@ -16,33 +16,35 @@ def build_jukebox(config: ResolvedJukeboxRuntimeConfig):
     library = JsonLibraryAdapter(config.library_path)
     current_tag_repository = TextCurrentTagAdapter(get_current_tag_path(config.library_path))
 
-    if config.player_type == "sonos":
-        player = SonosPlayerAdapter(host=config.sonos_host, name=config.sonos_name, group=config.sonos_group)
-    elif config.player_type == "dryrun":
-        player = DryrunPlayerAdapter()
-    else:
-        raise ValueError(f"Unknown player type: {config.player_type}")
+    match config.player_type:
+        case "sonos":
+            player = SonosPlayerAdapter(host=config.sonos_host, name=config.sonos_name, group=config.sonos_group)
+        case "dryrun":
+            player = DryrunPlayerAdapter()
+        case _:
+            raise ValueError(f"Unknown player type: {config.player_type}")
 
-    if config.reader_type == "pn532":
-        from jukebox.adapters.outbound.readers.pn532_reader_adapter import Pn532ReaderAdapter
-        from jukebox.pn532.profiles import SpiConnectionParams
+    match config.reader_type:
+        case "pn532":
+            from jukebox.adapters.outbound.readers.pn532_reader_adapter import Pn532ReaderAdapter
+            from jukebox.pn532.profiles import SpiConnectionParams
 
-        if config.pn532_protocol == "spi":
-            conn = config.pn532_connection
-            if not isinstance(conn, SpiConnectionParams):
-                raise ValueError(f"Expected SpiConnectionParams for protocol 'spi', got {type(conn).__name__}")
-            reader = Pn532ReaderAdapter(
-                read_timeout_seconds=config.pn532_read_timeout_seconds,
-                spi_reset=conn.reset,
-                spi_cs=conn.cs,
-                spi_irq=conn.irq,
-            )
-        else:
-            raise ValueError(f"Unsupported PN532 protocol: {config.pn532_protocol}")
-    elif config.reader_type == "dryrun":
-        reader = DryrunReaderAdapter()
-    else:
-        raise ValueError(f"Unknown reader type: {config.reader_type}")
+            match config.pn532_protocol, config.pn532_connection:
+                case "spi", conn if isinstance(conn, SpiConnectionParams):
+                    reader = Pn532ReaderAdapter(
+                        read_timeout_seconds=config.pn532_read_timeout_seconds,
+                        spi_reset=conn.reset,
+                        spi_cs=conn.cs,
+                        spi_irq=conn.irq,
+                    )
+                case "spi", conn:
+                    raise ValueError(f"Expected SpiConnectionParams for protocol 'spi', got {type(conn).__name__}")
+                case _:
+                    raise ValueError(f"Unsupported PN532 protocol: {config.pn532_protocol}")
+        case "dryrun":
+            reader = DryrunReaderAdapter()
+        case _:
+            raise ValueError(f"Unknown reader type: {config.reader_type}")
 
     determine_action = DetermineAction(
         pause_delay=config.pause_delay_seconds,

--- a/jukebox/domain/entities/current_tag_action.py
+++ b/jukebox/domain/entities/current_tag_action.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from enum import StrEnum
 
 
-class CurrentTagAction(str, Enum):
+class CurrentTagAction(StrEnum):
     """Actions that can be taken on the physical current tag state."""
 
     SET = "set"

--- a/jukebox/domain/entities/disc.py
+++ b/jukebox/domain/entities/disc.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from pydantic import BaseModel, Field
 
 
@@ -13,10 +11,10 @@ class DiscOption(BaseModel):
 class DiscMetadata(BaseModel):
     """Metadata information for a disc."""
 
-    artist: Optional[str] = Field(default=None, description="Name of the artist or band", examples=["Zubi", None])
-    album: Optional[str] = Field(default=None, description="Name of the album", examples=["Dear Z", None])
-    track: Optional[str] = Field(default=None, description="Name of the track", examples=["dey ok", None])
-    playlist: Optional[str] = Field(default=None, description="Name of the playlist", examples=["dey ok", None])
+    artist: str | None = Field(default=None, description="Name of the artist or band", examples=["Zubi", None])
+    album: str | None = Field(default=None, description="Name of the album", examples=["Dear Z", None])
+    track: str | None = Field(default=None, description="Name of the track", examples=["dey ok", None])
+    playlist: str | None = Field(default=None, description="Name of the playlist", examples=["dey ok", None])
 
 
 class Disc(BaseModel):

--- a/jukebox/domain/entities/library.py
+++ b/jukebox/domain/entities/library.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from pydantic import BaseModel, ConfigDict, Field
 
 from jukebox.domain.entities import Disc
@@ -9,4 +7,4 @@ class Library(BaseModel):
     """A library containing a collection of discs indexed by tag ID."""
 
     model_config = ConfigDict(strict=True)
-    discs: Dict[str, Disc] = Field(default={}, description="Correspondences between tags and discs")
+    discs: dict[str, Disc] = Field(default={}, description="Correspondences between tags and discs")

--- a/jukebox/domain/entities/playback_action.py
+++ b/jukebox/domain/entities/playback_action.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from enum import StrEnum
 
 
-class PlaybackAction(str, Enum):
+class PlaybackAction(StrEnum):
     """Actions that can be performed during playback."""
 
     CONTINUE = "continue"

--- a/jukebox/domain/entities/playback_session.py
+++ b/jukebox/domain/entities/playback_session.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from pydantic import BaseModel
 
 
@@ -7,13 +5,13 @@ class PlaybackSession(BaseModel):
     """Tracks the current logical playback and physical reader states."""
 
     # Logical playback state
-    playing_tag: Optional[str] = None
-    paused_at: Optional[float] = None
-    playing_tag_removed_at: Optional[float] = None
+    playing_tag: str | None = None
+    paused_at: float | None = None
+    playing_tag_removed_at: float | None = None
 
     # Physical reader state
-    physical_tag: Optional[str] = None
-    physical_tag_removed_at: Optional[float] = None
+    physical_tag: str | None = None
+    physical_tag_removed_at: float | None = None
 
     # Timestamp
-    last_event_timestamp: Optional[float] = None
+    last_event_timestamp: float | None = None

--- a/jukebox/domain/entities/tag_event.py
+++ b/jukebox/domain/entities/tag_event.py
@@ -1,10 +1,8 @@
-from typing import Optional
-
 from pydantic import BaseModel
 
 
 class TagEvent(BaseModel):
     """Represents a tag detection event from the reader."""
 
-    tag_id: Optional[str]  # None if no tag detected
+    tag_id: str | None  # None if no tag detected
     timestamp: float

--- a/jukebox/domain/ports/reader_port.py
+++ b/jukebox/domain/ports/reader_port.py
@@ -1,11 +1,10 @@
 from abc import ABC, abstractmethod
-from typing import Optional
 
 
 class ReaderPort(ABC):
     """Port for tag reader implementations."""
 
     @abstractmethod
-    def read(self) -> Optional[str]:
+    def read(self) -> str | None:
         """Read a tag ID. Returns None if no tag detected."""
         pass

--- a/jukebox/domain/repositories/current_tag_repository.py
+++ b/jukebox/domain/repositories/current_tag_repository.py
@@ -1,10 +1,9 @@
 from abc import ABC, abstractmethod
-from typing import Optional
 
 
 class CurrentTagRepository(ABC):
     @abstractmethod
-    def get(self) -> Optional[str]:
+    def get(self) -> str | None:
         pass
 
     @abstractmethod

--- a/jukebox/domain/repositories/library_repository.py
+++ b/jukebox/domain/repositories/library_repository.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import Optional
 
 from jukebox.domain.entities import Disc
 
@@ -10,7 +9,7 @@ class LibraryRepository(ABC):
         pass
 
     @abstractmethod
-    def get_disc(self, tag_id: str) -> Optional[Disc]:
+    def get_disc(self, tag_id: str) -> Disc | None:
         pass
 
     @abstractmethod

--- a/jukebox/domain/use_cases/handle_tag_event.py
+++ b/jukebox/domain/use_cases/handle_tag_event.py
@@ -41,56 +41,57 @@ class HandleTagEvent:
             session.playing_tag_removed_at,
         )
 
-        if action == PlaybackAction.CONTINUE:
-            # Reset when tag is present
-            session.playing_tag_removed_at = None
+        match action:
+            case PlaybackAction.CONTINUE:
+                # Reset when tag is present
+                session.playing_tag_removed_at = None
 
-        elif action == PlaybackAction.RESUME:
-            with suppress_playback_error("Playback operation `RESUME` failed; stopping session update"):
-                self.player.resume()
+            case PlaybackAction.RESUME:
+                with suppress_playback_error("Playback operation `RESUME` failed; stopping session update"):
+                    self.player.resume()
+                    session.paused_at = None
+                    session.playing_tag_removed_at = None
+
+            case PlaybackAction.PLAY:
+                LOGGER.info("Found card with UID: %s", tag_event.tag_id)
+
+                disc = self.library.get_disc(tag_event.tag_id) if tag_event.tag_id is not None else None
+                if disc is not None:
+                    LOGGER.info("Found corresponding disc: %s", disc)
+                    with suppress_playback_error(
+                        f"Playback operation `PLAY` failed for tag_id='{tag_event.tag_id}'; stopping session update"
+                    ):
+                        self.player.play(disc.uri, disc.option.shuffle)
+                        session.playing_tag = tag_event.tag_id
+                        session.paused_at = None
+                        session.playing_tag_removed_at = None
+                else:
+                    LOGGER.warning("No disc found for UID: %s", tag_event.tag_id)
+
+            case PlaybackAction.WAITING:
+                # Grace period - tag removed but not pausing yet
+                if session.playing_tag_removed_at is None:
+                    session.playing_tag_removed_at = tag_event.timestamp
+                grace_period_elapsed = tag_event.timestamp - session.playing_tag_removed_at
+                LOGGER.debug("Grace period: %.3fs / %gs", grace_period_elapsed, self.determine_action.pause_delay)
+
+            case PlaybackAction.PAUSE:
+                with suppress_playback_error("Playback operation `PAUSE` failed; continuing session update"):
+                    self.player.pause()
+                session.paused_at = tag_event.timestamp
+
+            case PlaybackAction.STOP:
+                with suppress_playback_error("Playback operation `STOP` failed; continuing session update"):
+                    self.player.stop()
+                session.playing_tag = None
                 session.paused_at = None
                 session.playing_tag_removed_at = None
 
-        elif action == PlaybackAction.PLAY:
-            LOGGER.info("Found card with UID: %s", tag_event.tag_id)
+            case PlaybackAction.IDLE:
+                pass
 
-            disc = self.library.get_disc(tag_event.tag_id) if tag_event.tag_id is not None else None
-            if disc is not None:
-                LOGGER.info("Found corresponding disc: %s", disc)
-                with suppress_playback_error(
-                    f"Playback operation `PLAY` failed for tag_id='{tag_event.tag_id}'; stopping session update"
-                ):
-                    self.player.play(disc.uri, disc.option.shuffle)
-                    session.playing_tag = tag_event.tag_id
-                    session.paused_at = None
-                    session.playing_tag_removed_at = None
-            else:
-                LOGGER.warning("No disc found for UID: %s", tag_event.tag_id)
-
-        elif action == PlaybackAction.WAITING:
-            # Grace period - tag removed but not pausing yet
-            if session.playing_tag_removed_at is None:
-                session.playing_tag_removed_at = tag_event.timestamp
-            grace_period_elapsed = tag_event.timestamp - session.playing_tag_removed_at
-            LOGGER.debug("Grace period: %.3fs / %gs", grace_period_elapsed, self.determine_action.pause_delay)
-
-        elif action == PlaybackAction.PAUSE:
-            with suppress_playback_error("Playback operation `PAUSE` failed; continuing session update"):
-                self.player.pause()
-            session.paused_at = tag_event.timestamp
-
-        elif action == PlaybackAction.STOP:
-            with suppress_playback_error("Playback operation `STOP` failed; continuing session update"):
-                self.player.stop()
-            session.playing_tag = None
-            session.paused_at = None
-            session.playing_tag_removed_at = None
-
-        elif action == PlaybackAction.IDLE:
-            pass
-
-        else:
-            LOGGER.warning("`%s` action is not implemented yet", action.value)
+            case _:
+                LOGGER.warning("`%s` action is not implemented yet", action.value)
 
         session.last_event_timestamp = tag_event.timestamp
         return session
@@ -109,30 +110,31 @@ class HandleTagEvent:
     def _apply_current_tag_action(
         self, action: CurrentTagAction, tag_event: TagEvent, session: PlaybackSession
     ) -> None:
-        if action == CurrentTagAction.SET:
-            if tag_event.tag_id is None:
-                LOGGER.error(
-                    "`SET` action without tag_id",
-                    extra={"event": tag_event, "session": session},
-                )
-                return
-            self.current_tag_repository.set(tag_event.tag_id)
-            session.physical_tag = tag_event.tag_id
-            session.physical_tag_removed_at = None
+        match action:
+            case CurrentTagAction.SET:
+                if tag_event.tag_id is None:
+                    LOGGER.error(
+                        "`SET` action without tag_id",
+                        extra={"event": tag_event, "session": session},
+                    )
+                    return
+                self.current_tag_repository.set(tag_event.tag_id)
+                session.physical_tag = tag_event.tag_id
+                session.physical_tag_removed_at = None
 
-        elif action == CurrentTagAction.CLEAR:
-            self.current_tag_repository.clear()
-            session.physical_tag = None
-            session.physical_tag_removed_at = None
+            case CurrentTagAction.CLEAR:
+                self.current_tag_repository.clear()
+                session.physical_tag = None
+                session.physical_tag_removed_at = None
 
-        elif action == CurrentTagAction.RESTORE:
-            session.physical_tag_removed_at = None
+            case CurrentTagAction.RESTORE:
+                session.physical_tag_removed_at = None
 
-        elif action == CurrentTagAction.REMOVE:
-            session.physical_tag_removed_at = tag_event.timestamp
+            case CurrentTagAction.REMOVE:
+                session.physical_tag_removed_at = tag_event.timestamp
 
-        elif action == CurrentTagAction.KEEP:
-            pass  # No state changed
+            case CurrentTagAction.KEEP:
+                pass  # No state changed
 
 
 @contextmanager

--- a/jukebox/pn532/profiles.py
+++ b/jukebox/pn532/profiles.py
@@ -1,10 +1,10 @@
 import dataclasses
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, TypeAlias
 
-Pn532BoardProfile = Literal["waveshare_hat", "hiletgo_v3", "custom"]
+Pn532BoardProfile: TypeAlias = Literal["waveshare_hat", "hiletgo_v3", "custom"]
 
-Pn532Protocol = Literal["spi"]
+Pn532Protocol: TypeAlias = Literal["spi"]
 
 
 @dataclass(frozen=True)
@@ -14,9 +14,9 @@ class SpiConnectionParams:
     irq: int | None
 
 
-# Today SpiConnectionParams only; Union[SpiConnectionParams, UartConnectionParams, ...]
+# Today SpiConnectionParams only; SpiConnectionParams | UartConnectionParams, ...
 # will be introduced when additional protocols are added.
-Pn532ConnectionParams = SpiConnectionParams
+Pn532ConnectionParams: TypeAlias = SpiConnectionParams
 
 
 @dataclass(frozen=True)

--- a/jukebox/pn532/profiles.py
+++ b/jukebox/pn532/profiles.py
@@ -1,6 +1,6 @@
 import dataclasses
 from dataclasses import dataclass
-from typing import Literal, Optional
+from typing import Literal
 
 Pn532BoardProfile = Literal["waveshare_hat", "hiletgo_v3", "custom"]
 
@@ -9,9 +9,9 @@ Pn532Protocol = Literal["spi"]
 
 @dataclass(frozen=True)
 class SpiConnectionParams:
-    reset: Optional[int]
-    cs: Optional[int]
-    irq: Optional[int]
+    reset: int | None
+    cs: int | None
+    irq: int | None
 
 
 # Today SpiConnectionParams only; Union[SpiConnectionParams, UartConnectionParams, ...]

--- a/jukebox/settings/definitions.py
+++ b/jukebox/settings/definitions.py
@@ -1,5 +1,6 @@
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable, Optional, cast
+from typing import cast
 
 from .entities import AppSettings
 from .types import JsonObject
@@ -225,7 +226,7 @@ SETTINGS = {
 }
 
 
-def get_setting_definition(dotted_path: str) -> Optional[SettingDefinition]:
+def get_setting_definition(dotted_path: str) -> SettingDefinition | None:
     return SETTINGS.get(dotted_path)
 
 

--- a/jukebox/settings/entities.py
+++ b/jukebox/settings/entities.py
@@ -1,5 +1,5 @@
 import os
-from typing import Literal
+from typing import Literal, Self
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -28,7 +28,7 @@ class SelectedSonosGroupSettings(StrictModel):
     members: list[SelectedSonosSpeakerSettings]
 
     @model_validator(mode="after")
-    def validate_group_shape(self):
+    def validate_group_shape(self) -> Self:
         if not self.members:
             raise ValueError("selected_group must include at least one member")
 
@@ -51,7 +51,7 @@ class SonosPlayerSettings(PersistedSonosPlayerSettings):
     manual_name: str | None = None
 
     @model_validator(mode="after")
-    def validate_manual_target(self):
+    def validate_manual_target(self) -> Self:
         if self.manual_host and self.manual_name:
             raise ValueError("manual_host and manual_name are mutually exclusive")
         return self
@@ -232,7 +232,7 @@ class ResolvedSonosGroupRuntime(StrictModel):
     missing_member_uids: list[str] = Field(default_factory=list)
 
     @model_validator(mode="after")
-    def validate_group_shape(self):
+    def validate_group_shape(self) -> Self:
         if not self.members:
             raise ValueError("resolved Sonos group must include at least one member")
 
@@ -277,7 +277,7 @@ class ResolvedJukeboxRuntimeConfig(StrictModel):
     verbose: bool = False
 
     @model_validator(mode="after")
-    def validate_runtime_rules(self):
+    def validate_runtime_rules(self) -> Self:
         validate_resolved_jukebox_runtime_rules(self)
         return self
 

--- a/jukebox/settings/entities.py
+++ b/jukebox/settings/entities.py
@@ -1,5 +1,5 @@
 import os
-from typing import Literal, Optional
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -23,7 +23,7 @@ class SelectedSonosSpeakerSettings(StrictModel):
 
 
 class SelectedSonosGroupSettings(StrictModel):
-    household_id: Optional[str] = Field(default=None, exclude_if=lambda value: value is None)
+    household_id: str | None = Field(default=None, exclude_if=lambda value: value is None)
     coordinator_uid: str
     members: list[SelectedSonosSpeakerSettings]
 
@@ -43,12 +43,12 @@ class SelectedSonosGroupSettings(StrictModel):
 
 
 class PersistedSonosPlayerSettings(StrictModel):
-    selected_group: Optional[SelectedSonosGroupSettings] = None
+    selected_group: SelectedSonosGroupSettings | None = None
 
 
 class SonosPlayerSettings(PersistedSonosPlayerSettings):
-    manual_host: Optional[str] = None
-    manual_name: Optional[str] = None
+    manual_host: str | None = None
+    manual_name: str | None = None
 
     @model_validator(mode="after")
     def validate_manual_target(self):
@@ -67,9 +67,9 @@ class PlayerSettings(PersistedPlayerSettings):
 
 
 class Pn532SpiSettings(StrictModel):
-    reset: Optional[int] = Field(default=None, ge=0)
-    cs: Optional[int] = Field(default=None, ge=0)
-    irq: Optional[int] = Field(default=None, ge=0)
+    reset: int | None = Field(default=None, ge=0)
+    cs: int | None = Field(default=None, ge=0)
+    irq: int | None = Field(default=None, ge=0)
 
 
 class Pn532ReaderSettings(StrictModel):
@@ -129,93 +129,93 @@ class AppSettings(PersistedAppSettings):
 
 
 class SparseSelectedSonosSpeakerSettings(StrictModel):
-    uid: Optional[str] = None
+    uid: str | None = None
 
 
 class SparseSelectedSonosGroupSettings(StrictModel):
-    household_id: Optional[str] = None
-    coordinator_uid: Optional[str] = None
-    members: Optional[list[SparseSelectedSonosSpeakerSettings]] = None
+    household_id: str | None = None
+    coordinator_uid: str | None = None
+    members: list[SparseSelectedSonosSpeakerSettings] | None = None
 
 
 class SparsePersistedSonosPlayerSettings(StrictModel):
-    selected_group: Optional[SparseSelectedSonosGroupSettings] = None
+    selected_group: SparseSelectedSonosGroupSettings | None = None
 
 
 class SparseSonosPlayerSettings(SparsePersistedSonosPlayerSettings):
-    manual_host: Optional[str] = None
-    manual_name: Optional[str] = None
+    manual_host: str | None = None
+    manual_name: str | None = None
 
 
 class SparsePersistedPlayerSettings(StrictModel):
-    type: Optional[Literal["dryrun", "sonos"]] = None
-    sonos: Optional[SparsePersistedSonosPlayerSettings] = None
+    type: Literal["dryrun", "sonos"] | None = None
+    sonos: SparsePersistedSonosPlayerSettings | None = None
 
 
 class SparsePlayerSettings(SparsePersistedPlayerSettings):
-    sonos: Optional[SparseSonosPlayerSettings] = None
+    sonos: SparseSonosPlayerSettings | None = None
 
 
 class SparsePn532SpiSettings(StrictModel):
-    reset: Optional[int] = Field(default=None, ge=0)
-    cs: Optional[int] = Field(default=None, ge=0)
-    irq: Optional[int] = Field(default=None, ge=0)
+    reset: int | None = Field(default=None, ge=0)
+    cs: int | None = Field(default=None, ge=0)
+    irq: int | None = Field(default=None, ge=0)
 
 
 class SparsePn532ReaderSettings(StrictModel):
-    read_timeout_seconds: Optional[float] = None
-    board_profile: Optional[Literal["waveshare_hat", "hiletgo_v3", "custom"]] = None
-    protocol: Optional[Literal["spi"]] = None
-    spi: Optional[SparsePn532SpiSettings] = None
+    read_timeout_seconds: float | None = None
+    board_profile: Literal["waveshare_hat", "hiletgo_v3", "custom"] | None = None
+    protocol: Literal["spi"] | None = None
+    spi: SparsePn532SpiSettings | None = None
 
 
 class SparseReaderSettings(StrictModel):
-    type: Optional[Literal["dryrun", "pn532"]] = None
-    pn532: Optional[SparsePn532ReaderSettings] = None
+    type: Literal["dryrun", "pn532"] | None = None
+    pn532: SparsePn532ReaderSettings | None = None
 
 
 class SparsePlaybackSettings(StrictModel):
-    pause_duration_seconds: Optional[int] = None
-    pause_delay_seconds: Optional[float] = None
+    pause_duration_seconds: int | None = None
+    pause_delay_seconds: float | None = None
 
 
 class SparseRuntimeSettings(StrictModel):
-    loop_interval_seconds: Optional[float] = None
+    loop_interval_seconds: float | None = None
 
 
 class SparsePersistedJukeboxSettings(StrictModel):
-    player: Optional[SparsePersistedPlayerSettings] = None
-    reader: Optional[SparseReaderSettings] = None
-    playback: Optional[SparsePlaybackSettings] = None
-    runtime: Optional[SparseRuntimeSettings] = None
+    player: SparsePersistedPlayerSettings | None = None
+    reader: SparseReaderSettings | None = None
+    playback: SparsePlaybackSettings | None = None
+    runtime: SparseRuntimeSettings | None = None
 
 
 class SparseJukeboxSettings(SparsePersistedJukeboxSettings):
-    player: Optional[SparsePlayerSettings] = None
+    player: SparsePlayerSettings | None = None
 
 
 class SparseServerSettings(StrictModel):
-    port: Optional[int] = None
+    port: int | None = None
 
 
 class SparsePathsSettings(StrictModel):
-    library_path: Optional[str] = None
+    library_path: str | None = None
 
 
 class SparseAdminSettings(StrictModel):
-    api: Optional[SparseServerSettings] = None
-    ui: Optional[SparseServerSettings] = None
+    api: SparseServerSettings | None = None
+    ui: SparseServerSettings | None = None
 
 
 class SparsePersistedAppSettings(StrictModel):
     schema_version: int
-    paths: Optional[SparsePathsSettings] = None
-    jukebox: Optional[SparsePersistedJukeboxSettings] = None
-    admin: Optional[SparseAdminSettings] = None
+    paths: SparsePathsSettings | None = None
+    jukebox: SparsePersistedJukeboxSettings | None = None
+    admin: SparseAdminSettings | None = None
 
 
 class SparseAppSettings(SparsePersistedAppSettings):
-    jukebox: Optional[SparseJukeboxSettings] = None
+    jukebox: SparseJukeboxSettings | None = None
 
 
 class ResolvedSonosSpeakerRuntime(StrictModel):
@@ -263,9 +263,9 @@ class ResolvedSonosGroupRuntime(StrictModel):
 class ResolvedJukeboxRuntimeConfig(StrictModel):
     library_path: str
     player_type: Literal["dryrun", "sonos"]
-    sonos_host: Optional[str] = None
-    sonos_name: Optional[str] = None
-    sonos_group: Optional[ResolvedSonosGroupRuntime] = None
+    sonos_host: str | None = None
+    sonos_name: str | None = None
+    sonos_group: ResolvedSonosGroupRuntime | None = None
     reader_type: Literal["dryrun", "pn532"]
     pause_duration_seconds: int
     pause_delay_seconds: float

--- a/jukebox/settings/file_settings_repository.py
+++ b/jukebox/settings/file_settings_repository.py
@@ -2,7 +2,6 @@ import json
 import os
 import tempfile
 from contextlib import suppress
-from typing import Optional
 
 from pydantic import ValidationError
 
@@ -14,7 +13,7 @@ from .types import JsonObject
 
 
 class FileSettingsRepository:
-    def __init__(self, filepath: Optional[str] = None):
+    def __init__(self, filepath: str | None = None):
         if filepath is None:
             xdg_config_home = os.environ.get("XDG_CONFIG_HOME", "~/.config")
             self.filepath = os.path.expanduser(os.path.join(xdg_config_home, "jukebox/settings.json"))
@@ -26,7 +25,7 @@ class FileSettingsRepository:
             return {"schema_version": CURRENT_SETTINGS_SCHEMA_VERSION}
 
         try:
-            with open(self.filepath, "r", encoding="utf-8") as file_obj:
+            with open(self.filepath, encoding="utf-8") as file_obj:
                 raw_data = json.load(file_obj)
         except json.JSONDecodeError as err:
             raise MalformedSettingsFileError(f"Malformed settings file at '{self.filepath}': {err}") from err

--- a/jukebox/settings/migration.py
+++ b/jukebox/settings/migration.py
@@ -1,5 +1,4 @@
 import copy
-from typing import Tuple
 
 from .errors import InvalidSettingsError, UnsupportedSettingsVersionError
 from .types import JsonObject, JsonValue
@@ -7,7 +6,7 @@ from .types import JsonObject, JsonValue
 CURRENT_SETTINGS_SCHEMA_VERSION = 1
 
 
-def migrate_settings_data(data: JsonValue) -> Tuple[JsonObject, bool]:
+def migrate_settings_data(data: JsonValue) -> tuple[JsonObject, bool]:
     if not isinstance(data, dict):
         raise InvalidSettingsError("The settings file root must be a JSON object.")
 

--- a/jukebox/settings/resolve.py
+++ b/jukebox/settings/resolve.py
@@ -1,7 +1,7 @@
 import copy
 import json
 import os
-from typing import Optional, Union, cast
+from typing import cast
 
 from pydantic import ValidationError
 
@@ -52,8 +52,8 @@ class SettingsService:
     def __init__(
         self,
         repository: SettingsRepository,
-        env_overrides: Optional[JsonObject] = None,
-        cli_overrides: Optional[JsonObject] = None,
+        env_overrides: JsonObject | None = None,
+        cli_overrides: JsonObject | None = None,
     ):
         self.repository = repository
         self.env_overrides = copy.deepcopy(env_overrides or {})
@@ -164,7 +164,7 @@ class SettingsService:
         self,
         updated_data: JsonObject,
         updated_paths: list[str],
-        reset_paths: Optional[list[str]] = None,
+        reset_paths: list[str] | None = None,
     ) -> JsonObject:
         persisted_before = self.repository.load_persisted_settings_data()
 
@@ -288,7 +288,7 @@ def _resolve_provenance_label(file_value: object, env_value: object, cli_value: 
     return "default"
 
 
-def _get_child(node: JsonObject, key: str) -> Union[JsonValue, object]:
+def _get_child(node: JsonObject, key: str) -> JsonValue | object:
     if isinstance(node, dict) and key in node:
         return node[key]
     return _MISSING
@@ -300,7 +300,7 @@ def _without_schema_version(data: JsonObject) -> JsonObject:
     return filtered
 
 
-def _collect_patch_paths(node: JsonObject, prefix: Optional[str] = None) -> set[str]:
+def _collect_patch_paths(node: JsonObject, prefix: str | None = None) -> set[str]:
     paths = set()
 
     for key, value in node.items():

--- a/jukebox/settings/runtime_resolver.py
+++ b/jukebox/settings/runtime_resolver.py
@@ -1,4 +1,5 @@
 import os
+from typing import TypeAlias
 
 from pydantic import ValidationError
 
@@ -10,7 +11,7 @@ from .errors import InvalidSettingsError
 from .service_protocols import RuntimeSettingsService
 from .validation_rules import validate_settings_rules
 
-ActiveSonosTarget = tuple[str | None, str | None, ResolvedSonosGroupRuntime | None]
+ActiveSonosTarget: TypeAlias = tuple[str | None, str | None, ResolvedSonosGroupRuntime | None]
 
 
 class JukeboxRuntimeResolver:

--- a/jukebox/settings/runtime_resolver.py
+++ b/jukebox/settings/runtime_resolver.py
@@ -1,5 +1,4 @@
 import os
-from typing import Optional, Tuple
 
 from pydantic import ValidationError
 
@@ -11,7 +10,7 @@ from .errors import InvalidSettingsError
 from .service_protocols import RuntimeSettingsService
 from .validation_rules import validate_settings_rules
 
-ActiveSonosTarget = Tuple[Optional[str], Optional[str], Optional[ResolvedSonosGroupRuntime]]
+ActiveSonosTarget = tuple[str | None, str | None, ResolvedSonosGroupRuntime | None]
 
 
 class JukeboxRuntimeResolver:

--- a/jukebox/settings/selected_sonos_group_repository.py
+++ b/jukebox/settings/selected_sonos_group_repository.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from jukebox.sonos.selection import (
     SaveSelectedSonosGroupResult,
     SelectedSonosGroupRepository,
@@ -14,7 +12,7 @@ class SettingsSelectedSonosGroupRepository(SelectedSonosGroupRepository):
     def __init__(self, settings_service: SettingsService):
         self.settings_service = settings_service
 
-    def get_selected_group(self) -> Optional[SelectedSonosGroupSettings]:
+    def get_selected_group(self) -> SelectedSonosGroupSettings | None:
         persisted = self.settings_service.get_persisted_settings_view()
         selected_group_data = _lookup_selected_group(persisted)
         if selected_group_data is None:
@@ -40,7 +38,7 @@ class SettingsSelectedSonosGroupRepository(SelectedSonosGroupRepository):
         )
 
 
-def _lookup_selected_group(persisted: JsonObject) -> Optional[JsonObject]:
+def _lookup_selected_group(persisted: JsonObject) -> JsonObject | None:
     jukebox_settings = persisted.get("jukebox")
     if not isinstance(jukebox_settings, dict):
         return None

--- a/jukebox/settings/types.py
+++ b/jukebox/settings/types.py
@@ -1,4 +1,2 @@
-from typing import Union
-
-JsonValue = Union[None, bool, int, float, str, list["JsonValue"], dict[str, "JsonValue"]]
+JsonValue = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
 JsonObject = dict[str, JsonValue]

--- a/jukebox/settings/types.py
+++ b/jukebox/settings/types.py
@@ -1,2 +1,4 @@
-JsonValue = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
-JsonObject = dict[str, JsonValue]
+from typing import TypeAlias
+
+JsonValue: TypeAlias = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
+JsonObject: TypeAlias = dict[str, JsonValue]

--- a/jukebox/settings/types.py
+++ b/jukebox/settings/types.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Union
+from typing import Union
 
-JsonValue = Union[None, bool, int, float, str, List["JsonValue"], Dict[str, "JsonValue"]]
-JsonObject = Dict[str, JsonValue]
+JsonValue = Union[None, bool, int, float, str, list["JsonValue"], dict[str, "JsonValue"]]
+JsonObject = dict[str, JsonValue]

--- a/jukebox/settings/validation_rules.py
+++ b/jukebox/settings/validation_rules.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
-from typing import Any, Callable, Iterable, Mapping, Optional
+from typing import Any
 
 from .timing_validation import validate_loop_interval_lower_than_pause_delay
 
@@ -46,7 +47,7 @@ def get_rules_supported_by_settings(settings: Mapping[str, Any]) -> list[Setting
 
 def validate_settings_rules(
     settings: Mapping[str, Any],
-    updated_paths: Optional[Iterable[str]] = None,
+    updated_paths: Iterable[str] | None = None,
 ) -> None:
     supported_rules = get_rules_supported_by_settings(settings)
     if updated_paths is None:

--- a/jukebox/settings/view_utils.py
+++ b/jukebox/settings/view_utils.py
@@ -1,4 +1,4 @@
-from typing import Optional, cast
+from typing import cast
 
 from .types import JsonObject
 
@@ -31,7 +31,7 @@ def lookup_provenance_label(root: JsonObject, dotted_path: str) -> str:
     return collapsed_label
 
 
-def collapse_provenance_value(value: object) -> Optional[str]:
+def collapse_provenance_value(value: object) -> str | None:
     if isinstance(value, str):
         return value
     if not isinstance(value, dict):

--- a/jukebox/sonos/selection.py
+++ b/jukebox/sonos/selection.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional, Protocol
+from typing import Literal, Protocol
 
 from pydantic import BaseModel, ConfigDict
 
@@ -18,7 +18,7 @@ class StrictModel(BaseModel):
 class SonosSelectionMemberAvailability(StrictModel):
     uid: str
     status: Literal["available", "unavailable"]
-    speaker: Optional[DiscoveredSonosSpeaker] = None
+    speaker: DiscoveredSonosSpeaker | None = None
 
 
 class SonosSelectionAvailability(StrictModel):
@@ -27,7 +27,7 @@ class SonosSelectionAvailability(StrictModel):
 
 
 class SonosSelectionStatus(StrictModel):
-    selected_group: Optional[SelectedSonosGroupSettings] = None
+    selected_group: SelectedSonosGroupSettings | None = None
     availability: SonosSelectionAvailability
 
 
@@ -45,7 +45,7 @@ class SaveSelectedSonosGroupResult(StrictModel):
 
 
 class SelectedSonosGroupRepository(Protocol):
-    def get_selected_group(self) -> Optional[SelectedSonosGroupSettings]: ...
+    def get_selected_group(self) -> SelectedSonosGroupSettings | None: ...
 
     def save_selected_group(self, selected_group: SelectedSonosGroupSettings) -> SaveSelectedSonosGroupResult: ...
 
@@ -58,8 +58,8 @@ class SaveSonosSelection:
     def execute(
         self,
         uids: list[str],
-        coordinator_uid: Optional[str] = None,
-        requested_household_id: Optional[str] = None,
+        coordinator_uid: str | None = None,
+        requested_household_id: str | None = None,
     ) -> SonosSelectionResult:
         available_speakers = self.sonos_service.list_network_speakers()
         validated_group = _validate_selection_request(
@@ -144,8 +144,8 @@ class _ValidatedSonosSelectionRequest(StrictModel):
 def _validate_selection_request(
     available_speakers: list[DiscoveredSonosSpeaker],
     requested_uids: list[str],
-    coordinator_uid: Optional[str] = None,
-    requested_household_id: Optional[str] = None,
+    coordinator_uid: str | None = None,
+    requested_household_id: str | None = None,
 ) -> _ValidatedSonosSelectionRequest:
     if not requested_uids:
         raise ValueError("`uids` must include at least one UID.")

--- a/jukebox/sonos/service.py
+++ b/jukebox/sonos/service.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Optional, Protocol
+from typing import Protocol
 
 from jukebox.settings.entities import (
     ResolvedSonosGroupRuntime,
@@ -30,10 +30,10 @@ class SonosService(Protocol):
 
 @dataclass(frozen=True)
 class InspectedSelectedSonosGroup:
-    coordinator: Optional[DiscoveredSonosSpeaker]
+    coordinator: DiscoveredSonosSpeaker | None
     resolved_members: list[DiscoveredSonosSpeaker]
     missing_member_uids: list[str] = field(default_factory=list)
-    error_message: Optional[str] = None
+    error_message: str | None = None
 
 
 class DefaultSonosService:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "A Jukebox to play music on speakers using 'CD' with NFC tag"
 authors = [{ name = "Gudsfile" }]
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.9,<3.14"
+requires-python = ">=3.11,<3.14"
 dependencies = [
     "pydantic==2.13.3",
     "questionary==2.1.1",
@@ -18,8 +18,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ api = [
 ui = [
     "gukebox[api]",
     "fastui==0.9.0",
-    "python-multipart==0.0.22",
+    "python-multipart==0.0.26",
 ]
 pn532 = [
   "pyserial==3.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ extend-exclude = ["pn532/"]
 extend-select = [
     "SIM",
     "I",
-    "UP032",
+    "UP",
     "G",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,10 +69,7 @@ extend-select = [
 exclude = ["pn532/"]
 
 [tool.ty.rules]
-# Ignoring missing-argument rule for now as it is a false positive for pydantic 2.5.3 (necessary for python <3.10):
-# "No arguments provided for required parameters `__pydantic_extra__`, `__pydantic_fields_set__`, `__pydantic_private__`"
-# CI/CD will treat this rule as an error for Python >= 3.10.
-missing-argument = "warn"
+missing-argument = "error"
 
 [build-system]
 requires = ["uv_build>=0.8.7,<0.12.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dev = [
 [tool.ruff]
 line-length = 120
 indent-width = 4
-target-version = "py313"
+target-version = "py311"
 extend-exclude = ["pn532/"]
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ pn532 = [
 
 [dependency-groups]
 dev = [
-    "pytest==8.4.2",
+    "pytest==9.0.3",
     "pytest-mock==3.15.1",
     "ruff==0.15.12",
     "ty==0.0.33",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,9 +68,6 @@ extend-select = [
 [tool.ty.src]
 exclude = ["pn532/"]
 
-[tool.ty.rules]
-missing-argument = "error"
-
 [build-system]
 requires = ["uv_build>=0.8.7,<0.12.0"]
 build-backend = "uv_build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,7 @@ dependencies = [
     "pydantic==2.13.3",
     "questionary==2.1.1",
     "soco==0.31.0",
-    "typer==0.23.2; python_version < '3.10'",
-    "typer==0.24.1; python_version >= '3.10'",
+    "typer==0.24.1",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -29,15 +28,13 @@ Repository = "https://github.com/Gudsfile/jukebox"
 
 [project.optional-dependencies]
 api = [
-    "fastapi==0.128.7; python_version < '3.10'",
-    "fastapi==0.135.1; python_version >= '3.10'",
-    "uvicorn==0.39.0; python_version < '3.10'",
-    "uvicorn==0.41.0; python_version >= '3.10'",
+    "fastapi==0.135.1",
+    "uvicorn==0.41.0",
 ]
 ui = [
     "gukebox[api]",
-    "fastui==0.9.0 ; python_version >= '3.10'",
-    "python-multipart==0.0.22; python_version >= '3.10'",
+    "fastui==0.9.0",
+    "python-multipart==0.0.22",
 ]
 pn532 = [
   "pyserial==3.5",

--- a/tests/discstore/adapters/inbound/test_api_controller.py
+++ b/tests/discstore/adapters/inbound/test_api_controller.py
@@ -1,6 +1,6 @@
 import importlib.util
 import sys
-from typing import Dict, List, Tuple, cast
+from typing import cast
 from unittest.mock import MagicMock, create_autospec
 
 import pytest
@@ -30,10 +30,10 @@ if FASTAPI_INSTALLED:
     from jukebox.sonos.service import InspectedSelectedSonosGroup
 
 
-InvalidUidPayloadCase = Tuple[Dict[str, object], List[object], str]
+InvalidUidPayloadCase = tuple[dict[str, object], list[object], str]
 
 
-INVALID_UID_PAYLOAD_CASES: List[InvalidUidPayloadCase] = [
+INVALID_UID_PAYLOAD_CASES: list[InvalidUidPayloadCase] = [
     ({"uids": []}, [], "`uids` must include at least one UID."),
     ({"uids": ["speaker-1", "speaker-1"]}, [], "`uids` must not contain duplicate UIDs."),
 ]

--- a/tests/discstore/adapters/inbound/test_cli_display.py
+++ b/tests/discstore/adapters/inbound/test_cli_display.py
@@ -1,6 +1,5 @@
 import sys
 from io import StringIO
-from typing import Dict
 
 import pytest
 
@@ -9,7 +8,7 @@ from discstore.domain.entities import Disc, DiscMetadata, DiscOption
 
 
 @pytest.fixture
-def sample_discs() -> Dict[str, Disc]:
+def sample_discs() -> dict[str, Disc]:
     return {
         "abc123": Disc(
             uri="/path/to/music.mp3",

--- a/tests/discstore/adapters/inbound/test_ui_controller.py
+++ b/tests/discstore/adapters/inbound/test_ui_controller.py
@@ -1,7 +1,6 @@
 import json
 import sys
 from importlib import util
-from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, create_autospec
 
 import pytest
@@ -17,14 +16,6 @@ def build_speaker(uid, name, host, household_id):
         household_id=household_id,
         is_visible=True,
     )
-
-
-def test_module_import_failure():
-    version_below_py37 = (3, 7, 17, "final", 0)
-    with mock.patch("sys.version_info", version_below_py37), pytest.raises(RuntimeError) as err:
-        import discstore.adapters.inbound.ui_controller  # noqa: F401
-
-    assert "The `ui_controller` module requires Python 3.10+." in str(err.value)
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="FastUI requires Python 3.10+")

--- a/tests/discstore/adapters/inbound/test_ui_controller.py
+++ b/tests/discstore/adapters/inbound/test_ui_controller.py
@@ -18,7 +18,6 @@ def build_speaker(uid, name, host, household_id):
     )
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason="FastUI requires Python 3.10+")
 def test_dependencies_import_failure(mocker):
     sys.modules.pop("discstore.adapters.inbound.ui_controller", None)
     mocker.patch.dict("sys.modules", {"fastui": None})
@@ -132,10 +131,7 @@ def walk_components(components):
             yield from walk_components(children)
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 def test_ui_controller_registers_fastui_routes_and_page_structure():
     from discstore.domain.entities import Disc, DiscMetadata, DiscOption
 
@@ -260,10 +256,7 @@ def test_ui_controller_registers_fastui_routes_and_page_structure():
     assert "/api/ui" in html_response.body.decode("utf-8")
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 def test_settings_page_groups_entries_and_shows_persisted_and_effective_values():
     controller = build_controller()
 
@@ -313,10 +306,7 @@ def test_settings_page_groups_entries_and_shows_persisted_and_effective_values()
     assert page[1].event.name == "toast-settings-success"
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 def test_settings_edit_pages_render_select_text_and_json_fields():
     controller = build_controller()
     route = next(
@@ -382,10 +372,7 @@ def test_settings_edit_pages_render_select_text_and_json_fields():
     assert reset_form.footer[0].text == "Reset"
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 def test_sonos_page_renders_saved_selection_and_discovered_speakers():
     controller = build_controller()
     route = next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/ui/sonos")
@@ -412,10 +399,7 @@ def test_sonos_page_renders_saved_selection_and_discovered_speakers():
     assert page[1].event.name == "toast-sonos-success"
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 def test_sonos_edit_page_renders_speaker_and_coordinator_selects():
     controller = build_controller()
     route = next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/ui/sonos/edit")
@@ -453,10 +437,7 @@ def test_sonos_edit_page_renders_speaker_and_coordinator_selects():
     assert form.method == "POST"
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_sonos_selection_saves_and_redirects():
     from discstore.adapters.inbound.ui_controller import SonosSelectionForm
@@ -495,10 +476,7 @@ async def test_update_sonos_selection_saves_and_redirects():
     assert "Changes+take+effect+after+restart." in response[0].event.url
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_sonos_selection_returns_field_error_for_invalid_coordinator():
     from discstore.adapters.inbound.ui_controller import SonosSelectionForm
@@ -522,10 +500,7 @@ async def test_update_sonos_selection_returns_field_error_for_invalid_coordinato
     assert "coordinator_uid=speaker-2" in response[0].event.url
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 def test_sonos_edit_page_renders_error_banner_and_preserves_submitted_values():
     controller = build_controller()
     route = next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/ui/sonos/edit")
@@ -557,10 +532,7 @@ def test_sonos_edit_page_renders_error_banner_and_preserves_submitted_values():
     )
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_sonos_selection_saves_single_speaker_selection():
     from discstore.adapters.inbound.ui_controller import SonosSelectionForm
@@ -595,10 +567,7 @@ async def test_update_sonos_selection_saves_single_speaker_selection():
     assert response[0].event.url.startswith("/sonos?")
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_sonos_selection_redirects_when_write_succeeds_but_effective_settings_stay_invalid():
     from discstore.adapters.inbound.ui_controller import SonosSelectionForm
@@ -639,10 +608,7 @@ async def test_update_sonos_selection_redirects_when_write_succeeds_but_effectiv
     assert "effective+settings+are+still+unavailable" in response[0].event.url
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_reset_sonos_selection_calls_service_and_redirects():
     controller = build_controller()
@@ -661,10 +627,7 @@ async def test_reset_sonos_selection_calls_service_and_redirects():
     assert "toast=toast-sonos-success" in response[0].event.url
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 def test_settings_pages_render_error_banner_when_effective_settings_are_unavailable():
     from jukebox.settings.errors import InvalidSettingsError
 
@@ -706,10 +669,7 @@ def test_settings_pages_render_error_banner_when_effective_settings_are_unavaila
     assert any(component.type == "Paragraph" and component.text == "8100" for component in edit_components)
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 def test_settings_page_renders_mixed_provenance_label():
     controller = build_controller()
     controller.settings_service.get_effective_settings_view.return_value["provenance"]["jukebox"]["player"]["sonos"][
@@ -726,10 +686,7 @@ def test_settings_page_renders_mixed_provenance_label():
     assert any(component.type == "Paragraph" and component.text == "Mixed source" for component in all_components)
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 def test_settings_edit_page_renders_empty_object_field_with_placeholder_when_no_value():
     controller = build_controller()
     controller.settings_service.get_persisted_settings_view.return_value = {"schema_version": 1}
@@ -785,10 +742,7 @@ def test_settings_edit_page_renders_empty_object_field_with_placeholder_when_no_
     )
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_setting_builds_scalar_patch_and_redirects_with_service_message():
     from discstore.adapters.inbound.ui_controller import SettingValueForm
@@ -812,10 +766,7 @@ async def test_update_setting_builds_scalar_patch_and_redirects_with_service_mes
     assert "Changes+take+effect+after+restart." in response[0].event.url
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_setting_builds_object_patch_from_json_text():
     from discstore.adapters.inbound.ui_controller import SettingValueForm
@@ -850,10 +801,7 @@ async def test_update_setting_builds_object_patch_from_json_text():
     assert response[0].event.url.startswith("/settings?")
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_setting_treats_blank_object_text_as_none():
     from discstore.adapters.inbound.ui_controller import SettingValueForm
@@ -881,10 +829,7 @@ async def test_update_setting_treats_blank_object_text_as_none():
     )
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_setting_returns_field_error_for_invalid_json():
     from fastapi import HTTPException
@@ -912,10 +857,7 @@ async def test_update_setting_returns_field_error_for_invalid_json():
     }
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_setting_returns_field_error_for_non_object_json():
     from fastapi import HTTPException
@@ -943,10 +885,7 @@ async def test_update_setting_returns_field_error_for_non_object_json():
     }
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_setting_redirects_when_write_succeeds_but_effective_settings_stay_invalid():
     from discstore.adapters.inbound.ui_controller import SettingValueForm
@@ -989,10 +928,7 @@ async def test_update_setting_redirects_when_write_succeeds_but_effective_settin
     assert "effective+settings+are+still+unavailable" in response[0].event.url
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_setting_returns_field_error_for_shared_validation_failure():
     from fastapi import HTTPException
@@ -1022,10 +958,7 @@ async def test_update_setting_returns_field_error_for_shared_validation_failure(
     }
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_reset_setting_redirects_when_reset_succeeds_but_effective_settings_stay_invalid():
     from jukebox.settings.errors import InvalidSettingsError
@@ -1068,10 +1001,7 @@ async def test_reset_setting_redirects_when_reset_succeeds_but_effective_setting
     assert "effective+settings+are+still+unavailable" in response[0].event.url
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_reset_setting_calls_service_and_returns_refreshed_settings_page():
     controller = build_controller()
@@ -1089,10 +1019,7 @@ async def test_reset_setting_calls_service_and_returns_refreshed_settings_page()
     assert response[0].event.url.startswith("/settings?")
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_reset_setting_rerenders_edit_page_with_visible_error():
     from jukebox.settings.errors import InvalidSettingsError
@@ -1118,10 +1045,7 @@ async def test_reset_setting_rerenders_edit_page_with_visible_error():
     )
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 def test_ui_controller_does_not_register_get_reset_setting_route():
     controller = build_controller()
 
@@ -1132,10 +1056,7 @@ def test_ui_controller_does_not_register_get_reset_setting_route():
     )
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 def test_disc_library_components_render_empty_and_editable_states():
     from discstore.adapters.inbound.ui_controller import DiscTable
 
@@ -1164,10 +1085,7 @@ def test_disc_library_components_render_empty_and_editable_states():
     assert edit_button.on_click.url == "/discs/tag-123/edit"
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 def test_current_tag_banner_for_unknown_disc_offers_add_cta():
     from discstore.domain.entities import CurrentTagStatus
 
@@ -1185,10 +1103,7 @@ def test_current_tag_banner_for_unknown_disc_offers_add_cta():
     assert button.on_click.url == "/discs/new?prefill=current"
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 def test_current_tag_banner_for_known_disc_is_informational_only():
     from discstore.domain.entities import CurrentTagStatus
 
@@ -1205,10 +1120,7 @@ def test_current_tag_banner_for_known_disc_is_informational_only():
     assert button.on_click.url == "/discs/tag-123/edit"
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 def test_new_disc_form_components_render_blank_add_form():
     controller = build_controller()
 
@@ -1220,10 +1132,7 @@ def test_new_disc_form_components_render_blank_add_form():
     assert form.initial is None
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 def test_new_disc_form_components_can_prefill_current_tag():
     from discstore.domain.entities import CurrentTagStatus
 
@@ -1238,10 +1147,7 @@ def test_new_disc_form_components_can_prefill_current_tag():
     assert form.initial == {"tag": "tag-123", "shuffle": False}
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 def test_edit_disc_form_components_prefill_existing_disc():
     from discstore.domain.entities import Disc, DiscMetadata, DiscOption
 
@@ -1267,10 +1173,7 @@ def test_edit_disc_form_components_prefill_existing_disc():
     }
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 def test_disc_form_helpers_return_errors_for_invalid_current_tag_state_or_missing_edit_target():
     from discstore.domain.entities import CurrentTagStatus
 
@@ -1290,10 +1193,7 @@ def test_disc_form_helpers_return_errors_for_invalid_current_tag_state_or_missin
     assert missing_disc_components[0].type == "Error"
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 def test_form_page_components_include_back_link_and_form():
     controller = build_controller()
     components = controller._build_form_page_components(
@@ -1308,10 +1208,7 @@ def test_form_page_components_include_back_link_and_form():
     assert any(component.type == "Link" and component.on_click.url == "/" for component in page_components)
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_current_tag_banner_event_stream_emits_serialized_updates():
     from discstore.domain.entities import CurrentTagStatus
@@ -1329,10 +1226,7 @@ async def test_current_tag_banner_event_stream_emits_serialized_updates():
     assert "Unknown disc on reader" in first_chunk.decode("utf-8")
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_create_disc_returns_success_toast():
     from discstore.adapters.inbound.ui_controller import DiscForm
@@ -1358,10 +1252,7 @@ async def test_create_disc_returns_success_toast():
     assert "toast=toast-add-disc-success" in response[0].event.url
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_create_disc_returns_conflict_when_add_fails():
     from fastapi import HTTPException
@@ -1386,10 +1277,7 @@ async def test_create_disc_returns_conflict_when_add_fails():
     }
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_disc_uses_edit_path():
     from discstore.adapters.inbound.ui_controller import DiscForm
@@ -1417,10 +1305,7 @@ async def test_update_disc_uses_edit_path():
     assert "toast=toast-edit-disc-success" in response[0].event.url
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_disc_rejects_tag_changes():
     from fastapi import HTTPException
@@ -1448,10 +1333,7 @@ async def test_update_disc_rejects_tag_changes():
     }
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_disc_returns_field_error_when_edit_target_is_missing():
     from fastapi import HTTPException
@@ -1480,10 +1362,7 @@ async def test_update_disc_returns_field_error_when_edit_target_is_missing():
     }
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_delete_disc_endpoint_calls_remove_use_case():
     controller = build_controller()
@@ -1501,10 +1380,7 @@ async def test_delete_disc_endpoint_calls_remove_use_case():
     assert "toast=toast-remove-disc-success" in response[0].event.url
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_delete_disc_returns_404_when_disc_not_found():
     from fastapi import HTTPException
@@ -1524,10 +1400,7 @@ async def test_delete_disc_returns_404_when_disc_not_found():
     assert "Disc not found" in err.value.detail
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10) or util.find_spec("fastui") is None,
-    reason="FastUI dependencies are not installed",
-)
+@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
 def test_index_page_shows_remove_toast():
     controller = build_controller()
     components = controller._build_index_page_components(toast="toast-remove-disc-success")

--- a/tests/discstore/adapters/inbound/test_ui_controller.py
+++ b/tests/discstore/adapters/inbound/test_ui_controller.py
@@ -1412,3 +1412,23 @@ def test_index_page_shows_remove_toast():
         component for component in all_components if component.type == "Toast" and "removed" in str(component.body)
     )
     assert remove_toast.open_trigger.name == "toast-remove-disc-success"
+
+
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
+@pytest.mark.anyio
+async def test_form_parsing_does_not_lack_python_multipart():
+    """Verify that python-multipart is installed.
+
+    Without it, FastAPI raises: "The `python-multipart` library must be installed to use
+    form parsing in the UI.
+    """
+    from starlette.requests import Request
+
+    scope = {"type": "http", "headers": []}
+    request = Request(scope)
+
+    try:
+        await request.form()
+    except RuntimeError as e:
+        assert "python-multipart" not in str(e)
+        raise

--- a/tests/discstore/adapters/inbound/test_ui_controller.py
+++ b/tests/discstore/adapters/inbound/test_ui_controller.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock, MagicMock, create_autospec
 
 import pytest
 
+FASTUI_INSTALLED = util.find_spec("fastui") is not None
+
 
 def build_speaker(uid, name, host, household_id):
     from jukebox.sonos.discovery import DiscoveredSonosSpeaker
@@ -131,7 +133,7 @@ def walk_components(components):
             yield from walk_components(children)
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 def test_ui_controller_registers_fastui_routes_and_page_structure():
     from discstore.domain.entities import Disc, DiscMetadata, DiscOption
 
@@ -256,7 +258,7 @@ def test_ui_controller_registers_fastui_routes_and_page_structure():
     assert "/api/ui" in html_response.body.decode("utf-8")
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 def test_settings_page_groups_entries_and_shows_persisted_and_effective_values():
     controller = build_controller()
 
@@ -306,7 +308,7 @@ def test_settings_page_groups_entries_and_shows_persisted_and_effective_values()
     assert page[1].event.name == "toast-settings-success"
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 def test_settings_edit_pages_render_select_text_and_json_fields():
     controller = build_controller()
     route = next(
@@ -372,7 +374,7 @@ def test_settings_edit_pages_render_select_text_and_json_fields():
     assert reset_form.footer[0].text == "Reset"
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 def test_sonos_page_renders_saved_selection_and_discovered_speakers():
     controller = build_controller()
     route = next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/ui/sonos")
@@ -399,7 +401,7 @@ def test_sonos_page_renders_saved_selection_and_discovered_speakers():
     assert page[1].event.name == "toast-sonos-success"
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 def test_sonos_edit_page_renders_speaker_and_coordinator_selects():
     controller = build_controller()
     route = next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/ui/sonos/edit")
@@ -437,7 +439,7 @@ def test_sonos_edit_page_renders_speaker_and_coordinator_selects():
     assert form.method == "POST"
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_sonos_selection_saves_and_redirects():
     from discstore.adapters.inbound.ui_controller import SonosSelectionForm
@@ -476,7 +478,7 @@ async def test_update_sonos_selection_saves_and_redirects():
     assert "Changes+take+effect+after+restart." in response[0].event.url
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_sonos_selection_returns_field_error_for_invalid_coordinator():
     from discstore.adapters.inbound.ui_controller import SonosSelectionForm
@@ -500,7 +502,7 @@ async def test_update_sonos_selection_returns_field_error_for_invalid_coordinato
     assert "coordinator_uid=speaker-2" in response[0].event.url
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 def test_sonos_edit_page_renders_error_banner_and_preserves_submitted_values():
     controller = build_controller()
     route = next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/ui/sonos/edit")
@@ -532,7 +534,7 @@ def test_sonos_edit_page_renders_error_banner_and_preserves_submitted_values():
     )
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_sonos_selection_saves_single_speaker_selection():
     from discstore.adapters.inbound.ui_controller import SonosSelectionForm
@@ -567,7 +569,7 @@ async def test_update_sonos_selection_saves_single_speaker_selection():
     assert response[0].event.url.startswith("/sonos?")
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_sonos_selection_redirects_when_write_succeeds_but_effective_settings_stay_invalid():
     from discstore.adapters.inbound.ui_controller import SonosSelectionForm
@@ -608,7 +610,7 @@ async def test_update_sonos_selection_redirects_when_write_succeeds_but_effectiv
     assert "effective+settings+are+still+unavailable" in response[0].event.url
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_reset_sonos_selection_calls_service_and_redirects():
     controller = build_controller()
@@ -627,7 +629,7 @@ async def test_reset_sonos_selection_calls_service_and_redirects():
     assert "toast=toast-sonos-success" in response[0].event.url
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 def test_settings_pages_render_error_banner_when_effective_settings_are_unavailable():
     from jukebox.settings.errors import InvalidSettingsError
 
@@ -669,7 +671,7 @@ def test_settings_pages_render_error_banner_when_effective_settings_are_unavaila
     assert any(component.type == "Paragraph" and component.text == "8100" for component in edit_components)
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 def test_settings_page_renders_mixed_provenance_label():
     controller = build_controller()
     controller.settings_service.get_effective_settings_view.return_value["provenance"]["jukebox"]["player"]["sonos"][
@@ -686,7 +688,7 @@ def test_settings_page_renders_mixed_provenance_label():
     assert any(component.type == "Paragraph" and component.text == "Mixed source" for component in all_components)
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 def test_settings_edit_page_renders_empty_object_field_with_placeholder_when_no_value():
     controller = build_controller()
     controller.settings_service.get_persisted_settings_view.return_value = {"schema_version": 1}
@@ -742,7 +744,7 @@ def test_settings_edit_page_renders_empty_object_field_with_placeholder_when_no_
     )
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_setting_builds_scalar_patch_and_redirects_with_service_message():
     from discstore.adapters.inbound.ui_controller import SettingValueForm
@@ -766,7 +768,7 @@ async def test_update_setting_builds_scalar_patch_and_redirects_with_service_mes
     assert "Changes+take+effect+after+restart." in response[0].event.url
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_setting_builds_object_patch_from_json_text():
     from discstore.adapters.inbound.ui_controller import SettingValueForm
@@ -801,7 +803,7 @@ async def test_update_setting_builds_object_patch_from_json_text():
     assert response[0].event.url.startswith("/settings?")
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_setting_treats_blank_object_text_as_none():
     from discstore.adapters.inbound.ui_controller import SettingValueForm
@@ -829,7 +831,7 @@ async def test_update_setting_treats_blank_object_text_as_none():
     )
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_setting_returns_field_error_for_invalid_json():
     from fastapi import HTTPException
@@ -857,7 +859,7 @@ async def test_update_setting_returns_field_error_for_invalid_json():
     }
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_setting_returns_field_error_for_non_object_json():
     from fastapi import HTTPException
@@ -885,7 +887,7 @@ async def test_update_setting_returns_field_error_for_non_object_json():
     }
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_setting_redirects_when_write_succeeds_but_effective_settings_stay_invalid():
     from discstore.adapters.inbound.ui_controller import SettingValueForm
@@ -928,7 +930,7 @@ async def test_update_setting_redirects_when_write_succeeds_but_effective_settin
     assert "effective+settings+are+still+unavailable" in response[0].event.url
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_setting_returns_field_error_for_shared_validation_failure():
     from fastapi import HTTPException
@@ -958,7 +960,7 @@ async def test_update_setting_returns_field_error_for_shared_validation_failure(
     }
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_reset_setting_redirects_when_reset_succeeds_but_effective_settings_stay_invalid():
     from jukebox.settings.errors import InvalidSettingsError
@@ -1001,7 +1003,7 @@ async def test_reset_setting_redirects_when_reset_succeeds_but_effective_setting
     assert "effective+settings+are+still+unavailable" in response[0].event.url
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_reset_setting_calls_service_and_returns_refreshed_settings_page():
     controller = build_controller()
@@ -1019,7 +1021,7 @@ async def test_reset_setting_calls_service_and_returns_refreshed_settings_page()
     assert response[0].event.url.startswith("/settings?")
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_reset_setting_rerenders_edit_page_with_visible_error():
     from jukebox.settings.errors import InvalidSettingsError
@@ -1045,7 +1047,7 @@ async def test_reset_setting_rerenders_edit_page_with_visible_error():
     )
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 def test_ui_controller_does_not_register_get_reset_setting_route():
     controller = build_controller()
 
@@ -1056,7 +1058,7 @@ def test_ui_controller_does_not_register_get_reset_setting_route():
     )
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 def test_disc_library_components_render_empty_and_editable_states():
     from discstore.adapters.inbound.ui_controller import DiscTable
 
@@ -1085,7 +1087,7 @@ def test_disc_library_components_render_empty_and_editable_states():
     assert edit_button.on_click.url == "/discs/tag-123/edit"
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 def test_current_tag_banner_for_unknown_disc_offers_add_cta():
     from discstore.domain.entities import CurrentTagStatus
 
@@ -1103,7 +1105,7 @@ def test_current_tag_banner_for_unknown_disc_offers_add_cta():
     assert button.on_click.url == "/discs/new?prefill=current"
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 def test_current_tag_banner_for_known_disc_is_informational_only():
     from discstore.domain.entities import CurrentTagStatus
 
@@ -1120,7 +1122,7 @@ def test_current_tag_banner_for_known_disc_is_informational_only():
     assert button.on_click.url == "/discs/tag-123/edit"
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 def test_new_disc_form_components_render_blank_add_form():
     controller = build_controller()
 
@@ -1132,7 +1134,7 @@ def test_new_disc_form_components_render_blank_add_form():
     assert form.initial is None
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 def test_new_disc_form_components_can_prefill_current_tag():
     from discstore.domain.entities import CurrentTagStatus
 
@@ -1147,7 +1149,7 @@ def test_new_disc_form_components_can_prefill_current_tag():
     assert form.initial == {"tag": "tag-123", "shuffle": False}
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 def test_edit_disc_form_components_prefill_existing_disc():
     from discstore.domain.entities import Disc, DiscMetadata, DiscOption
 
@@ -1173,7 +1175,7 @@ def test_edit_disc_form_components_prefill_existing_disc():
     }
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 def test_disc_form_helpers_return_errors_for_invalid_current_tag_state_or_missing_edit_target():
     from discstore.domain.entities import CurrentTagStatus
 
@@ -1193,7 +1195,7 @@ def test_disc_form_helpers_return_errors_for_invalid_current_tag_state_or_missin
     assert missing_disc_components[0].type == "Error"
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 def test_form_page_components_include_back_link_and_form():
     controller = build_controller()
     components = controller._build_form_page_components(
@@ -1208,7 +1210,7 @@ def test_form_page_components_include_back_link_and_form():
     assert any(component.type == "Link" and component.on_click.url == "/" for component in page_components)
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_current_tag_banner_event_stream_emits_serialized_updates():
     from discstore.domain.entities import CurrentTagStatus
@@ -1226,7 +1228,7 @@ async def test_current_tag_banner_event_stream_emits_serialized_updates():
     assert "Unknown disc on reader" in first_chunk.decode("utf-8")
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_create_disc_returns_success_toast():
     from discstore.adapters.inbound.ui_controller import DiscForm
@@ -1252,7 +1254,7 @@ async def test_create_disc_returns_success_toast():
     assert "toast=toast-add-disc-success" in response[0].event.url
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_create_disc_returns_conflict_when_add_fails():
     from fastapi import HTTPException
@@ -1277,7 +1279,7 @@ async def test_create_disc_returns_conflict_when_add_fails():
     }
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_disc_uses_edit_path():
     from discstore.adapters.inbound.ui_controller import DiscForm
@@ -1305,7 +1307,7 @@ async def test_update_disc_uses_edit_path():
     assert "toast=toast-edit-disc-success" in response[0].event.url
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_disc_rejects_tag_changes():
     from fastapi import HTTPException
@@ -1333,7 +1335,7 @@ async def test_update_disc_rejects_tag_changes():
     }
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_update_disc_returns_field_error_when_edit_target_is_missing():
     from fastapi import HTTPException
@@ -1362,7 +1364,7 @@ async def test_update_disc_returns_field_error_when_edit_target_is_missing():
     }
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_delete_disc_endpoint_calls_remove_use_case():
     controller = build_controller()
@@ -1380,7 +1382,7 @@ async def test_delete_disc_endpoint_calls_remove_use_case():
     assert "toast=toast-remove-disc-success" in response[0].event.url
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_delete_disc_returns_404_when_disc_not_found():
     from fastapi import HTTPException
@@ -1400,7 +1402,7 @@ async def test_delete_disc_returns_404_when_disc_not_found():
     assert "Disc not found" in err.value.detail
 
 
-@pytest.mark.skipif(util.find_spec("fastui") is None, reason="FastUI dependencies are not installed")
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 def test_index_page_shows_remove_toast():
     controller = build_controller()
     components = controller._build_index_page_components(toast="toast-remove-disc-success")

--- a/tests/discstore/adapters/inbound/test_ui_controller.py
+++ b/tests/discstore/adapters/inbound/test_ui_controller.py
@@ -547,7 +547,7 @@ async def test_update_sonos_selection_saves_single_speaker_selection():
         if getattr(route, "path", None) == "/api/ui/sonos/edit" and "POST" in route.methods
     )
 
-    response = await route.endpoint(SonosSelectionForm(uids="speaker-1", coordinator_uid="speaker-1"))
+    response = await route.endpoint(SonosSelectionForm(uids="speaker-1", coordinator_uid="speaker-1"))  # ty: ignore[invalid-argument-type] # field_validator coerces str to list[str] at runtime
 
     controller.settings_service.patch_persisted_settings.assert_called_once_with(
         {

--- a/tests/jukebox/adapters/outbound/test_json_library_adapter.py
+++ b/tests/jukebox/adapters/outbound/test_json_library_adapter.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 
 import pytest

--- a/tests/jukebox/adapters/outbound/test_json_library_adapter.py
+++ b/tests/jukebox/adapters/outbound/test_json_library_adapter.py
@@ -15,7 +15,7 @@ def write_library(filepath, library: Library | dict) -> None:
 
 
 def read_library(filepath) -> dict:
-    with open(filepath, "r", encoding="utf-8") as file_obj:
+    with open(filepath, encoding="utf-8") as file_obj:
         return json.load(file_obj)
 
 

--- a/tests/jukebox/adapters/outbound/test_text_current_tag_adapter.py
+++ b/tests/jukebox/adapters/outbound/test_text_current_tag_adapter.py
@@ -81,7 +81,7 @@ def test_no_partial_text_observed_during_writes(tmp_path, monkeypatch):
 
     for _ in range(100):
         try:
-            with open(adapter.filepath, "r", encoding="utf-8") as current_tag_file:
+            with open(adapter.filepath, encoding="utf-8") as current_tag_file:
                 observed_payloads.append(current_tag_file.read())
         except Exception as err:  # pragma: no cover - exercised only on failure
             observed_errors.append(err)

--- a/tests/jukebox/pn532/test_pn532_profiles.py
+++ b/tests/jukebox/pn532/test_pn532_profiles.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Optional
 
 import pytest
 
@@ -88,8 +87,8 @@ def test_resolve_connection_params_raises_for_unsupported_protocol():
 def test_resolve_connection_params_raises_for_mismatched_override_type():
     @dataclass(frozen=True)
     class UartConnectionParams:
-        tx: Optional[int]
-        rx: Optional[int]
+        tx: int | None
+        rx: int | None
 
     with pytest.raises(ValueError, match="Expected overrides of type SpiConnectionParams"):
         resolve_connection_params(

--- a/tests/jukebox/settings/_helpers.py
+++ b/tests/jukebox/settings/_helpers.py
@@ -1,4 +1,4 @@
-from typing import Optional, cast
+from typing import cast
 
 from jukebox.settings.entities import (
     ResolvedSonosGroupRuntime,
@@ -29,9 +29,9 @@ def lookup_json_object(root: JsonObject, *path: str) -> JsonObject:
 
 def build_resolved_sonos_group_runtime(
     coordinator_uid: str = "speaker-1",
-    speakers: Optional[list[tuple[str, str, str, str]]] = None,
+    speakers: list[tuple[str, str, str, str]] | None = None,
     household_id: str = "household-1",
-    missing_member_uids: Optional[list[str]] = None,
+    missing_member_uids: list[str] | None = None,
 ) -> ResolvedSonosGroupRuntime:
     speakers = speakers or [("speaker-1", "Living Room", "192.168.1.20", household_id)]
     members = [
@@ -50,9 +50,9 @@ def build_resolved_sonos_group_runtime(
 class StubSonosService:
     def __init__(
         self,
-        resolved_group: Optional[ResolvedSonosGroupRuntime] = None,
-        inspected_group: Optional[InspectedSelectedSonosGroup] = None,
-        error: Optional[Exception] = None,
+        resolved_group: ResolvedSonosGroupRuntime | None = None,
+        inspected_group: InspectedSelectedSonosGroup | None = None,
+        error: Exception | None = None,
     ):
         self.resolved_group = resolved_group
         self.inspected_group = inspected_group
@@ -99,7 +99,7 @@ class StubSonosService:
 
 def resolve_jukebox_runtime(
     settings_service: SettingsService,
-    sonos_service: Optional[StubSonosService] = None,
+    sonos_service: StubSonosService | None = None,
     verbose: bool = False,
 ):
     if sonos_service is None:

--- a/tests/jukebox/settings/test_definitions_consistency.py
+++ b/tests/jukebox/settings/test_definitions_consistency.py
@@ -1,4 +1,5 @@
-from typing import Any, Literal, Optional, Union, get_args, get_origin
+from types import UnionType
+from typing import Any, Literal, Union, get_args, get_origin
 
 from pydantic import BaseModel
 
@@ -55,7 +56,7 @@ def _field_type_name(annotation: Any) -> str:
     raise AssertionError(f"Unsupported field annotation: {annotation!r}")
 
 
-def _extract_model_type(annotation: Any) -> Optional[type[BaseModel]]:
+def _extract_model_type(annotation: Any) -> type[BaseModel] | None:
     annotation = _strip_none(annotation)
     if isinstance(annotation, type) and issubclass(annotation, BaseModel):
         return annotation
@@ -63,7 +64,7 @@ def _extract_model_type(annotation: Any) -> Optional[type[BaseModel]]:
 
 
 def _strip_none(annotation: Any) -> Any:
-    if get_origin(annotation) is not Union:
+    if get_origin(annotation) not in (Union, UnionType):
         return annotation
 
     args = tuple(arg for arg in get_args(annotation) if arg is not type(None))

--- a/tests/jukebox/settings/test_selected_sonos_group_repository.py
+++ b/tests/jukebox/settings/test_selected_sonos_group_repository.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from jukebox.settings.entities import (
     AppSettings,
     ResolvedAdminRuntimeConfig,
@@ -13,8 +11,8 @@ from jukebox.settings.types import JsonObject
 class StubSettingsService:
     def __init__(
         self,
-        persisted_view: Optional[JsonObject] = None,
-        patch_result: Optional[JsonObject] = None,
+        persisted_view: JsonObject | None = None,
+        patch_result: JsonObject | None = None,
     ):
         if persisted_view is None:
             persisted_view = {"schema_version": 1}

--- a/uv.lock
+++ b/uv.lock
@@ -217,21 +217,18 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastapi", marker = "python_full_version >= '3.10' and extra == 'api'", specifier = "==0.135.1" },
-    { name = "fastapi", marker = "python_full_version < '3.10' and extra == 'api'", specifier = "==0.128.7" },
-    { name = "fastui", marker = "python_full_version >= '3.10' and extra == 'ui'", specifier = "==0.9.0" },
+    { name = "fastapi", marker = "extra == 'api'", specifier = "==0.135.1" },
+    { name = "fastui", marker = "extra == 'ui'", specifier = "==0.9.0" },
     { name = "gukebox", extras = ["api"], marker = "extra == 'ui'" },
     { name = "lgpio", marker = "python_full_version < '3.13' and extra == 'pn532'", specifier = "==0.2.2.0" },
     { name = "pydantic", specifier = "==2.13.3" },
     { name = "pyserial", marker = "extra == 'pn532'", specifier = "==3.5" },
-    { name = "python-multipart", marker = "python_full_version >= '3.10' and extra == 'ui'", specifier = "==0.0.22" },
+    { name = "python-multipart", marker = "extra == 'ui'", specifier = "==0.0.22" },
     { name = "questionary", specifier = "==2.1.1" },
     { name = "soco", specifier = "==0.31.0" },
     { name = "spidev", marker = "extra == 'pn532'", specifier = "==3.8" },
-    { name = "typer", marker = "python_full_version < '3.10'", specifier = "==0.23.2" },
-    { name = "typer", marker = "python_full_version >= '3.10'", specifier = "==0.24.1" },
-    { name = "uvicorn", marker = "python_full_version >= '3.10' and extra == 'api'", specifier = "==0.41.0" },
-    { name = "uvicorn", marker = "python_full_version < '3.10' and extra == 'api'", specifier = "==0.39.0" },
+    { name = "typer", specifier = "==0.24.1" },
+    { name = "uvicorn", marker = "extra == 'api'", specifier = "==0.41.0" },
 ]
 provides-extras = ["api", "ui", "pn532"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -234,7 +234,7 @@ provides-extras = ["api", "ui", "pn532"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-mock", specifier = "==3.15.1" },
     { name = "ruff", specifier = "==0.15.12" },
     { name = "ty", specifier = "==0.0.33" },
@@ -519,7 +519,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -528,9 +528,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -223,7 +223,7 @@ requires-dist = [
     { name = "lgpio", marker = "python_full_version < '3.13' and extra == 'pn532'", specifier = "==0.2.2.0" },
     { name = "pydantic", specifier = "==2.13.3" },
     { name = "pyserial", marker = "extra == 'pn532'", specifier = "==3.5" },
-    { name = "python-multipart", marker = "extra == 'ui'", specifier = "==0.0.22" },
+    { name = "python-multipart", marker = "extra == 'ui'", specifier = "==0.0.26" },
     { name = "questionary", specifier = "==2.1.1" },
     { name = "soco", specifier = "==0.31.0" },
     { name = "spidev", marker = "extra == 'pn532'", specifier = "==3.8" },
@@ -547,11 +547,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1,11 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.9, <3.14"
-resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version >= '3.10' and python_full_version < '3.13'",
-    "python_full_version < '3.10'",
-]
+requires-python = ">=3.11, <3.14"
 
 [[package]]
 name = "annotated-doc"
@@ -27,16 +22,15 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.12.1"
+version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "idna" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
 ]
 
 [[package]]
@@ -50,131 +44,80 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.2.25"
+version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
 ]
 
 [[package]]
 name = "charset-normalizer"
-version = "3.4.4"
+version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418, upload-time = "2025-10-14T04:42:32.879Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/b8/6d51fc1d52cbd52cd4ccedd5b5b2f0f6a11bbf6765c782298b0f3e808541/charset_normalizer-3.4.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e824f1492727fa856dd6eda4f7cee25f8518a12f3c4a56a74e8095695089cf6d", size = 209709, upload-time = "2025-10-14T04:40:11.385Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/af/1f9d7f7faafe2ddfb6f72a2e07a548a629c61ad510fe60f9630309908fef/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4bd5d4137d500351a30687c2d3971758aac9a19208fc110ccb9d7188fbe709e8", size = 148814, upload-time = "2025-10-14T04:40:13.135Z" },
-    { url = "https://files.pythonhosted.org/packages/79/3d/f2e3ac2bbc056ca0c204298ea4e3d9db9b4afe437812638759db2c976b5f/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:027f6de494925c0ab2a55eab46ae5129951638a49a34d87f4c3eda90f696b4ad", size = 144467, upload-time = "2025-10-14T04:40:14.728Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/85/1bf997003815e60d57de7bd972c57dc6950446a3e4ccac43bc3070721856/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f820802628d2694cb7e56db99213f930856014862f3fd943d290ea8438d07ca8", size = 162280, upload-time = "2025-10-14T04:40:16.14Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/8e/6aa1952f56b192f54921c436b87f2aaf7c7a7c3d0d1a765547d64fd83c13/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:798d75d81754988d2565bff1b97ba5a44411867c0cf32b77a7e8f8d84796b10d", size = 159454, upload-time = "2025-10-14T04:40:17.567Z" },
-    { url = "https://files.pythonhosted.org/packages/36/3b/60cbd1f8e93aa25d1c669c649b7a655b0b5fb4c571858910ea9332678558/charset_normalizer-3.4.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d1bb833febdff5c8927f922386db610b49db6e0d4f4ee29601d71e7c2694313", size = 153609, upload-time = "2025-10-14T04:40:19.08Z" },
-    { url = "https://files.pythonhosted.org/packages/64/91/6a13396948b8fd3c4b4fd5bc74d045f5637d78c9675585e8e9fbe5636554/charset_normalizer-3.4.4-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cd98cdc06614a2f768d2b7286d66805f94c48cde050acdbbb7db2600ab3197e", size = 151849, upload-time = "2025-10-14T04:40:20.607Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/7a/59482e28b9981d105691e968c544cc0df3b7d6133152fb3dcdc8f135da7a/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:077fbb858e903c73f6c9db43374fd213b0b6a778106bc7032446a8e8b5b38b93", size = 151586, upload-time = "2025-10-14T04:40:21.719Z" },
-    { url = "https://files.pythonhosted.org/packages/92/59/f64ef6a1c4bdd2baf892b04cd78792ed8684fbc48d4c2afe467d96b4df57/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:244bfb999c71b35de57821b8ea746b24e863398194a4014e4c76adc2bbdfeff0", size = 145290, upload-time = "2025-10-14T04:40:23.069Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/63/3bf9f279ddfa641ffa1962b0db6a57a9c294361cc2f5fcac997049a00e9c/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:64b55f9dce520635f018f907ff1b0df1fdc31f2795a922fb49dd14fbcdf48c84", size = 163663, upload-time = "2025-10-14T04:40:24.17Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/09/c9e38fc8fa9e0849b172b581fd9803bdf6e694041127933934184e19f8c3/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:faa3a41b2b66b6e50f84ae4a68c64fcd0c44355741c6374813a800cd6695db9e", size = 151964, upload-time = "2025-10-14T04:40:25.368Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/d1/d28b747e512d0da79d8b6a1ac18b7ab2ecfd81b2944c4c710e166d8dd09c/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6515f3182dbe4ea06ced2d9e8666d97b46ef4c75e326b79bb624110f122551db", size = 161064, upload-time = "2025-10-14T04:40:26.806Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/9a/31d62b611d901c3b9e5500c36aab0ff5eb442043fb3a1c254200d3d397d9/charset_normalizer-3.4.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:cc00f04ed596e9dc0da42ed17ac5e596c6ccba999ba6bd92b0e0aef2f170f2d6", size = 155015, upload-time = "2025-10-14T04:40:28.284Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/f3/107e008fa2bff0c8b9319584174418e5e5285fef32f79d8ee6a430d0039c/charset_normalizer-3.4.4-cp310-cp310-win32.whl", hash = "sha256:f34be2938726fc13801220747472850852fe6b1ea75869a048d6f896838c896f", size = 99792, upload-time = "2025-10-14T04:40:29.613Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/66/e396e8a408843337d7315bab30dbf106c38966f1819f123257f5520f8a96/charset_normalizer-3.4.4-cp310-cp310-win_amd64.whl", hash = "sha256:a61900df84c667873b292c3de315a786dd8dac506704dea57bc957bd31e22c7d", size = 107198, upload-time = "2025-10-14T04:40:30.644Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/58/01b4f815bf0312704c267f2ccb6e5d42bcc7752340cd487bc9f8c3710597/charset_normalizer-3.4.4-cp310-cp310-win_arm64.whl", hash = "sha256:cead0978fc57397645f12578bfd2d5ea9138ea0fac82b2f63f7f7c6877986a69", size = 100262, upload-time = "2025-10-14T04:40:32.108Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/27/c6491ff4954e58a10f69ad90aca8a1b6fe9c5d3c6f380907af3c37435b59/charset_normalizer-3.4.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6e1fcf0720908f200cd21aa4e6750a48ff6ce4afe7ff5a79a90d5ed8a08296f8", size = 206988, upload-time = "2025-10-14T04:40:33.79Z" },
-    { url = "https://files.pythonhosted.org/packages/94/59/2e87300fe67ab820b5428580a53cad894272dbb97f38a7a814a2a1ac1011/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f819d5fe9234f9f82d75bdfa9aef3a3d72c4d24a6e57aeaebba32a704553aa0", size = 147324, upload-time = "2025-10-14T04:40:34.961Z" },
-    { url = "https://files.pythonhosted.org/packages/07/fb/0cf61dc84b2b088391830f6274cb57c82e4da8bbc2efeac8c025edb88772/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a59cb51917aa591b1c4e6a43c132f0cdc3c76dbad6155df4e28ee626cc77a0a3", size = 142742, upload-time = "2025-10-14T04:40:36.105Z" },
-    { url = "https://files.pythonhosted.org/packages/62/8b/171935adf2312cd745d290ed93cf16cf0dfe320863ab7cbeeae1dcd6535f/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8ef3c867360f88ac904fd3f5e1f902f13307af9052646963ee08ff4f131adafc", size = 160863, upload-time = "2025-10-14T04:40:37.188Z" },
-    { url = "https://files.pythonhosted.org/packages/09/73/ad875b192bda14f2173bfc1bc9a55e009808484a4b256748d931b6948442/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d9e45d7faa48ee908174d8fe84854479ef838fc6a705c9315372eacbc2f02897", size = 157837, upload-time = "2025-10-14T04:40:38.435Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/fc/de9cce525b2c5b94b47c70a4b4fb19f871b24995c728e957ee68ab1671ea/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:840c25fb618a231545cbab0564a799f101b63b9901f2569faecd6b222ac72381", size = 151550, upload-time = "2025-10-14T04:40:40.053Z" },
-    { url = "https://files.pythonhosted.org/packages/55/c2/43edd615fdfba8c6f2dfbd459b25a6b3b551f24ea21981e23fb768503ce1/charset_normalizer-3.4.4-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ca5862d5b3928c4940729dacc329aa9102900382fea192fc5e52eb69d6093815", size = 149162, upload-time = "2025-10-14T04:40:41.163Z" },
-    { url = "https://files.pythonhosted.org/packages/03/86/bde4ad8b4d0e9429a4e82c1e8f5c659993a9a863ad62c7df05cf7b678d75/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9c7f57c3d666a53421049053eaacdd14bbd0a528e2186fcb2e672effd053bb0", size = 150019, upload-time = "2025-10-14T04:40:42.276Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/86/a151eb2af293a7e7bac3a739b81072585ce36ccfb4493039f49f1d3cae8c/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:277e970e750505ed74c832b4bf75dac7476262ee2a013f5574dd49075879e161", size = 143310, upload-time = "2025-10-14T04:40:43.439Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/fe/43dae6144a7e07b87478fdfc4dbe9efd5defb0e7ec29f5f58a55aeef7bf7/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:31fd66405eaf47bb62e8cd575dc621c56c668f27d46a61d975a249930dd5e2a4", size = 162022, upload-time = "2025-10-14T04:40:44.547Z" },
-    { url = "https://files.pythonhosted.org/packages/80/e6/7aab83774f5d2bca81f42ac58d04caf44f0cc2b65fc6db2b3b2e8a05f3b3/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:0d3d8f15c07f86e9ff82319b3d9ef6f4bf907608f53fe9d92b28ea9ae3d1fd89", size = 149383, upload-time = "2025-10-14T04:40:46.018Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/e8/b289173b4edae05c0dde07f69f8db476a0b511eac556dfe0d6bda3c43384/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:9f7fcd74d410a36883701fafa2482a6af2ff5ba96b9a620e9e0721e28ead5569", size = 159098, upload-time = "2025-10-14T04:40:47.081Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/df/fe699727754cae3f8478493c7f45f777b17c3ef0600e28abfec8619eb49c/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ebf3e58c7ec8a8bed6d66a75d7fb37b55e5015b03ceae72a8e7c74495551e224", size = 152991, upload-time = "2025-10-14T04:40:48.246Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/86/584869fe4ddb6ffa3bd9f491b87a01568797fb9bd8933f557dba9771beaf/charset_normalizer-3.4.4-cp311-cp311-win32.whl", hash = "sha256:eecbc200c7fd5ddb9a7f16c7decb07b566c29fa2161a16cf67b8d068bd21690a", size = 99456, upload-time = "2025-10-14T04:40:49.376Z" },
-    { url = "https://files.pythonhosted.org/packages/65/f6/62fdd5feb60530f50f7e38b4f6a1d5203f4d16ff4f9f0952962c044e919a/charset_normalizer-3.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:5ae497466c7901d54b639cf42d5b8c1b6a4fead55215500d2f486d34db48d016", size = 106978, upload-time = "2025-10-14T04:40:50.844Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/9d/0710916e6c82948b3be62d9d398cb4fcf4e97b56d6a6aeccd66c4b2f2bd5/charset_normalizer-3.4.4-cp311-cp311-win_arm64.whl", hash = "sha256:65e2befcd84bc6f37095f5961e68a6f077bf44946771354a28ad434c2cce0ae1", size = 99969, upload-time = "2025-10-14T04:40:52.272Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/85/1637cd4af66fa687396e757dec650f28025f2a2f5a5531a3208dc0ec43f2/charset_normalizer-3.4.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0a98e6759f854bd25a58a73fa88833fba3b7c491169f86ce1180c948ab3fd394", size = 208425, upload-time = "2025-10-14T04:40:53.353Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/6a/04130023fef2a0d9c62d0bae2649b69f7b7d8d24ea5536feef50551029df/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b5b290ccc2a263e8d185130284f8501e3e36c5e02750fc6b6bdeb2e9e96f1e25", size = 148162, upload-time = "2025-10-14T04:40:54.558Z" },
-    { url = "https://files.pythonhosted.org/packages/78/29/62328d79aa60da22c9e0b9a66539feae06ca0f5a4171ac4f7dc285b83688/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74bb723680f9f7a6234dcf67aea57e708ec1fbdf5699fb91dfd6f511b0a320ef", size = 144558, upload-time = "2025-10-14T04:40:55.677Z" },
-    { url = "https://files.pythonhosted.org/packages/86/bb/b32194a4bf15b88403537c2e120b817c61cd4ecffa9b6876e941c3ee38fe/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f1e34719c6ed0b92f418c7c780480b26b5d9c50349e9a9af7d76bf757530350d", size = 161497, upload-time = "2025-10-14T04:40:57.217Z" },
-    { url = "https://files.pythonhosted.org/packages/19/89/a54c82b253d5b9b111dc74aca196ba5ccfcca8242d0fb64146d4d3183ff1/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2437418e20515acec67d86e12bf70056a33abdacb5cb1655042f6538d6b085a8", size = 159240, upload-time = "2025-10-14T04:40:58.358Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/10/d20b513afe03acc89ec33948320a5544d31f21b05368436d580dec4e234d/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11d694519d7f29d6cd09f6ac70028dba10f92f6cdd059096db198c283794ac86", size = 153471, upload-time = "2025-10-14T04:40:59.468Z" },
-    { url = "https://files.pythonhosted.org/packages/61/fa/fbf177b55bdd727010f9c0a3c49eefa1d10f960e5f09d1d887bf93c2e698/charset_normalizer-3.4.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ac1c4a689edcc530fc9d9aa11f5774b9e2f33f9a0c6a57864e90908f5208d30a", size = 150864, upload-time = "2025-10-14T04:41:00.623Z" },
-    { url = "https://files.pythonhosted.org/packages/05/12/9fbc6a4d39c0198adeebbde20b619790e9236557ca59fc40e0e3cebe6f40/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:21d142cc6c0ec30d2efee5068ca36c128a30b0f2c53c1c07bd78cb6bc1d3be5f", size = 150647, upload-time = "2025-10-14T04:41:01.754Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/1f/6a9a593d52e3e8c5d2b167daf8c6b968808efb57ef4c210acb907c365bc4/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5dbe56a36425d26d6cfb40ce79c314a2e4dd6211d51d6d2191c00bed34f354cc", size = 145110, upload-time = "2025-10-14T04:41:03.231Z" },
-    { url = "https://files.pythonhosted.org/packages/30/42/9a52c609e72471b0fc54386dc63c3781a387bb4fe61c20231a4ebcd58bdd/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:5bfbb1b9acf3334612667b61bd3002196fe2a1eb4dd74d247e0f2a4d50ec9bbf", size = 162839, upload-time = "2025-10-14T04:41:04.715Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/5b/c0682bbf9f11597073052628ddd38344a3d673fda35a36773f7d19344b23/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:d055ec1e26e441f6187acf818b73564e6e6282709e9bcb5b63f5b23068356a15", size = 150667, upload-time = "2025-10-14T04:41:05.827Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/24/a41afeab6f990cf2daf6cb8c67419b63b48cf518e4f56022230840c9bfb2/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:af2d8c67d8e573d6de5bc30cdb27e9b95e49115cd9baad5ddbd1a6207aaa82a9", size = 160535, upload-time = "2025-10-14T04:41:06.938Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/e5/6a4ce77ed243c4a50a1fecca6aaaab419628c818a49434be428fe24c9957/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:780236ac706e66881f3b7f2f32dfe90507a09e67d1d454c762cf642e6e1586e0", size = 154816, upload-time = "2025-10-14T04:41:08.101Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/ef/89297262b8092b312d29cdb2517cb1237e51db8ecef2e9af5edbe7b683b1/charset_normalizer-3.4.4-cp312-cp312-win32.whl", hash = "sha256:5833d2c39d8896e4e19b689ffc198f08ea58116bee26dea51e362ecc7cd3ed26", size = 99694, upload-time = "2025-10-14T04:41:09.23Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/2d/1e5ed9dd3b3803994c155cd9aacb60c82c331bad84daf75bcb9c91b3295e/charset_normalizer-3.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:a79cfe37875f822425b89a82333404539ae63dbdddf97f84dcbc3d339aae9525", size = 107131, upload-time = "2025-10-14T04:41:10.467Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/d9/0ed4c7098a861482a7b6a95603edce4c0d9db2311af23da1fb2b75ec26fc/charset_normalizer-3.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:376bec83a63b8021bb5c8ea75e21c4ccb86e7e45ca4eb81146091b56599b80c3", size = 100390, upload-time = "2025-10-14T04:41:11.915Z" },
-    { url = "https://files.pythonhosted.org/packages/97/45/4b3a1239bbacd321068ea6e7ac28875b03ab8bc0aa0966452db17cd36714/charset_normalizer-3.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e1f185f86a6f3403aa2420e815904c67b2f9ebc443f045edd0de921108345794", size = 208091, upload-time = "2025-10-14T04:41:13.346Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/62/73a6d7450829655a35bb88a88fca7d736f9882a27eacdca2c6d505b57e2e/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b39f987ae8ccdf0d2642338faf2abb1862340facc796048b604ef14919e55ed", size = 147936, upload-time = "2025-10-14T04:41:14.461Z" },
-    { url = "https://files.pythonhosted.org/packages/89/c5/adb8c8b3d6625bef6d88b251bbb0d95f8205831b987631ab0c8bb5d937c2/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3162d5d8ce1bb98dd51af660f2121c55d0fa541b46dff7bb9b9f86ea1d87de72", size = 144180, upload-time = "2025-10-14T04:41:15.588Z" },
-    { url = "https://files.pythonhosted.org/packages/91/ed/9706e4070682d1cc219050b6048bfd293ccf67b3d4f5a4f39207453d4b99/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:81d5eb2a312700f4ecaa977a8235b634ce853200e828fbadf3a9c50bab278328", size = 161346, upload-time = "2025-10-14T04:41:16.738Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/0d/031f0d95e4972901a2f6f09ef055751805ff541511dc1252ba3ca1f80cf5/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5bd2293095d766545ec1a8f612559f6b40abc0eb18bb2f5d1171872d34036ede", size = 158874, upload-time = "2025-10-14T04:41:17.923Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/83/6ab5883f57c9c801ce5e5677242328aa45592be8a00644310a008d04f922/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a8a8b89589086a25749f471e6a900d3f662d1d3b6e2e59dcecf787b1cc3a1894", size = 153076, upload-time = "2025-10-14T04:41:19.106Z" },
-    { url = "https://files.pythonhosted.org/packages/75/1e/5ff781ddf5260e387d6419959ee89ef13878229732732ee73cdae01800f2/charset_normalizer-3.4.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc7637e2f80d8530ee4a78e878bce464f70087ce73cf7c1caf142416923b98f1", size = 150601, upload-time = "2025-10-14T04:41:20.245Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/57/71be810965493d3510a6ca79b90c19e48696fb1ff964da319334b12677f0/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f8bf04158c6b607d747e93949aa60618b61312fe647a6369f88ce2ff16043490", size = 150376, upload-time = "2025-10-14T04:41:21.398Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/d5/c3d057a78c181d007014feb7e9f2e65905a6c4ef182c0ddf0de2924edd65/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:554af85e960429cf30784dd47447d5125aaa3b99a6f0683589dbd27e2f45da44", size = 144825, upload-time = "2025-10-14T04:41:22.583Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/8c/d0406294828d4976f275ffbe66f00266c4b3136b7506941d87c00cab5272/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:74018750915ee7ad843a774364e13a3db91682f26142baddf775342c3f5b1133", size = 162583, upload-time = "2025-10-14T04:41:23.754Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/24/e2aa1f18c8f15c4c0e932d9287b8609dd30ad56dbe41d926bd846e22fb8d/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c0463276121fdee9c49b98908b3a89c39be45d86d1dbaa22957e38f6321d4ce3", size = 150366, upload-time = "2025-10-14T04:41:25.27Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/5b/1e6160c7739aad1e2df054300cc618b06bf784a7a164b0f238360721ab86/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:362d61fd13843997c1c446760ef36f240cf81d3ebf74ac62652aebaf7838561e", size = 160300, upload-time = "2025-10-14T04:41:26.725Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/10/f882167cd207fbdd743e55534d5d9620e095089d176d55cb22d5322f2afd/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9a26f18905b8dd5d685d6d07b0cdf98a79f3c7a918906af7cc143ea2e164c8bc", size = 154465, upload-time = "2025-10-14T04:41:28.322Z" },
-    { url = "https://files.pythonhosted.org/packages/89/66/c7a9e1b7429be72123441bfdbaf2bc13faab3f90b933f664db506dea5915/charset_normalizer-3.4.4-cp313-cp313-win32.whl", hash = "sha256:9b35f4c90079ff2e2edc5b26c0c77925e5d2d255c42c74fdb70fb49b172726ac", size = 99404, upload-time = "2025-10-14T04:41:29.95Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/26/b9924fa27db384bdcd97ab83b4f0a8058d96ad9626ead570674d5e737d90/charset_normalizer-3.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:b435cba5f4f750aa6c0a0d92c541fb79f69a387c91e61f1795227e4ed9cece14", size = 107092, upload-time = "2025-10-14T04:41:31.188Z" },
-    { url = "https://files.pythonhosted.org/packages/af/8f/3ed4bfa0c0c72a7ca17f0380cd9e4dd842b09f664e780c13cff1dcf2ef1b/charset_normalizer-3.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:542d2cee80be6f80247095cc36c418f7bddd14f4a6de45af91dfad36d817bba2", size = 100408, upload-time = "2025-10-14T04:41:32.624Z" },
-    { url = "https://files.pythonhosted.org/packages/46/7c/0c4760bccf082737ca7ab84a4c2034fcc06b1f21cf3032ea98bd6feb1725/charset_normalizer-3.4.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a9768c477b9d7bd54bc0c86dbaebdec6f03306675526c9927c0e8a04e8f94af9", size = 209609, upload-time = "2025-10-14T04:42:10.922Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/a4/69719daef2f3d7f1819de60c9a6be981b8eeead7542d5ec4440f3c80e111/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1bee1e43c28aa63cb16e5c14e582580546b08e535299b8b6158a7c9c768a1f3d", size = 149029, upload-time = "2025-10-14T04:42:12.38Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/21/8d4e1d6c1e6070d3672908b8e4533a71b5b53e71d16828cc24d0efec564c/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:fd44c878ea55ba351104cb93cc85e74916eb8fa440ca7903e57575e97394f608", size = 144580, upload-time = "2025-10-14T04:42:13.549Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/0a/a616d001b3f25647a9068e0b9199f697ce507ec898cacb06a0d5a1617c99/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0f04b14ffe5fdc8c4933862d8306109a2c51e0704acfa35d51598eb45a1e89fc", size = 162340, upload-time = "2025-10-14T04:42:14.892Z" },
-    { url = "https://files.pythonhosted.org/packages/85/93/060b52deb249a5450460e0585c88a904a83aec474ab8e7aba787f45e79f2/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cd09d08005f958f370f539f186d10aec3377d55b9eeb0d796025d4886119d76e", size = 159619, upload-time = "2025-10-14T04:42:16.676Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/21/0274deb1cc0632cd587a9a0ec6b4674d9108e461cb4cd40d457adaeb0564/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4fe7859a4e3e8457458e2ff592f15ccb02f3da787fcd31e0183879c3ad4692a1", size = 153980, upload-time = "2025-10-14T04:42:17.917Z" },
-    { url = "https://files.pythonhosted.org/packages/28/2b/e3d7d982858dccc11b31906976323d790dded2017a0572f093ff982d692f/charset_normalizer-3.4.4-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fa09f53c465e532f4d3db095e0c55b615f010ad81803d383195b6b5ca6cbf5f3", size = 152174, upload-time = "2025-10-14T04:42:19.018Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/ff/4a269f8e35f1e58b2df52c131a1fa019acb7ef3f8697b7d464b07e9b492d/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:7fa17817dc5625de8a027cb8b26d9fefa3ea28c8253929b8d6649e705d2835b6", size = 151666, upload-time = "2025-10-14T04:42:20.171Z" },
-    { url = "https://files.pythonhosted.org/packages/da/c9/ec39870f0b330d58486001dd8e532c6b9a905f5765f58a6f8204926b4a93/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:5947809c8a2417be3267efc979c47d76a079758166f7d43ef5ae8e9f92751f88", size = 145550, upload-time = "2025-10-14T04:42:21.324Z" },
-    { url = "https://files.pythonhosted.org/packages/75/8f/d186ab99e40e0ed9f82f033d6e49001701c81244d01905dd4a6924191a30/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:4902828217069c3c5c71094537a8e623f5d097858ac6ca8252f7b4d10b7560f1", size = 163721, upload-time = "2025-10-14T04:42:22.46Z" },
-    { url = "https://files.pythonhosted.org/packages/96/b1/6047663b9744df26a7e479ac1e77af7134b1fcf9026243bb48ee2d18810f/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:7c308f7e26e4363d79df40ca5b2be1c6ba9f02bdbccfed5abddb7859a6ce72cf", size = 152127, upload-time = "2025-10-14T04:42:23.712Z" },
-    { url = "https://files.pythonhosted.org/packages/59/78/e5a6eac9179f24f704d1be67d08704c3c6ab9f00963963524be27c18ed87/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:2c9d3c380143a1fedbff95a312aa798578371eb29da42106a29019368a475318", size = 161175, upload-time = "2025-10-14T04:42:24.87Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/43/0e626e42d54dd2f8dd6fc5e1c5ff00f05fbca17cb699bedead2cae69c62f/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:cb01158d8b88ee68f15949894ccc6712278243d95f344770fa7593fa2d94410c", size = 155375, upload-time = "2025-10-14T04:42:27.246Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/91/d9615bf2e06f35e4997616ff31248c3657ed649c5ab9d35ea12fce54e380/charset_normalizer-3.4.4-cp39-cp39-win32.whl", hash = "sha256:2677acec1a2f8ef614c6888b5b4ae4060cc184174a938ed4e8ef690e15d3e505", size = 99692, upload-time = "2025-10-14T04:42:28.425Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/a9/6c040053909d9d1ef4fcab45fddec083aedc9052c10078339b47c8573ea8/charset_normalizer-3.4.4-cp39-cp39-win_amd64.whl", hash = "sha256:f8e160feb2aed042cd657a72acc0b481212ed28b1b9a95c0cee1621b524e1966", size = 107192, upload-time = "2025-10-14T04:42:29.482Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/c6/4fa536b2c0cd3edfb7ccf8469fa0f363ea67b7213a842b90909ca33dd851/charset_normalizer-3.4.4-cp39-cp39-win_arm64.whl", hash = "sha256:b5d84d37db046c5ca74ee7bb47dd6cbc13f80665fdde3e8040bdd3fb015ecb50", size = 100220, upload-time = "2025-10-14T04:42:30.632Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
 ]
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
-]
-
-[[package]]
-name = "click"
-version = "8.3.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version >= '3.10' and python_full_version < '3.13'",
-]
-dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
 ]
 
 [[package]]
@@ -200,8 +143,8 @@ name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dnspython", marker = "python_full_version >= '3.10'" },
-    { name = "idna", marker = "python_full_version >= '3.10'" },
+    { name = "dnspython" },
+    { name = "idna" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
 wheels = [
@@ -209,50 +152,15 @@ wheels = [
 ]
 
 [[package]]
-name = "exceptiongroup"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
-]
-
-[[package]]
-name = "fastapi"
-version = "0.128.7"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "annotated-doc", marker = "python_full_version < '3.10'" },
-    { name = "pydantic", marker = "python_full_version < '3.10'" },
-    { name = "starlette", version = "0.49.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
-    { name = "typing-inspection", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/fc/af386750b3fd8d8828167e4c82b787a8eeca2eca5c5429c9db8bb7c70e04/fastapi-0.128.7.tar.gz", hash = "sha256:783c273416995486c155ad2c0e2b45905dedfaf20b9ef8d9f6a9124670639a24", size = 375325, upload-time = "2026-02-10T12:26:40.968Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/1a/f983b45661c79c31be575c570d46c437a5409b67a939c1b3d8d6b3ed7a7f/fastapi-0.128.7-py3-none-any.whl", hash = "sha256:6bd9bd31cb7047465f2d3fa3ba3f33b0870b17d4eaf7cdb36d1576ab060ad662", size = 103630, upload-time = "2026-02-10T12:26:39.414Z" },
-]
-
-[[package]]
 name = "fastapi"
 version = "0.135.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version >= '3.10' and python_full_version < '3.13'",
-]
 dependencies = [
-    { name = "annotated-doc", marker = "python_full_version >= '3.10'" },
-    { name = "pydantic", marker = "python_full_version >= '3.10'" },
-    { name = "starlette", version = "0.50.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
-    { name = "typing-inspection", marker = "python_full_version >= '3.10'" },
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e7/7b/f8e0211e9380f7195ba3f3d40c292594fd81ba8ec4629e3854c353aaca45/fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd", size = 394962, upload-time = "2026-03-01T18:18:29.369Z" }
 wheels = [
@@ -264,7 +172,7 @@ name = "fastui"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", extra = ["email"], marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", extra = ["email"] },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/27/e52de3e3a3dd16cda6fac11d2b5b0ed8a54e14386a303bc8f757275df121/fastui-0.9.0.tar.gz", hash = "sha256:490ae906adea604f6fbb6270a8d1836611371dd304a1c556cad2785474a287f9", size = 29625, upload-time = "2025-10-28T08:55:17.305Z" }
 wheels = [
@@ -279,16 +187,13 @@ dependencies = [
     { name = "pydantic" },
     { name = "questionary" },
     { name = "soco" },
-    { name = "typer", version = "0.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typer", version = "0.24.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typer" },
 ]
 
 [package.optional-dependencies]
 api = [
-    { name = "fastapi", version = "0.128.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "fastapi", version = "0.135.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "uvicorn", version = "0.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "uvicorn", version = "0.41.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "fastapi" },
+    { name = "uvicorn" },
 ]
 pn532 = [
     { name = "lgpio", marker = "python_full_version < '3.13'" },
@@ -296,12 +201,10 @@ pn532 = [
     { name = "spidev" },
 ]
 ui = [
-    { name = "fastapi", version = "0.128.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "fastapi", version = "0.135.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "fastui", marker = "python_full_version >= '3.10'" },
-    { name = "python-multipart", marker = "python_full_version >= '3.10'" },
-    { name = "uvicorn", version = "0.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "uvicorn", version = "0.41.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "fastapi" },
+    { name = "fastui" },
+    { name = "python-multipart" },
+    { name = "uvicorn" },
 ]
 
 [package.dev-dependencies]
@@ -351,11 +254,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.13"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
 ]
 
 [[package]]
@@ -369,24 +272,8 @@ wheels = [
 
 [[package]]
 name = "iniconfig"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
-]
-
-[[package]]
-name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version >= '3.10' and python_full_version < '3.13'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
@@ -398,18 +285,12 @@ version = "0.2.2.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/56/33/26ec2e8049eaa2f077bf23a12dc61ca559fbfa7bea0516bf263d657ae275/lgpio-0.2.2.0.tar.gz", hash = "sha256:11372e653b200f76a0b3ef8a23a0735c85ec678a9f8550b9893151ed0f863fff", size = 90087, upload-time = "2024-03-29T21:59:55.901Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/b9/d23f9539bbddf47c01a14fc96158a42d9de454fd9d04f7be1347ca6db8fd/lgpio-0.2.2.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:97fe5fb0e888c96031e8899e8c0eca64c63076a6d1f1e774acad8696430b2ff6", size = 376674, upload-time = "2024-03-29T22:00:41.969Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/db/fbbade15dbc9febdbd06bd82531c0a78206f96262003145d6953396d9554/lgpio-0.2.2.0-cp310-cp310-manylinux_2_34_aarch64.whl", hash = "sha256:f8f1a2818ed4293182999679ac8559aea70d45743f5a3ae8025837e529d9e0d4", size = 356711, upload-time = "2024-04-01T22:49:43.455Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/ca/1c5278b2548e956a52a07efae91ce2300f81c8cf4ad3d7d6b98ce8987e15/lgpio-0.2.2.0-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:d245f315e4bc5ba1b72df9fd935a16c99e56ccf6b41d9f66a87804c1dfd91c86", size = 362126, upload-time = "2024-04-13T14:08:11.879Z" },
     { url = "https://files.pythonhosted.org/packages/78/4e/5721ae44b29e4fe9175f68c881694e3713066590739a7c87f8cee2835c25/lgpio-0.2.2.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:5b3c403e1fba9c17d178f1bde102726c548fc5c4fc1ccf5ec3e18f3c08e07e04", size = 382992, upload-time = "2024-03-29T22:00:45.039Z" },
     { url = "https://files.pythonhosted.org/packages/88/53/e57a22fe815fc68d0991655c1105b8ed872a68491d32e4e0e7d10ffb5c4d/lgpio-0.2.2.0-cp311-cp311-manylinux_2_34_aarch64.whl", hash = "sha256:a2f71fb95b149d8ac82c7c6bae70f054f6dc42a006ad35c90c7d8e54921fbcf4", size = 364848, upload-time = "2024-04-01T22:49:45.889Z" },
     { url = "https://files.pythonhosted.org/packages/a4/71/11f4e3d76400e4ca43f9f9b014f5a86d9a265340c0bea45cce037277eb34/lgpio-0.2.2.0-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:e9f4f3915abe5ae0ffdb4b96f485076d80a663876d839e2d3fd9218a71b9873e", size = 370183, upload-time = "2024-04-13T14:08:14.139Z" },
     { url = "https://files.pythonhosted.org/packages/fe/73/e56c9afb845df53492d42bdea01df9895272bccfdd5128f34719c3a07990/lgpio-0.2.2.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:6c65ac42e878764d04a71ed12fe6d46089b36e9e8127722bf29bb2e4bc91de22", size = 383956, upload-time = "2024-03-29T22:00:47.315Z" },
     { url = "https://files.pythonhosted.org/packages/3b/1c/becd00f66d2c65feed9a668ff9d91732394cb6baba7bec505d55de0e30c9/lgpio-0.2.2.0-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:d907db79292c721c605af08187385ddb3b7af09907e1ffca56cf0cd6558ace0a", size = 366058, upload-time = "2024-04-01T22:49:47.615Z" },
     { url = "https://files.pythonhosted.org/packages/4c/7a/e3b4e5225c9792c4092b2cc07504746acbe62d0a8e4cb023bdf65f6430cf/lgpio-0.2.2.0-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:2aadff092f642fcdada8457c158f87259dfda3a89ec19bae0b99ff22b34aac4b", size = 372103, upload-time = "2024-04-13T14:08:16.351Z" },
-    { url = "https://files.pythonhosted.org/packages/07/bb/61170f77afe6be106eb76994468d0b814df5d69475b2ef4c58df6dbbbe34/lgpio-0.2.2.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:1594dd4fdf054ff396bf0730802732c26aa2040d6c70250d0d34f703baafd121", size = 376643, upload-time = "2024-03-29T22:00:51.795Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/ec/ebfcb05deb276f34aa2abf9f4163980014177a916ffd217525f47b63192d/lgpio-0.2.2.0-cp39-cp39-manylinux_2_34_aarch64.whl", hash = "sha256:9ed135824c717901457dcf2462bb1af9f5445aa6e56bb7a9263fc064620ef586", size = 356475, upload-time = "2024-04-01T22:49:49.92Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/69/f60b1479b4370f3f9fba696d1c42e5802292421a2f96f63fff001698848c/lgpio-0.2.2.0-cp39-cp39-manylinux_2_34_x86_64.whl", hash = "sha256:f95d6a6db23f99e745e0aee36cd49a515dd6846a5ddb49474c73a390bb2048e2", size = 361735, upload-time = "2024-04-13T14:08:18.011Z" },
 ]
 
 [[package]]
@@ -418,22 +299,6 @@ version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/28/30/9abc9e34c657c33834eaf6cd02124c61bdf5944d802aa48e69be8da3585d/lxml-6.1.0.tar.gz", hash = "sha256:bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13", size = 4197006, upload-time = "2026-04-18T04:32:51.613Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/6e/ee8fc0e01202eb3dd2b9e1ea4f0910d72425d35c66187c63931d7a3ea73f/lxml-6.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:41dcc4c7b10484257cbd6c37b83ddb26df2b0e5aff5ac00d095689015af868ec", size = 8540733, upload-time = "2026-04-18T04:27:33.185Z" },
-    { url = "https://files.pythonhosted.org/packages/54/e8/325fe9b942824c773dffe1baf0c35b046a763851fdff4393af4450bceeb7/lxml-6.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a31286dbb5e74c8e9a5344465b77ab4c5bd511a253b355b5ca2fae7e579fafec", size = 4602805, upload-time = "2026-04-18T04:27:36.097Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/81/221aa3ea4a40370bb0358fa454cbe7e5a837e522f7630c24dfef3f9a73b0/lxml-6.1.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1bc4cc83fb7f66ffb16f74d6dd0162e144333fc36ebcce32246f80c8735b2551", size = 5002652, upload-time = "2026-04-18T04:27:30.603Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/e1/fdbfb9019542f1875c093576df7f37adc2983c8ba7ecf17e5f14490bc107/lxml-6.1.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:20cf4d0651987c906a2f5cba4e3a8d6ba4bfdf973cfe2a96c0d6053888ea2ecd", size = 5155332, upload-time = "2026-04-18T04:27:33.507Z" },
-    { url = "https://files.pythonhosted.org/packages/56/b1/4087c782fff397cd03abf9c551069be59bb04a7e548c50fb7b9c4cdaca28/lxml-6.1.0-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffb34ea45a82dd637c2c97ae1bbb920850c1e59bcae79ce1c15af531d83e7215", size = 5057226, upload-time = "2026-04-18T04:27:37.567Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/66/516c79dec8417f3a972327330254c0b5fac93d5c3ecfd8a5b43650a5a4d9/lxml-6.1.0-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1d9b99e5b2597e4f5aed2484fef835256fa1b68a19e4265c97628ef4bf8bcf4", size = 5287588, upload-time = "2026-04-18T04:27:41.4Z" },
-    { url = "https://files.pythonhosted.org/packages/94/1d/e578f4cbeb42b9df9f29b0d44a45a7cdfa3a5ae300dd59ec68e3602d29bb/lxml-6.1.0-cp310-cp310-manylinux_2_28_i686.whl", hash = "sha256:d43aa26dcda363f21e79afa0668f5029ed7394b3bb8c92a6927a3d34e8b610ea", size = 5412438, upload-time = "2026-04-18T04:27:45.589Z" },
-    { url = "https://files.pythonhosted.org/packages/47/5b/2aa68307d6d15959e84d4882f9c04f2da63127eac463e1594166f681ef77/lxml-6.1.0-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:6262b87f9e5c1e5fe501d6c153247289af42eb44ad7660b9b3de17baaf92d6f6", size = 4770997, upload-time = "2026-04-18T04:27:49.853Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/c9/3e51fc1228310a836b4eb32595ae00154ab12197fca944676a3ab3b163ea/lxml-6.1.0-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d1392c569c032f78a11a25d1de1c43fff13294c793b39e19d84fade3045cbbc3", size = 5359678, upload-time = "2026-04-18T04:31:56.184Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/91/ab8bc834f977fbbd310e697b120787c153db026f9151e02a88d2645d4e5b/lxml-6.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:045e387d1f4f42a418380930fa3f45c73c9b392faf67e495e58902e68e8f44a7", size = 5107890, upload-time = "2026-04-18T04:32:00.387Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/10/8a143cfa3ac99cb5b0523ff6d0429a9c9dddf25ffeae09caa3866c7964d9/lxml-6.1.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:9f93d5b8b07f73e8c77e3c6556a3db269918390c804b5e5fcdd4858232cc8f16", size = 4803977, upload-time = "2026-04-18T04:32:05.099Z" },
-    { url = "https://files.pythonhosted.org/packages/45/fd/ee02faf52fa39c2fe32f824628958b9aa86dff21343dc3161f0e3c6ccd15/lxml-6.1.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:de550d129f18d8ab819651ffe4f38b1b713c7e116707de3c0c6400d0ef34fbc1", size = 5350277, upload-time = "2026-04-18T04:32:09.176Z" },
-    { url = "https://files.pythonhosted.org/packages/85/8c/b3481364b8554b5d36d540189a87fc71e94b0b01c24f8f152bd662dd2e45/lxml-6.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c08da09dc003c9e8c70e06b53a11db6fb3b250c21c4236b03c7d7b443c318e7a", size = 5309717, upload-time = "2026-04-18T04:32:13.303Z" },
-    { url = "https://files.pythonhosted.org/packages/74/e8/a6b21927077a9127afa17473b6576b322616f34ac50ee4f577e763b75ec0/lxml-6.1.0-cp310-cp310-win32.whl", hash = "sha256:37448bf9c7d7adfc5254763901e2bbd6bb876228dfc1fc7f66e58c06368a7544", size = 3598491, upload-time = "2026-04-18T04:27:24.288Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/82/14dea800d041274d96c07d49ff9191f011d1427450850de19bf541e2cc12/lxml-6.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:2593a0a6621545b9095b71ad74ed4226eba438a7d9fc3712a99bdb15508cf93a", size = 4020906, upload-time = "2026-04-18T04:27:27.53Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/ba/d3539aaf4d9d21456b9a7b902816623227d05d63e7c5aafd8834c4b9bed6/lxml-6.1.0-cp310-cp310-win_arm64.whl", hash = "sha256:e80807d72f96b96ad5588cb85c75616e4f2795a7737d4630784c51497beb7776", size = 3667787, upload-time = "2026-04-18T04:27:29.407Z" },
     { url = "https://files.pythonhosted.org/packages/5e/5d/3bccad330292946f97962df9d5f2d3ae129cce6e212732a781e856b91e07/lxml-6.1.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cec05be8c876f92a5aa07b01d60bbb4d11cfbdd654cad0561c0d7b5c043a61b9", size = 8526232, upload-time = "2026-04-18T04:27:40.389Z" },
     { url = "https://files.pythonhosted.org/packages/a7/51/adc8826570a112f83bb4ddb3a2ab510bbc2ccd62c1b9fe1f34fae2d90b57/lxml-6.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9c03e048b6ce8e77b09c734e931584894ecd58d08296804ca2d0b184c933ce50", size = 4595448, upload-time = "2026-04-18T04:27:44.208Z" },
     { url = "https://files.pythonhosted.org/packages/54/84/5a9ec07cbe1d2334a6465f863b949a520d2699a755738986dcd3b6b89e3f/lxml-6.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:942454ff253da14218f972b23dc72fa4edf6c943f37edd19cd697618b626fac5", size = 4923771, upload-time = "2026-04-18T04:32:17.402Z" },
@@ -486,22 +351,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/73/16596f7e4e38fa33084b9ccbccc22a15f82a290a055126f2c1541236d2ff/lxml-6.1.0-cp313-cp313-win32.whl", hash = "sha256:28902146ffbe5222df411c5d19e5352490122e14447e98cd118907ee3fd6ee62", size = 3596938, upload-time = "2026-04-18T04:31:56.206Z" },
     { url = "https://files.pythonhosted.org/packages/8e/63/981401c5680c1eb30893f00a19641ac80db5d1e7086c62cb4b13ed813038/lxml-6.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:4a1503c56e4e2b38dc76f2f2da7bae69670c0f1933e27cfa34b2fa5876410b16", size = 3995728, upload-time = "2026-04-18T04:31:58.763Z" },
     { url = "https://files.pythonhosted.org/packages/e7/e8/c358a38ac3e541d16a1b527e4e9cb78c0419b0506a070ace11777e5e8404/lxml-6.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:e0af85773850417d994d019741239b901b22c6680206f46a34766926e466141d", size = 3658372, upload-time = "2026-04-18T04:32:03.629Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/e5/ce4f6c3fd846b6e84fd26e4451e0dd71ed41c11c06f933bc5e14209b8424/lxml-6.1.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:920354904d1cb86577d4b3cfe2830c2dbe81d6f4449e57ada428f1609b5985f7", size = 8553758, upload-time = "2026-04-18T04:32:27.055Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/c3/2dc396e40e6df8fa4f9aed713bd24d3ded0d2c59f6c526f374a4f20e2711/lxml-6.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c871299c595ee004d186f61840f0bfc4941aa3f17c8ba4a565ead7e4f4f820ee", size = 4607719, upload-time = "2026-04-18T04:32:30.824Z" },
-    { url = "https://files.pythonhosted.org/packages/89/cf/b9d36b388e3bffdae6d1c987e91ad08dae487bc1a45f499343d081b8b18e/lxml-6.1.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d0d799ff958655781296ec870d5e2448e75150da2b3d07f13ff5b0c2c35beefd", size = 5006003, upload-time = "2026-04-18T04:35:32.715Z" },
-    { url = "https://files.pythonhosted.org/packages/63/d9/28589f385b6028f1700a5d88444a3278b1b2e81425b71f44fb234082135d/lxml-6.1.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ba11752e346bd804ea312ec2eea2532dfa8b8d3261d81a32ef9e6ab16256280", size = 5159902, upload-time = "2026-04-18T04:35:35.444Z" },
-    { url = "https://files.pythonhosted.org/packages/57/fc/4d1ecc9f767fce8eec8e36b42c2b046e2076d71cb3f27363920c2c2a3412/lxml-6.1.0-cp39-cp39-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26c5272c6a4bf4cf32d3f5a7890c942b0e04438691157d341616d02cca74d4bd", size = 5062833, upload-time = "2026-04-18T04:35:38.185Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/85/4f183628e66b04390a78db807c79b2956a995f7fed5061fd73a54b9f8b7b/lxml-6.1.0-cp39-cp39-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c53fa3a5a52122d590e847a57ccf955557b9634a7f99ff5a35131321b0a85317", size = 5292986, upload-time = "2026-04-18T04:35:41.477Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/53/82043639bd363b82b0b480b5ec1f596ec09be6bf65358f0c44ea05e113c3/lxml-6.1.0-cp39-cp39-manylinux_2_28_i686.whl", hash = "sha256:76b958b4ea3104483c20f74866d55aa056546e15ebe83dd7aecd63698f43b755", size = 5416696, upload-time = "2026-04-18T04:35:44.358Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/84/12769cfd85fa18595d22ad6f4ea0ec548e3ba78c3111738fa5d1389321d6/lxml-6.1.0-cp39-cp39-manylinux_2_31_armv7l.whl", hash = "sha256:8c11b984b5ce6add4dccc7144c7be5d364d298f15b0c6a57da1991baedc750ce", size = 4773350, upload-time = "2026-04-18T04:35:47.407Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/7e/c8ca946407eb1dfc934681f8adfc7903d3541328d03cb372d4df323b0b58/lxml-6.1.0-cp39-cp39-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d3829a6e6fd550a219564912d4002c537f65da4c6ae4e093cc34462f4fa027ad", size = 5361754, upload-time = "2026-04-18T04:35:49.93Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/c3/a1eec3a444d1d6004e2eaf299eeaf43974f7cd9b602d191974dc0ef6dd2e/lxml-6.1.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:52b0ac6903cf74ebf997eb8c682d2fbac7d1ab7e4c552413eec55868a9b73f39", size = 5111074, upload-time = "2026-04-18T04:35:52.469Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/64/8e5b591750799f9e1ae7f72c1fd74c0489d503a255329462a27921e41ccf/lxml-6.1.0-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:29f5c00cb7d752bce2c70ebd2d31b0a42f9499ffdd3ecb2f31a5b73ee43031ad", size = 4808151, upload-time = "2026-04-18T04:35:55.176Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/f0/25dbf84ed5a83d7f3e8bbed7f7ec354e0bda198d4f360dbe67996d6b83fc/lxml-6.1.0-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:c748ebcb6877de89f48ab90ca96642ac458fff5dec291a2b9337cd4d0934e383", size = 5352754, upload-time = "2026-04-18T04:35:57.928Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/8b/98a6fd25ffd71ee32000ef402717937514e6a53ea3cd155437d9f1b7efd0/lxml-6.1.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:08950a23f296b3f83521577274e3d3b0f3d739bf2e68d01a752e4288bc50d286", size = 5315169, upload-time = "2026-04-18T04:36:00.947Z" },
-    { url = "https://files.pythonhosted.org/packages/64/76/f2e129250eb2d79155630c78bfd17a12b8ae4907cba70ef7defb7e46159a/lxml-6.1.0-cp39-cp39-win32.whl", hash = "sha256:11a873c77a181b4fef9c2e357d08ed399542c2af1390101da66720a19c7c9618", size = 3601056, upload-time = "2026-04-18T04:32:40.29Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/9f/c2d0bf629547f17e3a3e568d4ee7b42a5ecfbf03e145903c0636ef04ef82/lxml-6.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:81ff55c70b67d19d52b6fd118a114c0a4c97d799cd3089ff9bd9e2ff4b414ee2", size = 4024263, upload-time = "2026-04-18T04:32:42.88Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/93/5176afacf2b687efe96fb6933c23685b650df4018a4de43ea0da23e38860/lxml-6.1.0-cp39-cp39-win_arm64.whl", hash = "sha256:481d6e2104285d9add34f41b42b247b76b61c5b5c26c303c2e9707bbf8bd9a64", size = 3670698, upload-time = "2026-04-18T04:32:45.602Z" },
     { url = "https://files.pythonhosted.org/packages/f2/88/55143966481409b1740a3ac669e611055f49efd68087a5ce41582325db3e/lxml-6.1.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:546b66c0dd1bb8d9fa89d7123e5fa19a8aff3a1f2141eb22df96112afb17b842", size = 3930134, upload-time = "2026-04-18T04:32:35.008Z" },
     { url = "https://files.pythonhosted.org/packages/b5/97/28b985c2983938d3cb696dd5501423afb90a8c3e869ef5d3c62569282c0f/lxml-6.1.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5cfa1a34df366d9dc0d5eaf420f4cf2bb1e1bebe1066d1c2fc28c179f8a4004c", size = 4210749, upload-time = "2026-04-18T04:36:03.626Z" },
     { url = "https://files.pythonhosted.org/packages/29/67/dfab2b7d58214921935ccea7ce9b3df9b7d46f305d12f0f532ac7cf6b804/lxml-6.1.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db88156fcf544cdbf0d95588051515cfdfd4c876fc66444eb98bceb5d6db76de", size = 4318463, upload-time = "2026-04-18T04:36:06.309Z" },
@@ -512,29 +361,10 @@ wheels = [
 
 [[package]]
 name = "markdown-it-py"
-version = "3.0.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "mdurl", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
-]
-
-[[package]]
-name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version >= '3.10' and python_full_version < '3.13'",
-]
 dependencies = [
-    { name = "mdurl", marker = "python_full_version >= '3.10'" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
@@ -552,11 +382,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.0"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]
@@ -597,7 +427,7 @@ wheels = [
 
 [package.optional-dependencies]
 email = [
-    { name = "email-validator", marker = "python_full_version >= '3.10'" },
+    { name = "email-validator" },
 ]
 
 [[package]]
@@ -609,20 +439,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2a/ef/f7abb56c49382a246fd2ce9c799691e3c3e7175ec74b14d99e798bcddb1a/pydantic_core-2.46.3.tar.gz", hash = "sha256:41c178f65b8c29807239d47e6050262eb6bf84eb695e41101e62e38df4a5bc2c", size = 471412, upload-time = "2026-04-20T14:40:56.672Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/98/b50eb9a411e87483b5c65dba4fa430a06bac4234d3403a40e5a9905ebcd0/pydantic_core-2.46.3-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:1da3786b8018e60349680720158cc19161cc3b4bdd815beb0a321cd5ce1ad5b1", size = 2108971, upload-time = "2026-04-20T14:43:51.945Z" },
-    { url = "https://files.pythonhosted.org/packages/08/4b/f364b9d161718ff2217160a4b5d41ce38de60aed91c3689ebffa1c939d23/pydantic_core-2.46.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cc0988cb29d21bf4a9d5cf2ef970b5c0e38d8d8e107a493278c05dc6c1dda69f", size = 1949588, upload-time = "2026-04-20T14:44:10.386Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/8b/30bd03ee83b2f5e29f5ba8e647ab3c456bf56f2ec72fdbcc0215484a0854/pydantic_core-2.46.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:27f9067c3bfadd04c55484b89c0d267981b2f3512850f6f66e1e74204a4e4ce3", size = 1975986, upload-time = "2026-04-20T14:43:57.106Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/54/13ccf954d84ec275d5d023d5786e4aa48840bc9f161f2838dc98e1153518/pydantic_core-2.46.3-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a642ac886ecf6402d9882d10c405dcf4b902abeb2972cd5fb4a48c83cd59279a", size = 2055830, upload-time = "2026-04-20T14:44:15.499Z" },
-    { url = "https://files.pythonhosted.org/packages/be/0e/65f38125e660fdbd72aa858e7dfae893645cfa0e7b13d333e174a367cd23/pydantic_core-2.46.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:79f561438481f28681584b89e2effb22855e2179880314bcddbf5968e935e807", size = 2222340, upload-time = "2026-04-20T14:41:51.353Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/88/f3ab7739efe0e7e80777dbb84c59eb98518e3f57ea433206194c2e425272/pydantic_core-2.46.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:57a973eae4665352a47cf1a99b4ee864620f2fe663a217d7a8da68a1f3a5bfda", size = 2280727, upload-time = "2026-04-20T14:41:30.461Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/6d/c228219080817bec4982f9531cadb18da6aaa770fdeb114f49c237ac2c9f/pydantic_core-2.46.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83d002b97072a53ea150d63e0a3adfae5670cef5aa8a6e490240e482d3b22e57", size = 2092158, upload-time = "2026-04-20T14:44:07.305Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/b1/525a16711e7c6d61635fac3b0bd54600b5c5d9f60c6fc5aaab26b64a2297/pydantic_core-2.46.3-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:b40ddd51e7c44b28cfaef746c9d3c506d658885e0a46f9eeef2ee815cbf8e045", size = 2116626, upload-time = "2026-04-20T14:42:34.118Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/7c/17d30673351439a6951bf54f564cf2443ab00ae264ec9df00e2efd710eb5/pydantic_core-2.46.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ac5ec7fb9b87f04ee839af2d53bcadea57ded7d229719f56c0ed895bff987943", size = 2160691, upload-time = "2026-04-20T14:41:14.023Z" },
-    { url = "https://files.pythonhosted.org/packages/86/66/af8adbcbc0886ead7f1a116606a534d75a307e71e6e08226000d51b880d2/pydantic_core-2.46.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:a3b11c812f61b3129c4905781a2601dfdfdea5fe1e6c1cfb696b55d14e9c054f", size = 2182543, upload-time = "2026-04-20T14:40:48.886Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/37/6de71e0f54c54a4190010f57deb749e1ddf75c568ada3b1320b70067f121/pydantic_core-2.46.3-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:1108da631e602e5b3c38d6d04fe5bb3bfa54349e6918e3ca6cf570b2e2b2f9d4", size = 2324513, upload-time = "2026-04-20T14:42:36.121Z" },
-    { url = "https://files.pythonhosted.org/packages/51/b1/9fc74ce94f603d5ef59ff258ca9c2c8fb902fb548d340a96f77f4d1c3b7f/pydantic_core-2.46.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:de885175515bcfa98ae618c1df7a072f13d179f81376c8007112af20567fd08a", size = 2361853, upload-time = "2026-04-20T14:43:24.886Z" },
-    { url = "https://files.pythonhosted.org/packages/40/d0/4c652fc592db35f100279ee751d5a145aca1b9a7984b9684ba7c1b5b0535/pydantic_core-2.46.3-cp310-cp310-win32.whl", hash = "sha256:d11058e3201527d41bc6b545c79187c9e4bf85e15a236a6007f0e991518882b7", size = 1980465, upload-time = "2026-04-20T14:44:46.239Z" },
-    { url = "https://files.pythonhosted.org/packages/27/b8/a920453c38afbe1f355e1ea0b0d94a0a3e0b0879d32d793108755fa171d5/pydantic_core-2.46.3-cp310-cp310-win_amd64.whl", hash = "sha256:3612edf65c8ea67ac13616c4d23af12faef1ae435a8a93e5934c2a0cbbdd1fd6", size = 2073884, upload-time = "2026-04-20T14:43:01.201Z" },
     { url = "https://files.pythonhosted.org/packages/22/a2/1ba90a83e85a3f94c796b184f3efde9c72f2830dcda493eea8d59ba78e6d/pydantic_core-2.46.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:ab124d49d0459b2373ecf54118a45c28a1e6d4192a533fbc915e70f556feb8e5", size = 2106740, upload-time = "2026-04-20T14:41:20.932Z" },
     { url = "https://files.pythonhosted.org/packages/b6/f6/99ae893c89a0b9d3daec9f95487aa676709aa83f67643b3f0abaf4ab628a/pydantic_core-2.46.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cca67d52a5c7a16aed2b3999e719c4bcf644074eac304a5d3d62dd70ae7d4b2c", size = 1948293, upload-time = "2026-04-20T14:43:42.115Z" },
     { url = "https://files.pythonhosted.org/packages/3e/b8/2e8e636dc9e3f16c2e16bf0849e24be82c5ee82c603c65fc0326666328fc/pydantic_core-2.46.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5c024e08c0ba23e6fd68c771a521e9d6a792f2ebb0fa734296b36394dc30390e", size = 1973222, upload-time = "2026-04-20T14:41:57.841Z" },
@@ -668,20 +484,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/45/b3/ed14c659cbe7605e3ef063077680a64680aec81eb1a04763a05190d49b7f/pydantic_core-2.46.3-cp313-cp313-win32.whl", hash = "sha256:610eda2e3838f401105e6326ca304f5da1e15393ae25dacae5c5c63f2c275b13", size = 1965601, upload-time = "2026-04-20T14:41:42.128Z" },
     { url = "https://files.pythonhosted.org/packages/ef/bb/adb70d9a762ddd002d723fbf1bd492244d37da41e3af7b74ad212609027e/pydantic_core-2.46.3-cp313-cp313-win_amd64.whl", hash = "sha256:68cc7866ed863db34351294187f9b729964c371ba33e31c26f478471c52e1ed0", size = 2071517, upload-time = "2026-04-20T14:43:36.096Z" },
     { url = "https://files.pythonhosted.org/packages/52/eb/66faefabebfe68bd7788339c9c9127231e680b11906368c67ce112fdb47f/pydantic_core-2.46.3-cp313-cp313-win_arm64.whl", hash = "sha256:f64b5537ac62b231572879cd08ec05600308636a5d63bcbdb15063a466977bec", size = 2035802, upload-time = "2026-04-20T14:43:38.507Z" },
-    { url = "https://files.pythonhosted.org/packages/31/75/c1ee7cb5b2277fe1f95837a58fb692eeda7162494fc1ddccb5f23be1d7f6/pydantic_core-2.46.3-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:fa3eb7c2995aa443687a825bc30395c8521b7c6ec201966e55debfd1128bcceb", size = 2112012, upload-time = "2026-04-20T14:44:35.697Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/da/fb883281703dc5f4d68cdc648c503c46c8af5726f428013178d657c75181/pydantic_core-2.46.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3d08782c4045f90724b44c95d35ebec0d67edb8a957a2ac81d5a8e4b8a200495", size = 1953006, upload-time = "2026-04-20T14:43:33.878Z" },
-    { url = "https://files.pythonhosted.org/packages/92/47/5d7d7d04204920771086d768ca51306e34b63a31ad80a5f82c9d38dea568/pydantic_core-2.46.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:831eb19aa789a97356979e94c981e5667759301fb708d1c0d5adf1bc0098b873", size = 1980050, upload-time = "2026-04-20T14:41:03.154Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/e9/1c52019dd95babcff1bffe40022e8541c0447b8e4a44596a979c7309fa0c/pydantic_core-2.46.3-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4335e87c7afa436a0dfa899e138d57a72f8aad542e2cf19c36fb428461caabd0", size = 2057165, upload-time = "2026-04-20T14:43:44.507Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/0e/e0aac1f35baf80ff8f35d4fa58d85dce248324a764d950460cf5c0569758/pydantic_core-2.46.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:99421e7684a60f7f3550a1d159ade5fdff1954baedb6bdd407cba6a307c9f27d", size = 2225133, upload-time = "2026-04-20T14:41:07.334Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/df/8eb296b9661574ef26e990856991615c1e1fb1744a10b896bff684a3c99a/pydantic_core-2.46.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dd81f6907932ebac3abbe41378dac64b2380db1287e2aa64d8d88f78d170f51a", size = 2282409, upload-time = "2026-04-20T14:43:07.567Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/07/888c53b769be71072a1dbd741ec25160579d789ef276fd5bd2045a07b09a/pydantic_core-2.46.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f247596366f4221af52beddd65af1218797771d6989bc891a0b86ccaa019168", size = 2095775, upload-time = "2026-04-20T14:42:21.586Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/19/6c32bdb93362b899bf92ac42c824898ab93dd8a23f339cbf5c5098ef61a6/pydantic_core-2.46.3-cp39-cp39-manylinux_2_31_riscv64.whl", hash = "sha256:6dff8cc884679df229ebc6d8eb2321ea6f8e091bc7d4886d4dc2e0e71452843c", size = 2118999, upload-time = "2026-04-20T14:44:43.791Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/c6/31d926d003f59a032ff61b62990e378f0fb985aa9d77fd448a6140f7eb5f/pydantic_core-2.46.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:68ef2f623dda6d5a9067ac014e406c020c780b2a358930a7e5c1b73702900720", size = 2162368, upload-time = "2026-04-20T14:41:12.529Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/a1/48d669051947845ff54f5b7cb6254ccafb23aa284184de6f273145d0e45b/pydantic_core-2.46.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:d56bdb4af1767cc15b0386b3c581fdfe659bb9ee4a4f776e92c1cd9d074000d6", size = 2184786, upload-time = "2026-04-20T14:42:40.235Z" },
-    { url = "https://files.pythonhosted.org/packages/08/ff/a722cade3d4bd8ed6433a8e84eddf2f993b5fb4a47cade269289cfb4cc0c/pydantic_core-2.46.3-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:91249bcb7c165c2fb2a2f852dbc5c91636e2e218e75d96dfdd517e4078e173dd", size = 2325626, upload-time = "2026-04-20T14:41:37.73Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/8a/238e33805d6f3691bcce8739db7d0376a2388e1b3f2c8db2128f6683fc78/pydantic_core-2.46.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4b068543bdb707f5d935dab765d99227aa2545ef2820935f2e5dd801795c7dbd", size = 2363286, upload-time = "2026-04-20T14:42:29.385Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/2e/ab044f4431798a565242d5e8e48d080faa931f45e3d30df62e4f501d9bb0/pydantic_core-2.46.3-cp39-cp39-win32.whl", hash = "sha256:dcda6583921c05a40533f982321532f2d8db29326c7b95c4026941fa5074bd79", size = 1981660, upload-time = "2026-04-20T14:43:54.525Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/2c/13855786276f51fe86915c0533f4fc14e1d5421726ba8ad57caa09eb18ec/pydantic_core-2.46.3-cp39-cp39-win_amd64.whl", hash = "sha256:a35cc284c8dd7edae8a31533713b4d2467dfe7c4f1b5587dd4031f28f90d1d13", size = 2078793, upload-time = "2026-04-20T14:42:17.87Z" },
     { url = "https://files.pythonhosted.org/packages/66/7f/03dbad45cd3aa9083fbc93c210ae8b005af67e4136a14186950a747c6874/pydantic_core-2.46.3-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:9715525891ed524a0a1eb6d053c74d4d4ad5017677fb00af0b7c2644a31bae46", size = 2105683, upload-time = "2026-04-20T14:42:19.779Z" },
     { url = "https://files.pythonhosted.org/packages/26/22/4dc186ac8ea6b257e9855031f51b62a9637beac4d68ac06bee02f046f836/pydantic_core-2.46.3-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:9d2f400712a99a013aff420ef1eb9be077f8189a36c1e3ef87660b4e1088a874", size = 1940052, upload-time = "2026-04-20T14:43:59.274Z" },
     { url = "https://files.pythonhosted.org/packages/0d/ca/d376391a5aff1f2e8188960d7873543608130a870961c2b6b5236627c116/pydantic_core-2.46.3-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd2aab0e2e9dc2daf36bd2686c982535d5e7b1d930a1344a7bb6e82baab42a76", size = 1988172, upload-time = "2026-04-20T14:41:17.469Z" },
@@ -724,13 +526,10 @@ version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
     { name = "pygments" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
@@ -772,7 +571,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -780,23 +579,22 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]
 name = "rich"
-version = "14.3.3"
+version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]
@@ -854,77 +652,18 @@ name = "spidev"
 version = "3.8"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/67/87/039b6eeea781598015b538691bc174cc0bf77df9d4d2d3b8bf9245c0de8c/spidev-3.8.tar.gz", hash = "sha256:2bc02fb8c6312d519ebf1f4331067427c0921d3f77b8bcaf05189a2e8b8382c0", size = 13893, upload-time = "2025-09-15T18:56:20.672Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/b0/071fd633b4cb08353d6e6d494cef8bdb1e4eee2a2764d2d347b25551333d/spidev-3.8-cp39-cp39-linux_armv7l.whl", hash = "sha256:07d0da112ca944df41f080811bb123b910df63bb38b66712289bc4fd9d682185", size = 41223, upload-time = "2025-09-15T18:56:19.793Z" },
-]
 
 [[package]]
 name = "starlette"
-version = "0.49.3"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
 dependencies = [
-    { name = "anyio", marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/1a/608df0b10b53b0beb96a37854ee05864d182ddd4b1156a22f1ad3860425a/starlette-0.49.3.tar.gz", hash = "sha256:1c14546f299b5901a1ea0e34410575bc33bbd741377a10484a54445588d00284", size = 2655031, upload-time = "2025-11-01T15:12:26.13Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/e0/021c772d6a662f43b63044ab481dc6ac7592447605b5b35a957785363122/starlette-0.49.3-py3-none-any.whl", hash = "sha256:b579b99715fdc2980cf88c8ec96d3bf1ce16f5a8051a7c2b84ef9b1cdecaea2f", size = 74340, upload-time = "2025-11-01T15:12:24.387Z" },
-]
-
-[[package]]
-name = "starlette"
-version = "0.50.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version >= '3.10' and python_full_version < '3.13'",
-]
-dependencies = [
-    { name = "anyio", marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
-]
-
-[[package]]
-name = "tomli"
-version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/30/31573e9457673ab10aa432461bee537ce6cef177667deca369efb79df071/tomli-2.4.0.tar.gz", hash = "sha256:aa89c3f6c277dd275d8e243ad24f3b5e701491a860d5121f2cdd399fbb31fc9c", size = 17477, upload-time = "2026-01-11T11:22:38.165Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/d9/3dc2289e1f3b32eb19b9785b6a006b28ee99acb37d1d47f78d4c10e28bf8/tomli-2.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b5ef256a3fd497d4973c11bf142e9ed78b150d36f5773f1ca6088c230ffc5867", size = 153663, upload-time = "2026-01-11T11:21:45.27Z" },
-    { url = "https://files.pythonhosted.org/packages/51/32/ef9f6845e6b9ca392cd3f64f9ec185cc6f09f0a2df3db08cbe8809d1d435/tomli-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5572e41282d5268eb09a697c89a7bee84fae66511f87533a6f88bd2f7b652da9", size = 148469, upload-time = "2026-01-11T11:21:46.873Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/c2/506e44cce89a8b1b1e047d64bd495c22c9f71f21e05f380f1a950dd9c217/tomli-2.4.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:551e321c6ba03b55676970b47cb1b73f14a0a4dce6a3e1a9458fd6d921d72e95", size = 236039, upload-time = "2026-01-11T11:21:48.503Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/40/e1b65986dbc861b7e986e8ec394598187fa8aee85b1650b01dd925ca0be8/tomli-2.4.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e3f639a7a8f10069d0e15408c0b96a2a828cfdec6fca05296ebcdcc28ca7c76", size = 243007, upload-time = "2026-01-11T11:21:49.456Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/6f/6e39ce66b58a5b7ae572a0f4352ff40c71e8573633deda43f6a379d56b3e/tomli-2.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1b168f2731796b045128c45982d3a4874057626da0e2ef1fdd722848b741361d", size = 240875, upload-time = "2026-01-11T11:21:50.755Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/ad/cb089cb190487caa80204d503c7fd0f4d443f90b95cf4ef5cf5aa0f439b0/tomli-2.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:133e93646ec4300d651839d382d63edff11d8978be23da4cc106f5a18b7d0576", size = 246271, upload-time = "2026-01-11T11:21:51.81Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/63/69125220e47fd7a3a27fd0de0c6398c89432fec41bc739823bcc66506af6/tomli-2.4.0-cp311-cp311-win32.whl", hash = "sha256:b6c78bdf37764092d369722d9946cb65b8767bfa4110f902a1b2542d8d173c8a", size = 96770, upload-time = "2026-01-11T11:21:52.647Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/0d/a22bb6c83f83386b0008425a6cd1fa1c14b5f3dd4bad05e98cf3dbbf4a64/tomli-2.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:d3d1654e11d724760cdb37a3d7691f0be9db5fbdaef59c9f532aabf87006dbaa", size = 107626, upload-time = "2026-01-11T11:21:53.459Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/6d/77be674a3485e75cacbf2ddba2b146911477bd887dda9d8c9dfb2f15e871/tomli-2.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:cae9c19ed12d4e8f3ebf46d1a75090e4c0dc16271c5bce1c833ac168f08fb614", size = 94842, upload-time = "2026-01-11T11:21:54.831Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/43/7389a1869f2f26dba52404e1ef13b4784b6b37dac93bac53457e3ff24ca3/tomli-2.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:920b1de295e72887bafa3ad9f7a792f811847d57ea6b1215154030cf131f16b1", size = 154894, upload-time = "2026-01-11T11:21:56.07Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/05/2f9bf110b5294132b2edf13fe6ca6ae456204f3d749f623307cbb7a946f2/tomli-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7d6d9a4aee98fac3eab4952ad1d73aee87359452d1c086b5ceb43ed02ddb16b8", size = 149053, upload-time = "2026-01-11T11:21:57.467Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/41/1eda3ca1abc6f6154a8db4d714a4d35c4ad90adc0bcf700657291593fbf3/tomli-2.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:36b9d05b51e65b254ea6c2585b59d2c4cb91c8a3d91d0ed0f17591a29aaea54a", size = 243481, upload-time = "2026-01-11T11:21:58.661Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/6d/02ff5ab6c8868b41e7d4b987ce2b5f6a51d3335a70aa144edd999e055a01/tomli-2.4.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c8a885b370751837c029ef9bc014f27d80840e48bac415f3412e6593bbc18c1", size = 251720, upload-time = "2026-01-11T11:22:00.178Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/57/0405c59a909c45d5b6f146107c6d997825aa87568b042042f7a9c0afed34/tomli-2.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8768715ffc41f0008abe25d808c20c3d990f42b6e2e58305d5da280ae7d1fa3b", size = 247014, upload-time = "2026-01-11T11:22:01.238Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/0e/2e37568edd944b4165735687cbaf2fe3648129e440c26d02223672ee0630/tomli-2.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7b438885858efd5be02a9a133caf5812b8776ee0c969fea02c45e8e3f296ba51", size = 251820, upload-time = "2026-01-11T11:22:02.727Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/1c/ee3b707fdac82aeeb92d1a113f803cf6d0f37bdca0849cb489553e1f417a/tomli-2.4.0-cp312-cp312-win32.whl", hash = "sha256:0408e3de5ec77cc7f81960c362543cbbd91ef883e3138e81b729fc3eea5b9729", size = 97712, upload-time = "2026-01-11T11:22:03.777Z" },
-    { url = "https://files.pythonhosted.org/packages/69/13/c07a9177d0b3bab7913299b9278845fc6eaaca14a02667c6be0b0a2270c8/tomli-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:685306e2cc7da35be4ee914fd34ab801a6acacb061b6a7abca922aaf9ad368da", size = 108296, upload-time = "2026-01-11T11:22:04.86Z" },
-    { url = "https://files.pythonhosted.org/packages/18/27/e267a60bbeeee343bcc279bb9e8fbed0cbe224bc7b2a3dc2975f22809a09/tomli-2.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:5aa48d7c2356055feef06a43611fc401a07337d5b006be13a30f6c58f869e3c3", size = 94553, upload-time = "2026-01-11T11:22:05.854Z" },
-    { url = "https://files.pythonhosted.org/packages/34/91/7f65f9809f2936e1f4ce6268ae1903074563603b2a2bd969ebbda802744f/tomli-2.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:84d081fbc252d1b6a982e1870660e7330fb8f90f676f6e78b052ad4e64714bf0", size = 154915, upload-time = "2026-01-11T11:22:06.703Z" },
-    { url = "https://files.pythonhosted.org/packages/20/aa/64dd73a5a849c2e8f216b755599c511badde80e91e9bc2271baa7b2cdbb1/tomli-2.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9a08144fa4cba33db5255f9b74f0b89888622109bd2776148f2597447f92a94e", size = 149038, upload-time = "2026-01-11T11:22:07.56Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/8a/6d38870bd3d52c8d1505ce054469a73f73a0fe62c0eaf5dddf61447e32fa/tomli-2.4.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c73add4bb52a206fd0c0723432db123c0c75c280cbd67174dd9d2db228ebb1b4", size = 242245, upload-time = "2026-01-11T11:22:08.344Z" },
-    { url = "https://files.pythonhosted.org/packages/59/bb/8002fadefb64ab2669e5b977df3f5e444febea60e717e755b38bb7c41029/tomli-2.4.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fb2945cbe303b1419e2706e711b7113da57b7db31ee378d08712d678a34e51e", size = 250335, upload-time = "2026-01-11T11:22:09.951Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/3d/4cdb6f791682b2ea916af2de96121b3cb1284d7c203d97d92d6003e91c8d/tomli-2.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bbb1b10aa643d973366dc2cb1ad94f99c1726a02343d43cbc011edbfac579e7c", size = 245962, upload-time = "2026-01-11T11:22:11.27Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/4a/5f25789f9a460bd858ba9756ff52d0830d825b458e13f754952dd15fb7bb/tomli-2.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4cbcb367d44a1f0c2be408758b43e1ffb5308abe0ea222897d6bfc8e8281ef2f", size = 250396, upload-time = "2026-01-11T11:22:12.325Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/2f/b73a36fea58dfa08e8b3a268750e6853a6aac2a349241a905ebd86f3047a/tomli-2.4.0-cp313-cp313-win32.whl", hash = "sha256:7d49c66a7d5e56ac959cb6fc583aff0651094ec071ba9ad43df785abc2320d86", size = 97530, upload-time = "2026-01-11T11:22:13.865Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/af/ca18c134b5d75de7e8dc551c5234eaba2e8e951f6b30139599b53de9c187/tomli-2.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:3cf226acb51d8f1c394c1b310e0e0e61fecdd7adcb78d01e294ac297dd2e7f87", size = 108227, upload-time = "2026-01-11T11:22:15.224Z" },
-    { url = "https://files.pythonhosted.org/packages/22/c3/b386b832f209fee8073c8138ec50f27b4460db2fdae9ffe022df89a57f9b/tomli-2.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:d20b797a5c1ad80c516e41bc1fb0443ddb5006e9aaa7bda2d71978346aeb9132", size = 94748, upload-time = "2026-01-11T11:22:16.009Z" },
-    { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
 ]
 
 [[package]]
@@ -953,35 +692,13 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.23.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "annotated-doc", marker = "python_full_version < '3.10'" },
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "rich", marker = "python_full_version < '3.10'" },
-    { name = "shellingham", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d3/ae/93d16574e66dfe4c2284ffdaca4b0320ade32858cb2cc586c8dd79f127c5/typer-0.23.2.tar.gz", hash = "sha256:a99706a08e54f1aef8bb6a8611503808188a4092808e86addff1828a208af0de", size = 120162, upload-time = "2026-02-16T18:52:40.354Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/2c/dee705c427875402200fe779eb8a3c00ccb349471172c41178336e9599cc/typer-0.23.2-py3-none-any.whl", hash = "sha256:e9c8dc380f82450b3c851a9b9d5a0edf95d1d6456ae70c517d8b06a50c7a9978", size = 56834, upload-time = "2026-02-16T18:52:39.308Z" },
-]
-
-[[package]]
-name = "typer"
 version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version >= '3.10' and python_full_version < '3.13'",
-]
 dependencies = [
-    { name = "annotated-doc", marker = "python_full_version >= '3.10'" },
-    { name = "click", version = "8.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "rich", marker = "python_full_version >= '3.10'" },
-    { name = "shellingham", marker = "python_full_version >= '3.10'" },
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
@@ -1020,33 +737,11 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.39.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "h11", marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/4f/f9fdac7cf6dd79790eb165639b5c452ceeabc7bbabbba4569155470a287d/uvicorn-0.39.0.tar.gz", hash = "sha256:610512b19baa93423d2892d7823741f6d27717b642c8964000d7194dded19302", size = 82001, upload-time = "2025-12-21T13:05:17.973Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/25/db2b1c6c35bf22e17fe5412d2ee5d3fd7a20d07ebc9dac8b58f7db2e23a0/uvicorn-0.39.0-py3-none-any.whl", hash = "sha256:7beec21bd2693562b386285b188a7963b06853c0d006302b3e4cfed950c9929a", size = 68491, upload-time = "2025-12-21T13:05:16.291Z" },
-]
-
-[[package]]
-name = "uvicorn"
 version = "0.41.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version >= '3.10' and python_full_version < '3.13'",
-]
 dependencies = [
-    { name = "click", version = "8.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "h11", marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.10.*'" },
+    { name = "click" },
+    { name = "h11" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
 wheels = [


### PR DESCRIPTION
Closes #232 

## What changed

_not in order:_

**breaking changes**
- jukebox is no longer supported for Python 3.9 and Python 3.10 
- bump minimum Python version to 3.11

**chore**
- drop specific dependencies for Python<3.11
- bump dev dependencies
- fix target-version configuration to 3.11 (it was 3.13)
- remove Python<3.10 type-checking workaround
- enable all Ruff UP rules
- bump python-multipart to 0.0.26 (security update) ; add a test to document the need for this dependency 

**feat**
- add support PEP 604 unions (X | None) in _strip_none

**refactor**
- modernize codebase for Python 3.11 (ruff fixes: `uv run ruff check --select UP --fix`)
- modernize codebase for Python 3.11 (ruff unsafe fixes: `uv run ruff check --select UP --fix --unsafe-fixes`)
- modernize codebase for Python 3.11 (manual fixes)
- drop test_module_import_failure since there are no longer any exceptions for older versions of Python
- use FASTUI_INSTALLED flag to mirror FASTAPI_INSTALLED
- remove skip for Python<3.11 in tests
- adopt match/case syntax
- replace typing patterns with TypeAlias and Self
- remove __future__.annotations import

**others**
- add Python compatibility matrix
- remove the note regarding Python 3.9-specific syntax from the AI agent documentation
- fix two ty errors


## Notes 

Happy to split it into several pull requests.

Some changes aren't very useful, such as the use of the `match case` syntax; we can remove them for now to avoid introducing bugs (even though all the tests pass).
