### PR TITLE
🐛 Fix UPnP error masked by logging TypeError in Sonos adapter

### DIFF
--- a/discstore/adapters/inbound/cli_controller.py
+++ b/discstore/adapters/inbound/cli_controller.py
@@ -60,7 +60,7 @@ class CLIController:
         elif isinstance(command, CliSearchCommand):
             self.search_discs_flow(command)
         else:
-            LOGGER.error(f"Command not implemented yet: command='{command}'")
+            LOGGER.error("Command not implemented yet: command='%s'", command)
 
     def add_disc_flow(self, command: CliAddCommand) -> None:
         tag = self.resolve_tag_id.execute(command.tag, command.use_current_tag)
@@ -79,7 +79,7 @@ class CLIController:
         if command.mode == "line":
             display_library_line(discs)
             return
-        LOGGER.error(f"Displaying mode not implemented yet: mode='{command.mode}'")
+        LOGGER.error("Displaying mode not implemented yet: mode='%s'", command.mode)
 
     def remove_disc_flow(self, command: CliRemoveCommand) -> None:
         tag = self.resolve_tag_id.execute(command.tag, command.use_current_tag)
@@ -122,7 +122,7 @@ class CLIController:
     def search_discs_flow(self, command: CliSearchCommand) -> None:
         results = self.search_discs.execute(command.query)
         if not results:
-            LOGGER.info(f"No discs found matching '{command.query}'")
+            LOGGER.info("No discs found matching '%s'", command.query)
             return
-        LOGGER.info(f"Found {len(results)} disc(s) matching '{command.query}':")
+        LOGGER.info("Found %d disc(s) matching '%s':", len(results), command.query)
         display_library_table(results)

--- a/jukebox/adapters/outbound/json_library_adapter.py
+++ b/jukebox/adapters/outbound/json_library_adapter.py
@@ -27,11 +27,13 @@ class JsonLibraryAdapter(LibraryRepository):
                 data = json.load(f)
                 return Library.model_validate(data)
         except FileNotFoundError:
-            LOGGER.warning(f"No library file found, starting with an empty library: {self.filepath}")
+            LOGGER.warning("No library file found, starting with an empty library: %s", self.filepath)
             return Library()
         except (json.JSONDecodeError, ValidationError) as err:
             LOGGER.warning(
-                f"Error deserializing library, continuing with empty library: filepath: {self.filepath}, error: {err}"
+                "Error deserializing library, continuing with empty library: filepath: %s, error: %s",
+                self.filepath,
+                err,
             )
             return Library()
 

--- a/jukebox/adapters/outbound/players/dryrun_player_adapter.py
+++ b/jukebox/adapters/outbound/players/dryrun_player_adapter.py
@@ -9,7 +9,7 @@ class DryrunPlayerAdapter(PlayerPort):
     """Adapter for dryrun player implementing PlayerPort."""
 
     def play(self, uri: str, shuffle: bool = False) -> None:
-        LOGGER.info(f"Dryrun: Playing `{uri}` with shuffle={shuffle}")
+        LOGGER.info("Dryrun: Playing `%s` with shuffle=%s", uri, shuffle)
 
     def pause(self) -> None:
         LOGGER.info("Dryrun: Pausing")

--- a/jukebox/adapters/outbound/players/sonos_player_adapter.py
+++ b/jukebox/adapters/outbound/players/sonos_player_adapter.py
@@ -21,13 +21,16 @@ def catch_soco_upnp_exception(func):
             return func(*args, **kwargs)
         except SoCoUPnPException as err:
             if "UPnP Error 804" in str(err.message):
-                LOGGER.warning(f"{func.__name__} with `{args}` failed, probably a bad uri: {str(err.message)}")
+                LOGGER.warning("%s with `%s` failed, probably a bad uri: %s", func.__name__, args, err.message)
             elif "UPnP Error 701" in str(err.message):
                 LOGGER.warning(
-                    f"{func.__name__} with `{args}` failed, probably a not available transition: {str(err.message)}"
+                    "%s with `%s` failed, probably a not available transition: %s",
+                    func.__name__,
+                    args,
+                    err.message,
                 )
             else:
-                LOGGER.exception(f"{func.__name__} with `{args}` failed: {str(err)}")
+                LOGGER.exception("%s with `%s` failed: %s", func.__name__, args, str(err))
             return
 
     return wrapper
@@ -59,7 +62,9 @@ class SonosPlayerAdapter(PlayerPort):
             raise InvalidSettingsError(f"Failed to initialize Sonos player: {err}") from err
 
         LOGGER.info(
-            f"Found `{self.speaker.player_name}` with software version: {speaker_info.get('software_version', None)}"
+            "Found `%s` with software version: %s",
+            self.speaker.player_name,
+            speaker_info.get("software_version", None),
         )
         self.sharelink = ShareLinkPlugin(self.speaker)
 
@@ -69,13 +74,14 @@ class SonosPlayerAdapter(PlayerPort):
         if not discovered:
             raise RuntimeError("No Sonos speakers found on the network")
         speakers = sorted(discovered, key=lambda s: s.player_name)
-        LOGGER.info(f"Discovered {len(speakers)} Sonos speaker(s): {[s.player_name for s in speakers]}")
+        LOGGER.info("Discovered %d Sonos speaker(s): %s", len(speakers), [s.player_name for s in speakers])
         if name:
             matching = [s for s in speakers if s.player_name == name]
             if len(matching) > 1:
                 LOGGER.warning(
-                    f"Multiple Sonos speakers with name '{name}' found. Using first match. "
-                    "Consider using host IP to disambiguate."
+                    "Multiple Sonos speakers with name '%s' found. Using first match. "
+                    "Consider using host IP to disambiguate.",
+                    name,
                 )
             if matching:
                 return matching[0]
@@ -89,7 +95,7 @@ class SonosPlayerAdapter(PlayerPort):
         applied_operations = []
 
         if group.is_partial:
-            LOGGER.warning(f"Applying Sonos group best-effort with missing saved members: {group.missing_member_uids}")
+            LOGGER.warning("Applying Sonos group best-effort with missing saved members: %s", group.missing_member_uids)
 
         try:
             for member in group.members:
@@ -102,7 +108,9 @@ class SonosPlayerAdapter(PlayerPort):
 
                 rollback_coordinator = self._get_rollback_coordinator_for_join(speaker)
                 LOGGER.info(
-                    f"Joining Sonos speaker `{speaker.player_name}` to `{coordinator.player_name}` before playback"
+                    "Joining Sonos speaker `%s` to `%s` before playback",
+                    speaker.player_name,
+                    coordinator.player_name,
                 )
                 speaker.join(coordinator)
                 applied_operations.append(("join", speaker, rollback_coordinator))
@@ -114,7 +122,8 @@ class SonosPlayerAdapter(PlayerPort):
                         continue
 
                     LOGGER.info(
-                        f"Removing Sonos speaker `{current_member.player_name}` from coordinator group before playback"
+                        "Removing Sonos speaker `%s` from coordinator group before playback",
+                        current_member.player_name,
                     )
                     current_member.unjoin()
                     applied_operations.append(("unjoin", current_member, None))
@@ -127,7 +136,8 @@ class SonosPlayerAdapter(PlayerPort):
             try:
                 if operation == "join":
                     LOGGER.warning(
-                        f"Rolling back Sonos join for `{speaker.player_name}` after startup group enforcement failed"
+                        "Rolling back Sonos join for `%s` after startup group enforcement failed",
+                        speaker.player_name,
                     )
                     if rollback_target is None:
                         speaker.unjoin()
@@ -135,12 +145,16 @@ class SonosPlayerAdapter(PlayerPort):
                         speaker.join(rollback_target)
                 else:
                     LOGGER.warning(
-                        f"Rolling back Sonos removal for `{speaker.player_name}` after startup group enforcement failed"
+                        "Rolling back Sonos removal for `%s` after startup group enforcement failed",
+                        speaker.player_name,
                     )
                     speaker.join(coordinator)
             except Exception as err:
                 LOGGER.warning(
-                    f"Failed to roll back Sonos group change `{operation}` for `{speaker.player_name}`: {err}"
+                    "Failed to roll back Sonos group change `%s` for `%s`: %s",
+                    operation,
+                    speaker.player_name,
+                    err,
                 )
 
     @staticmethod
@@ -173,7 +187,7 @@ class SonosPlayerAdapter(PlayerPort):
 
     @catch_soco_upnp_exception
     def play(self, uri: str, shuffle: bool = False) -> None:
-        LOGGER.info(f"Playing `{uri}` on the player `{self.speaker.player_name}`")
+        LOGGER.info("Playing `%s` on the player `%s`", uri, self.speaker.player_name)
         self.speaker.clear_queue()
         _ = self.handle_uri(uri)
         self.speaker.play_mode = "SHUFFLE_NOREPEAT" if shuffle else "NORMAL"
@@ -181,17 +195,17 @@ class SonosPlayerAdapter(PlayerPort):
 
     @catch_soco_upnp_exception
     def pause(self) -> None:
-        LOGGER.info(f"Pausing player `{self.speaker.player_name}`")
+        LOGGER.info("Pausing player `%s`", self.speaker.player_name)
         self.speaker.pause()
 
     @catch_soco_upnp_exception
     def resume(self) -> None:
-        LOGGER.info(f"Resuming player `{self.speaker.player_name}`")
+        LOGGER.info("Resuming player `%s`", self.speaker.player_name)
         self.speaker.play()
 
     @catch_soco_upnp_exception
     def stop(self) -> None:
-        LOGGER.info(f"Stopping player `{self.speaker.player_name}` and clearing its queue")
+        LOGGER.info("Stopping player `%s` and clearing its queue", self.speaker.player_name)
         self.speaker.clear_queue()
 
     def handle_uri(self, uri):

--- a/jukebox/adapters/outbound/players/sonos_player_adapter.py
+++ b/jukebox/adapters/outbound/players/sonos_player_adapter.py
@@ -27,7 +27,7 @@ def catch_soco_upnp_exception(func):
                     f"{func.__name__} with `{args}` failed, probably a not available transition: {str(err.message)}"
                 )
             else:
-                LOGGER.error(f"{func.__name__} with `{args}` failed", err)
+                LOGGER.exception(f"{func.__name__} with `{args}` failed: {str(err)}")
             return
 
     return wrapper

--- a/jukebox/adapters/outbound/readers/dryrun_reader_adapter.py
+++ b/jukebox/adapters/outbound/readers/dryrun_reader_adapter.py
@@ -20,7 +20,7 @@ class DryrunReaderAdapter(ReaderPort):
 
     def read(self) -> Union[str, None]:
         if self.uid is not None and self.hold_until is not None and time.monotonic() < self.hold_until:
-            LOGGER.info(f"Reading tag {self.uid}")
+            LOGGER.info("Reading tag %s", self.uid)
             return self.uid
 
         self.uid = None
@@ -47,8 +47,9 @@ class DryrunReaderAdapter(ReaderPort):
                 self.hold_until = time.monotonic() + duration_seconds
             except ValueError:
                 LOGGER.warning(
-                    f"Duration parameter should be a non-negative number of seconds, received: `{commands[1]}`"
+                    "Duration parameter should be a non-negative number of seconds, received: `%s`",
+                    commands[1],
                 )
             return self.uid
-        LOGGER.warning(f"Invalid input, should be `tag_uid duration_seconds`, received: {commands}")
+        LOGGER.warning("Invalid input, should be `tag_uid duration_seconds`, received: %s", commands)
         return None

--- a/jukebox/adapters/outbound/readers/pn532_reader_adapter.py
+++ b/jukebox/adapters/outbound/readers/pn532_reader_adapter.py
@@ -46,7 +46,7 @@ class Pn532ReaderAdapter(ReaderPort):
         self.pn532 = PN532_SPI(debug=False, reset=spi_reset, cs=spi_cs, irq=spi_irq)
         self.read_timeout_seconds = read_timeout_seconds
         ic, ver, rev, support = self.pn532.get_firmware_version()
-        LOGGER.info(f"Found PN532 with firmware version: {ver}.{rev}")
+        LOGGER.info("Found PN532 with firmware version: %s.%s", ver, rev)
         self._firmware_version: tuple[int, int] = (ver, rev)
         self.pn532.SAM_configuration()
 

--- a/jukebox/adapters/outbound/text_current_tag_adapter.py
+++ b/jukebox/adapters/outbound/text_current_tag_adapter.py
@@ -56,7 +56,7 @@ class TextCurrentTagAdapter(CurrentTagRepository):
         except FileNotFoundError:
             return None
         except OSError as err:
-            LOGGER.warning(f"Error reading current tag state: filepath: {self.filepath}, error: {err}")
+            LOGGER.warning("Error reading current tag state: filepath: %s, error: %s", self.filepath, err)
             return None
 
         if not tag_id:

--- a/jukebox/domain/use_cases/handle_tag_event.py
+++ b/jukebox/domain/use_cases/handle_tag_event.py
@@ -31,8 +31,12 @@ class HandleTagEvent:
         action = self.determine_action.execute(tag_event, session)
 
         LOGGER.debug(
-            f"{action.value} \t\t {tag_event.tag_id} | {session.playing_tag} | "
-            f"{session.paused_at} | {session.playing_tag_removed_at}"
+            "%s \t\t %s | %s | %s | %s",
+            action.value,
+            tag_event.tag_id,
+            session.playing_tag,
+            session.paused_at,
+            session.playing_tag_removed_at,
         )
 
         if action == PlaybackAction.CONTINUE:
@@ -45,24 +49,24 @@ class HandleTagEvent:
             session.playing_tag_removed_at = None
 
         elif action == PlaybackAction.PLAY:
-            LOGGER.info(f"Found card with UID: {tag_event.tag_id}")
+            LOGGER.info("Found card with UID: %s", tag_event.tag_id)
 
             disc = self.library.get_disc(tag_event.tag_id) if tag_event.tag_id is not None else None
             if disc is not None:
-                LOGGER.info(f"Found corresponding disc: {disc}")
+                LOGGER.info("Found corresponding disc: %s", disc)
                 session.playing_tag = tag_event.tag_id
                 self.player.play(disc.uri, disc.option.shuffle)
                 session.paused_at = None
                 session.playing_tag_removed_at = None
             else:
-                LOGGER.warning(f"No disc found for UID: {tag_event.tag_id}")
+                LOGGER.warning("No disc found for UID: %s", tag_event.tag_id)
 
         elif action == PlaybackAction.WAITING:
             # Grace period - tag removed but not pausing yet
             if session.playing_tag_removed_at is None:
                 session.playing_tag_removed_at = tag_event.timestamp
             grace_period_elapsed = tag_event.timestamp - session.playing_tag_removed_at
-            LOGGER.debug(f"Grace period: {grace_period_elapsed:.3f}s / {self.determine_action.pause_delay:g}s")
+            LOGGER.debug("Grace period: %.3fs / %gs", grace_period_elapsed, self.determine_action.pause_delay)
 
         elif action == PlaybackAction.PAUSE:
             self.player.pause()
@@ -78,7 +82,7 @@ class HandleTagEvent:
             pass
 
         else:
-            LOGGER.warning(f"`{action.value}` action is not implemented yet")
+            LOGGER.warning("`%s` action is not implemented yet", action.value)
 
         session.last_event_timestamp = tag_event.timestamp
         return session
@@ -89,7 +93,9 @@ class HandleTagEvent:
             self._apply_current_tag_action(action, tag_event, session)
         except Exception as err:
             LOGGER.warning(
-                f"Failed to sync current tag state; continuing tag handling: tag_id={tag_event.tag_id!r}, error={err}"
+                "Failed to sync current tag state; continuing tag handling: tag_id=%r, error=%s",
+                tag_event.tag_id,
+                err,
             )
 
     def _apply_current_tag_action(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ extend-select = [
     "SIM",
     "I",
     "UP032",
+    "G",
 ]
 
 [tool.ty.src]


### PR DESCRIPTION
Closes #237 

## Context 
When attempting to play a Spotify URI on a Sonos player, the actual error (likely due to an invalid or unsupported URI) is hidden by a secondary logging error.

This results in misleading logs and makes debugging difficult.

## What changed

- Fixed the logging issue that was hiding the original error
- Enabled Ruff’s G rule set, including [rule G004](https://docs.astral.sh/ruff/rules/logging-f-string/), to prevent the use of f-strings in logging statements

## Test 

```
pi@raspberrypi:~/developer/jukebox $ uv run jukebox
[…]
2026-04-25 17:30:59,148 - jukebox - INFO         - Playing `spotify:playlist:xxxxxxxxxxxxxxxxxx` on the player `Coin détente`
2026-04-25 17:30:59,467 - jukebox - ERROR        - play with `(<jukebox.adapters.outbound.players.sonos_player_adapter.SonosPlayerAdapter object at 0x7f95da9410>, 'spotify:playlist:xxxxxxxxxxxxxxxxxx', False)` failed: UPnP Error 800 received:  from 192.168.1.19
Traceback (most recent call last):
  File "/home/pi/developer/jukebox/jukebox/adapters/outbound/players/sonos_player_adapter.py", line 21, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/developer/jukebox/jukebox/adapters/outbound/players/sonos_player_adapter.py", line 192, in play
    _ = self.handle_uri(uri)
        ^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/developer/jukebox/jukebox/adapters/outbound/players/sonos_player_adapter.py", line 213, in handle_uri
    return self.sharelink.add_share_link_to_queue(uri, position=1)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/developer/jukebox/.venv/lib/python3.11/site-packages/soco/plugins/sharelink.py", line 285, in add_share_link_to_queue
    raise fault
  File "/home/pi/developer/jukebox/.venv/lib/python3.11/site-packages/soco/plugins/sharelink.py", line 267, in add_share_link_to_queue
    response = self.soco.avTransport.AddURIToQueue(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/developer/jukebox/.venv/lib/python3.11/site-packages/soco/services.py", line 208, in _dispatcher
    return self.send_command(action, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/developer/jukebox/.venv/lib/python3.11/site-packages/soco/services.py", line 519, in send_command
    self.handle_upnp_error(response.text)
  File "/home/pi/developer/jukebox/.venv/lib/python3.11/site-packages/soco/services.py", line 575, in handle_upnp_error
    raise SoCoUPnPException(
soco.exceptions.SoCoUPnPException: UPnP Error 800 received:  from 192.168.1.19
```