### PR TITLE
🐛 Fix AttributeError on Sonos UI panel by calling list_network_speakers

### DIFF
--- a/discstore/adapters/inbound/ui_controller.py
+++ b/discstore/adapters/inbound/ui_controller.py
@@ -366,7 +366,7 @@ class UIController(APIController):
             return message
 
         try:
-            speakers = self.sonos_service.list_available_speakers()
+            speakers = self.sonos_service.list_network_speakers()
         except Exception:
             return message
 

--- a/discstore/adapters/inbound/ui_pages/sonos.py
+++ b/discstore/adapters/inbound/ui_pages/sonos.py
@@ -80,7 +80,7 @@ class SonosUIPageBuilder:
                 selected_group_repository=SettingsSelectedSonosGroupRepository(self.settings_service),
                 sonos_service=self.sonos_service,
             ).execute()
-            speakers = self.sonos_service.list_available_speakers()
+            speakers = self.sonos_service.list_network_speakers()
         except SonosDiscoveryError as err:
             discovery_error = str(err)
 
@@ -154,7 +154,7 @@ class SonosUIPageBuilder:
         ]
 
         try:
-            speakers = self.sonos_service.list_available_speakers()
+            speakers = self.sonos_service.list_network_speakers()
         except SonosDiscoveryError as err:
             components.append(
                 c.Error(

--- a/tests/discstore/adapters/inbound/test_ui_controller.py
+++ b/tests/discstore/adapters/inbound/test_ui_controller.py
@@ -2,7 +2,7 @@ import json
 import sys
 from importlib import util
 from unittest import mock
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, create_autospec
 
 import pytest
 
@@ -43,10 +43,10 @@ def test_dependencies_import_failure(mocker):
 
 def build_controller():
     from discstore.adapters.inbound.ui_controller import UIController
-    from jukebox.sonos.service import InspectedSelectedSonosGroup
+    from jukebox.sonos.service import InspectedSelectedSonosGroup, SonosService
 
     settings_service = MagicMock()
-    sonos_service = MagicMock()
+    sonos_service = create_autospec(SonosService)
     available_speakers = [
         build_speaker(uid="speaker-1", name="Kitchen", host="192.168.1.30", household_id="household-1"),
         build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31", household_id="household-1"),
@@ -113,7 +113,6 @@ def build_controller():
         "derived": {},
         "change_metadata": {},
     }
-    sonos_service.list_available_speakers.return_value = available_speakers
     sonos_service.list_network_speakers.return_value = available_speakers
     sonos_service.inspect_selected_group.return_value = InspectedSelectedSonosGroup(
         coordinator=available_speakers[1],

--- a/tests/discstore/test_command_handlers.py
+++ b/tests/discstore/test_command_handlers.py
@@ -1,12 +1,13 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, create_autospec
 
-from discstore.command_handlers import execute_library_command
+from discstore.command_handlers import InteractiveLibraryController, LibraryController, execute_library_command
 from discstore.commands import CliSearchCommand, InteractiveCliCommand
 from jukebox.settings.entities import ResolvedAdminRuntimeConfig
+from jukebox.settings.service_protocols import SettingsService
 
 
 def test_execute_library_command_runs_standard_cli_with_resolved_library_path():
-    settings_service = MagicMock()
+    settings_service = create_autospec(SettingsService)
     settings_service.resolve_admin_runtime.return_value = ResolvedAdminRuntimeConfig(
         library_path="/resolved/library.json",
         api_port=8000,
@@ -14,7 +15,7 @@ def test_execute_library_command_runs_standard_cli_with_resolved_library_path():
         verbose=True,
     )
     command = CliSearchCommand(type="search", query="beatles")
-    cli = MagicMock()
+    cli = create_autospec(LibraryController)
     build_cli_controller = MagicMock(return_value=cli)
     build_interactive_cli_controller = MagicMock()
 
@@ -33,14 +34,14 @@ def test_execute_library_command_runs_standard_cli_with_resolved_library_path():
 
 
 def test_execute_library_command_runs_interactive_cli_with_resolved_library_path():
-    settings_service = MagicMock()
+    settings_service = create_autospec(SettingsService)
     settings_service.resolve_admin_runtime.return_value = ResolvedAdminRuntimeConfig(
         library_path="/resolved/library.json",
         api_port=8000,
         ui_port=9000,
         verbose=False,
     )
-    interactive_cli = MagicMock()
+    interactive_cli = create_autospec(InteractiveLibraryController)
     build_cli_controller = MagicMock()
     build_interactive_cli_controller = MagicMock(return_value=interactive_cli)
 

--- a/tests/jukebox/sonos/test_selection.py
+++ b/tests/jukebox/sonos/test_selection.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import create_autospec
 
 import pytest
 
@@ -8,8 +8,9 @@ from jukebox.sonos.selection import (
     GetSonosSelectionStatus,
     SaveSelectedSonosGroupResult,
     SaveSonosSelection,
+    SelectedSonosGroupRepository,
 )
-from jukebox.sonos.service import InspectedSelectedSonosGroup
+from jukebox.sonos.service import InspectedSelectedSonosGroup, SonosService
 
 
 def build_speaker(uid="speaker-1", name="Kitchen", host="192.168.1.30", household_id="household-1"):
@@ -38,11 +39,11 @@ def build_inspected_group(
 
 
 def test_save_sonos_selection_defaults_coordinator_to_first_selected_uid():
-    selected_group_repository = MagicMock()
+    selected_group_repository = create_autospec(SelectedSonosGroupRepository)
     selected_group_repository.save_selected_group.return_value = SaveSelectedSonosGroupResult(
         message="Settings saved. Changes take effect after restart."
     )
-    sonos_service = MagicMock()
+    sonos_service = create_autospec(SonosService)
     sonos_service.list_network_speakers.return_value = [
         build_speaker(uid="speaker-1"),
         build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31"),
@@ -69,11 +70,11 @@ def test_save_sonos_selection_defaults_coordinator_to_first_selected_uid():
 
 
 def test_save_sonos_selection_persists_multi_member_selected_group_and_player_type():
-    selected_group_repository = MagicMock()
+    selected_group_repository = create_autospec(SelectedSonosGroupRepository)
     selected_group_repository.save_selected_group.return_value = SaveSelectedSonosGroupResult(
         message="Settings saved. Changes take effect after restart."
     )
-    sonos_service = MagicMock()
+    sonos_service = create_autospec(SonosService)
     sonos_service.list_network_speakers.return_value = [
         build_speaker(uid="speaker-1"),
         build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31"),
@@ -107,9 +108,9 @@ def test_save_sonos_selection_persists_multi_member_selected_group_and_player_ty
 
 
 def test_save_sonos_selection_validates_against_selectable_speakers():
-    selected_group_repository = MagicMock()
+    selected_group_repository = create_autospec(SelectedSonosGroupRepository)
     selected_group_repository.save_selected_group.return_value = SaveSelectedSonosGroupResult()
-    sonos_service = MagicMock()
+    sonos_service = create_autospec(SonosService)
     sonos_service.list_network_speakers.return_value = [build_speaker(uid="speaker-9", household_id="household-2")]
 
     SaveSonosSelection(
@@ -121,8 +122,8 @@ def test_save_sonos_selection_validates_against_selectable_speakers():
 
 
 def test_save_sonos_selection_rejects_unknown_uid_without_writing():
-    selected_group_repository = MagicMock()
-    sonos_service = MagicMock()
+    selected_group_repository = create_autospec(SelectedSonosGroupRepository)
+    sonos_service = create_autospec(SonosService)
     sonos_service.list_network_speakers.return_value = [build_speaker()]
 
     with pytest.raises(ValueError, match="not currently discoverable: speaker-9"):
@@ -135,8 +136,8 @@ def test_save_sonos_selection_rejects_unknown_uid_without_writing():
 
 
 def test_save_sonos_selection_rejects_empty_uid_input():
-    selected_group_repository = MagicMock()
-    sonos_service = MagicMock()
+    selected_group_repository = create_autospec(SelectedSonosGroupRepository)
+    sonos_service = create_autospec(SonosService)
     sonos_service.list_network_speakers.return_value = [build_speaker()]
 
     with pytest.raises(ValueError, match="`uids` must include at least one UID."):
@@ -149,8 +150,8 @@ def test_save_sonos_selection_rejects_empty_uid_input():
 
 
 def test_save_sonos_selection_rejects_duplicate_uids():
-    selected_group_repository = MagicMock()
-    sonos_service = MagicMock()
+    selected_group_repository = create_autospec(SelectedSonosGroupRepository)
+    sonos_service = create_autospec(SonosService)
     sonos_service.list_network_speakers.return_value = [build_speaker()]
 
     with pytest.raises(ValueError, match="`uids` must not contain duplicate UIDs."):
@@ -163,8 +164,8 @@ def test_save_sonos_selection_rejects_duplicate_uids():
 
 
 def test_save_sonos_selection_rejects_explicit_coordinator_outside_selected_group():
-    selected_group_repository = MagicMock()
-    sonos_service = MagicMock()
+    selected_group_repository = create_autospec(SelectedSonosGroupRepository)
+    sonos_service = create_autospec(SonosService)
     sonos_service.list_network_speakers.return_value = [
         build_speaker(uid="speaker-1"),
         build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31"),
@@ -180,8 +181,8 @@ def test_save_sonos_selection_rejects_explicit_coordinator_outside_selected_grou
 
 
 def test_save_sonos_selection_rejects_blank_coordinator_uid():
-    selected_group_repository = MagicMock()
-    sonos_service = MagicMock()
+    selected_group_repository = create_autospec(SelectedSonosGroupRepository)
+    sonos_service = create_autospec(SonosService)
     sonos_service.list_network_speakers.return_value = [
         build_speaker(uid="speaker-1"),
         build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31"),
@@ -197,8 +198,8 @@ def test_save_sonos_selection_rejects_blank_coordinator_uid():
 
 
 def test_save_sonos_selection_rejects_mixed_household_input():
-    selected_group_repository = MagicMock()
-    sonos_service = MagicMock()
+    selected_group_repository = create_autospec(SelectedSonosGroupRepository)
+    sonos_service = create_autospec(SonosService)
     sonos_service.list_network_speakers.return_value = [
         build_speaker(uid="speaker-1", household_id="household-1"),
         build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31", household_id="household-2"),
@@ -214,9 +215,9 @@ def test_save_sonos_selection_rejects_mixed_household_input():
 
 
 def test_save_sonos_selection_persists_selected_household_id():
-    selected_group_repository = MagicMock()
+    selected_group_repository = create_autospec(SelectedSonosGroupRepository)
     selected_group_repository.save_selected_group.return_value = SaveSelectedSonosGroupResult()
-    sonos_service = MagicMock()
+    sonos_service = create_autospec(SonosService)
     sonos_service.list_network_speakers.return_value = [
         build_speaker(uid="speaker-1", household_id="household-1"),
         build_speaker(uid="speaker-2", name="Living Room", host="192.168.1.31", household_id="household-1"),
@@ -242,9 +243,9 @@ def test_save_sonos_selection_persists_selected_household_id():
 
 
 def test_get_sonos_selection_status_reports_not_selected_without_discovery():
-    selected_group_repository = MagicMock()
+    selected_group_repository = create_autospec(SelectedSonosGroupRepository)
     selected_group_repository.get_selected_group.return_value = None
-    sonos_service = MagicMock()
+    sonos_service = create_autospec(SonosService)
 
     status = GetSonosSelectionStatus(
         selected_group_repository=selected_group_repository,
@@ -258,7 +259,7 @@ def test_get_sonos_selection_status_reports_not_selected_without_discovery():
 
 
 def test_get_sonos_selection_status_reports_available_multi_speaker_selection():
-    selected_group_repository = MagicMock()
+    selected_group_repository = create_autospec(SelectedSonosGroupRepository)
     selected_group_repository.get_selected_group.return_value = SelectedSonosGroupSettings(
         household_id="household-1",
         coordinator_uid="speaker-2",
@@ -267,7 +268,7 @@ def test_get_sonos_selection_status_reports_available_multi_speaker_selection():
             SelectedSonosSpeakerSettings(uid="speaker-2"),
         ],
     )
-    sonos_service = MagicMock()
+    sonos_service = create_autospec(SonosService)
     sonos_service.inspect_selected_group.return_value = build_inspected_group(
         resolved_members=[
             build_speaker(uid="speaker-1"),
@@ -290,7 +291,7 @@ def test_get_sonos_selection_status_reports_available_multi_speaker_selection():
 
 
 def test_get_sonos_selection_status_reports_partially_available_selection():
-    selected_group_repository = MagicMock()
+    selected_group_repository = create_autospec(SelectedSonosGroupRepository)
     selected_group_repository.get_selected_group.return_value = SelectedSonosGroupSettings(
         household_id="household-1",
         coordinator_uid="speaker-1",
@@ -299,7 +300,7 @@ def test_get_sonos_selection_status_reports_partially_available_selection():
             SelectedSonosSpeakerSettings(uid="speaker-2"),
         ],
     )
-    sonos_service = MagicMock()
+    sonos_service = create_autospec(SonosService)
     sonos_service.inspect_selected_group.return_value = build_inspected_group(
         resolved_members=[build_speaker(uid="speaker-1")],
         coordinator_uid="speaker-1",
@@ -318,7 +319,7 @@ def test_get_sonos_selection_status_reports_partially_available_selection():
 
 
 def test_get_sonos_selection_status_reports_unavailable_selection_when_coordinator_is_missing():
-    selected_group_repository = MagicMock()
+    selected_group_repository = create_autospec(SelectedSonosGroupRepository)
     selected_group_repository.get_selected_group.return_value = SelectedSonosGroupSettings(
         household_id="household-1",
         coordinator_uid="speaker-2",
@@ -327,7 +328,7 @@ def test_get_sonos_selection_status_reports_unavailable_selection_when_coordinat
             SelectedSonosSpeakerSettings(uid="speaker-2"),
         ],
     )
-    sonos_service = MagicMock()
+    sonos_service = create_autospec(SonosService)
     sonos_service.inspect_selected_group.return_value = build_inspected_group(
         resolved_members=[build_speaker(uid="speaker-1", host="192.168.1.31")],
         coordinator_uid="speaker-2",
@@ -346,7 +347,7 @@ def test_get_sonos_selection_status_reports_unavailable_selection_when_coordinat
 
 
 def test_get_sonos_selection_status_reports_unavailable_selection_for_mixed_households():
-    selected_group_repository = MagicMock()
+    selected_group_repository = create_autospec(SelectedSonosGroupRepository)
     selected_group_repository.get_selected_group.return_value = SelectedSonosGroupSettings(
         household_id="household-1",
         coordinator_uid="speaker-1",
@@ -355,7 +356,7 @@ def test_get_sonos_selection_status_reports_unavailable_selection_for_mixed_hous
             SelectedSonosSpeakerSettings(uid="speaker-2"),
         ],
     )
-    sonos_service = MagicMock()
+    sonos_service = create_autospec(SonosService)
     sonos_service.inspect_selected_group.return_value = build_inspected_group(
         resolved_members=[
             build_speaker(uid="speaker-1", household_id="household-1"),
@@ -377,7 +378,7 @@ def test_get_sonos_selection_status_reports_unavailable_selection_for_mixed_hous
 
 
 def test_get_sonos_selection_status_reports_unavailable_when_partial_group_spans_households():
-    selected_group_repository = MagicMock()
+    selected_group_repository = create_autospec(SelectedSonosGroupRepository)
     selected_group_repository.get_selected_group.return_value = SelectedSonosGroupSettings(
         household_id="household-1",
         coordinator_uid="speaker-1",
@@ -387,7 +388,7 @@ def test_get_sonos_selection_status_reports_unavailable_when_partial_group_spans
             SelectedSonosSpeakerSettings(uid="speaker-3"),
         ],
     )
-    sonos_service = MagicMock()
+    sonos_service = create_autospec(SonosService)
     sonos_service.inspect_selected_group.return_value = build_inspected_group(
         resolved_members=[
             build_speaker(uid="speaker-1", household_id="household-1"),


### PR DESCRIPTION
Closes #236 

## Context

This PR fixes an `AttributeError` in the Sonos UI panel caused by a deprecated method call. The method `list_available_speakers` no longer exists and has been replaced by `list_network_speakers`.

The tests use plain `MagicMock`, which allows undefined methods to be called without errors, this masks broken interfaces. 

## What Changed

- replaced `list_available_speakers` with the updated `list_network_speakers` method
- improved test reliability by replacing `MagicMock` with `create_autospec` for `sonos_service`
- extended this improvement to all protocol-related mocks to ensure stricter interface validation in tests

### Test 

`localhost:800/sonos` is accessible again. 