### PR TITLE
🐛 Fix Sonos playback state stuck on play failure

### DIFF
--- a/jukebox/adapters/outbound/players/sonos_player_adapter.py
+++ b/jukebox/adapters/outbound/players/sonos_player_adapter.py
@@ -8,6 +8,7 @@ from soco.exceptions import SoCoException, SoCoUPnPException
 from soco.plugins.sharelink import ShareLinkPlugin
 from urllib3.exceptions import HTTPError
 
+from jukebox.domain.errors import PlaybackError
 from jukebox.domain.ports import PlayerPort
 from jukebox.settings.entities import ResolvedSonosGroupRuntime
 from jukebox.settings.errors import InvalidSettingsError
@@ -31,7 +32,7 @@ def catch_soco_upnp_exception(func):
                 )
             else:
                 LOGGER.exception("%s with `%s` failed: %s", func.__name__, args, str(err))
-            return
+            raise PlaybackError(str(err)) from err
 
     return wrapper
 

--- a/jukebox/domain/errors.py
+++ b/jukebox/domain/errors.py
@@ -1,0 +1,2 @@
+class PlaybackError(Exception):
+    """Raised when a player operation fails."""

--- a/jukebox/domain/use_cases/handle_tag_event.py
+++ b/jukebox/domain/use_cases/handle_tag_event.py
@@ -1,6 +1,8 @@
 import logging
+from contextlib import contextmanager
 
 from jukebox.domain.entities import CurrentTagAction, PlaybackAction, PlaybackSession, TagEvent
+from jukebox.domain.errors import PlaybackError
 from jukebox.domain.ports import PlayerPort
 from jukebox.domain.repositories import CurrentTagRepository, LibraryRepository
 from jukebox.domain.use_cases.determine_action import DetermineAction
@@ -44,9 +46,10 @@ class HandleTagEvent:
             session.playing_tag_removed_at = None
 
         elif action == PlaybackAction.RESUME:
-            self.player.resume()
-            session.paused_at = None
-            session.playing_tag_removed_at = None
+            with suppress_playback_error("Playback operation `RESUME` failed; stopping session update"):
+                self.player.resume()
+                session.paused_at = None
+                session.playing_tag_removed_at = None
 
         elif action == PlaybackAction.PLAY:
             LOGGER.info("Found card with UID: %s", tag_event.tag_id)
@@ -54,10 +57,13 @@ class HandleTagEvent:
             disc = self.library.get_disc(tag_event.tag_id) if tag_event.tag_id is not None else None
             if disc is not None:
                 LOGGER.info("Found corresponding disc: %s", disc)
-                session.playing_tag = tag_event.tag_id
-                self.player.play(disc.uri, disc.option.shuffle)
-                session.paused_at = None
-                session.playing_tag_removed_at = None
+                with suppress_playback_error(
+                    f"Playback operation `PLAY` failed for tag_id='{tag_event.tag_id}'; stopping session update"
+                ):
+                    self.player.play(disc.uri, disc.option.shuffle)
+                    session.playing_tag = tag_event.tag_id
+                    session.paused_at = None
+                    session.playing_tag_removed_at = None
             else:
                 LOGGER.warning("No disc found for UID: %s", tag_event.tag_id)
 
@@ -69,11 +75,13 @@ class HandleTagEvent:
             LOGGER.debug("Grace period: %.3fs / %gs", grace_period_elapsed, self.determine_action.pause_delay)
 
         elif action == PlaybackAction.PAUSE:
-            self.player.pause()
+            with suppress_playback_error("Playback operation `PAUSE` failed; continuing session update"):
+                self.player.pause()
             session.paused_at = tag_event.timestamp
 
         elif action == PlaybackAction.STOP:
-            self.player.stop()
+            with suppress_playback_error("Playback operation `STOP` failed; continuing session update"):
+                self.player.stop()
             session.playing_tag = None
             session.paused_at = None
             session.playing_tag_removed_at = None
@@ -125,3 +133,11 @@ class HandleTagEvent:
 
         elif action == CurrentTagAction.KEEP:
             pass  # No state changed
+
+
+@contextmanager
+def suppress_playback_error(msg: str):
+    try:
+        yield
+    except PlaybackError:
+        LOGGER.warning(msg)

--- a/tests/jukebox/adapters/outbound/players/test_sonos_player_adapters.py
+++ b/tests/jukebox/adapters/outbound/players/test_sonos_player_adapters.py
@@ -1,10 +1,16 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from soco.exceptions import SoCoUPnPException
 
-from jukebox.adapters.outbound.players.sonos_player_adapter import SonosPlayerAdapter
+from jukebox.adapters.outbound.players.sonos_player_adapter import SonosPlayerAdapter, catch_soco_upnp_exception
+from jukebox.domain.errors import PlaybackError
 from jukebox.settings.errors import InvalidSettingsError
 from tests.jukebox.settings._helpers import build_resolved_sonos_group_runtime
+
+
+def make_exception(code: str):
+    return SoCoUPnPException(f"UPnP Error {code} received", code, f"<errorCode>{code}</errorCode>")
 
 
 @patch("jukebox.adapters.outbound.players.sonos_player_adapter.SoCo")
@@ -632,3 +638,53 @@ def test_init_with_duplicate_speaker_names_logs_warning(mock_sharelink, mock_soc
 
     assert adapter.speaker.player_name == "Kitchen"
     assert "Multiple Sonos speakers with name 'Kitchen' found. Using first match." in caplog.text
+
+
+@pytest.mark.parametrize(
+    "adapter_method, soco_method, args",
+    [
+        ("play", "play_from_queue", ("uri",)),
+        ("pause", "pause", ()),
+        ("resume", "play", ()),
+        ("stop", "clear_queue", ()),
+    ],
+)
+@patch("jukebox.adapters.outbound.players.sonos_player_adapter.SoCo")
+def test_methods_log_and_raise_on_upnp_error(mock_soco, caplog, adapter_method, soco_method, args):
+    mock_speaker = MagicMock()
+    mock_soco.return_value = mock_speaker
+    mock_speaker.get_speaker_info.return_value = {"software_version": "1.0"}
+
+    getattr(mock_speaker, soco_method).side_effect = make_exception("804")
+
+    adapter = SonosPlayerAdapter(host="192.168.1.100")
+
+    with pytest.raises(PlaybackError):
+        getattr(adapter, adapter_method)(*args)
+
+    assert "bad uri" in caplog.text
+    getattr(mock_speaker, soco_method).assert_called()
+
+
+@pytest.mark.parametrize("error_code, expected_message", (("804", "bad uri"), ("701", "not available transition")))
+def test_decorator_logs_warning_for_know_codes(caplog, error_code, expected_message):
+    @catch_soco_upnp_exception
+    def failing():
+        raise make_exception(error_code)
+
+    with pytest.raises(PlaybackError), caplog.at_level("WARNING"):
+        failing()
+
+    assert expected_message in caplog.text
+    assert any(r.levelname == "WARNING" for r in caplog.records)
+
+
+def test_decorator_logs_exception_for_other_codes(caplog):
+    @catch_soco_upnp_exception
+    def failing():
+        raise make_exception("999")
+
+    with pytest.raises(PlaybackError), caplog.at_level("ERROR"):
+        failing()
+
+    assert any(r.levelname == "ERROR" for r in caplog.records)

--- a/tests/jukebox/domain/use_cases/test_handle_tag_event.py
+++ b/tests/jukebox/domain/use_cases/test_handle_tag_event.py
@@ -3,9 +3,10 @@ from unittest.mock import MagicMock, call
 import pytest
 
 from jukebox.domain.entities import CurrentTagAction, Disc, DiscMetadata, DiscOption, PlaybackSession, TagEvent
+from jukebox.domain.errors import PlaybackError
 from jukebox.domain.use_cases.determine_action import DetermineAction
 from jukebox.domain.use_cases.determine_current_tag_action import DetermineCurrentTagAction
-from jukebox.domain.use_cases.handle_tag_event import HandleTagEvent
+from jukebox.domain.use_cases.handle_tag_event import HandleTagEvent, suppress_playback_error
 
 
 @pytest.fixture
@@ -450,3 +451,80 @@ def test_same_tag_returns_after_pause_resumes_immediately(handle_tag_event, mock
     mock_player.resume.assert_called_once()
     assert session.paused_at is None
     assert session.playing_tag_removed_at is None
+
+
+def test_handle_play_action_does_not_update_session_when_player_raises(handle_tag_event, mock_player):
+    mock_player.play.side_effect = PlaybackError("bad uri")
+    session = PlaybackSession()
+    tag_event = TagEvent(tag_id="test-tag", timestamp=100.0)
+
+    new_session = handle_tag_event.execute(tag_event, session)
+
+    mock_player.play.assert_called_once()
+    assert new_session.playing_tag is None
+
+
+def test_handle_resume_action_does_not_update_session_when_player_raises(handle_tag_event, mock_player):
+    mock_player.resume.side_effect = PlaybackError("cannot resume")
+    session = PlaybackSession()
+    session.playing_tag = "test-tag"
+    session.paused_at = 60.0
+    tag_event = TagEvent(tag_id="test-tag", timestamp=100.0)
+
+    new_session = handle_tag_event.execute(tag_event, session)
+
+    mock_player.resume.assert_called_once()
+    assert new_session.paused_at == 60.0
+
+
+def test_handle_pause_action_updates_session_even_when_player_raises(handle_tag_event, mock_player):
+    mock_player.pause.side_effect = PlaybackError("cannot pause")
+    session = PlaybackSession()
+    session.playing_tag = "test-tag"
+    session.playing_tag_removed_at = 96.9
+    tag_event = TagEvent(tag_id=None, timestamp=100.0)
+
+    new_session = handle_tag_event.execute(tag_event, session)
+
+    mock_player.pause.assert_called_once()
+    assert new_session.paused_at == 100.0
+
+
+def test_handle_stop_action_updates_session_even_when_player_raises(handle_tag_event, mock_player):
+    mock_player.stop.side_effect = PlaybackError("cannot stop")
+    session = PlaybackSession()
+    session.playing_tag = "test-tag"
+    session.paused_at = 49.0
+    tag_event = TagEvent(tag_id=None, timestamp=100.0)
+
+    new_session = handle_tag_event.execute(tag_event, session)
+
+    mock_player.stop.assert_called_once()
+    assert new_session.playing_tag is None
+    assert new_session.paused_at is None
+
+
+def test_suppress_playback_error_suppresses_playback_error():
+    with suppress_playback_error("msg"):
+        raise PlaybackError("boom")
+
+
+def test_suppress_playback_error_logs_warning(caplog):
+    with suppress_playback_error("something went wrong"), caplog.at_level("WARNING"):
+        raise PlaybackError("boom")
+
+    assert "something went wrong" in caplog.text
+    assert any(r.levelname == "WARNING" for r in caplog.records)
+
+
+def test_suppress_playback_error_does_not_suppress_other_exceptions():
+    with pytest.raises(RuntimeError), suppress_playback_error("msg"):
+        raise RuntimeError("not a playback error")
+
+
+def test_suppress_playback_error_runs_body_when_no_error():
+    executed = False
+    with suppress_playback_error("msg"):
+        executed = True
+
+    assert executed is True


### PR DESCRIPTION
Closes #226

## Context
When a tag is added to the library with an invalid URI, `SonosPlayerAdapter.play()` was failing silently, the SoCo exception was swallowed by the decorator. Meanwhile, `HandleTagEvent` had already set `session.playing_tag` before calling the player, leaving the session in a "playing" state even though nothing had started. Subsequent reads of the same tag would trigger `CONTINUE`/`RESUME` instead of a fresh `PLAY`.

## What Changed
**`PlaybackError`** (new): domain exception in `jukebox/domain/errors.py`. The Sonos adapter translates `SoCoUPnPException` into this type.

**`catch_soco_upnp_exception`**: the decorator now logs then re-raises a `PlaybackError` for all decorated methods (play, pause, resume, stop).

`HandleTagEvent`: _state_ updates are split by intent:
- `PLAY` and `RESUME`: session state updated only on success (via `log_playback_error`), so `playing_tag` is never set when the player call fails
- `PAUSE` and `STOP`: session state always updated regardless of player errors, if the player is already stopped or paused, the session should still reflect the intended state to avoid infinite retry loops
- `IDLE`, `CONTINUE` and `WAITING`: no change (no `PlaybackError` to handle)

## Out of scope
Does not address #124 (refactoring `HandleTagEvent` responsibilities). The `suppress_playback_error` helper is a small step toward clarity, but the broader separation of concerns is left for a dedicated effort.