### PR TITLE
♻️ Remove UIController delegation wrappers

### DIFF
--- a/jukebox/adapters/inbound/admin/ui_controller.py
+++ b/jukebox/adapters/inbound/admin/ui_controller.py
@@ -1,4 +1,3 @@
-from collections.abc import AsyncIterator
 from typing import Annotated
 
 from jukebox.shared.dependency_messages import optional_extra_dependency_message
@@ -18,24 +17,20 @@ except ModuleNotFoundError as e:
 from pydantic import BaseModel, Field
 
 from jukebox.adapters.inbound.admin.api_controller import APIController
-from jukebox.adapters.inbound.admin.ui_pages.library import DiscForm, DiscTable, LibraryUIPageBuilder
+from jukebox.adapters.inbound.admin.ui_pages.library import DiscForm, LibraryUIPageBuilder
 from jukebox.adapters.inbound.admin.ui_pages.settings import SettingsUIPageBuilder
 from jukebox.adapters.inbound.admin.ui_pages.sonos import SonosSelectionForm, SonosUIPageBuilder
-from jukebox.domain.entities import CurrentTagStatus, Disc, DiscMetadata, DiscOption
+from jukebox.domain.entities import Disc, DiscMetadata, DiscOption
 from jukebox.domain.use_cases.library.add_disc import AddDisc
 from jukebox.domain.use_cases.library.edit_disc import EditDisc
 from jukebox.domain.use_cases.library.get_current_tag_status import GetCurrentTagStatus
 from jukebox.domain.use_cases.library.get_disc import GetDisc
 from jukebox.domain.use_cases.library.list_discs import ListDiscs
 from jukebox.domain.use_cases.library.remove_disc import RemoveDisc
-from jukebox.settings.definitions import (
-    EditableSettingDisplay,
-    get_setting_definition,
-)
+from jukebox.settings.definitions import get_setting_definition
 from jukebox.settings.errors import SettingsError
 from jukebox.settings.selected_sonos_group_repository import SettingsSelectedSonosGroupRepository
 from jukebox.settings.service_protocols import SettingsService
-from jukebox.settings.types import JsonObject, JsonValue
 from jukebox.sonos.discovery import SonosDiscoveryError
 from jukebox.sonos.selection import SaveSonosSelection
 from jukebox.sonos.service import SonosService
@@ -81,12 +76,12 @@ class UIController(APIController):
 
         @self.app.get("/api/ui/", response_model=FastUI, response_model_exclude_none=True)
         def list_discs(toast: str | None = None) -> list[AnyComponent]:
-            return self._build_index_page_components(toast=toast)
+            return self.library_pages.build_index_page_components(toast=toast)
 
         @self.app.get("/api/ui/current-tag-banner/events")
         async def get_current_tag_banner_events(request: Request) -> StreamingResponse:
             return StreamingResponse(
-                self._current_tag_banner_event_stream(request),
+                self.library_pages.current_tag_banner_event_stream(request),
                 media_type="text/event-stream",
                 headers={
                     "Cache-Control": "no-cache",
@@ -97,9 +92,11 @@ class UIController(APIController):
 
         @self.app.get("/api/ui/discs/new", response_model=FastUI, response_model_exclude_none=True)
         def new_disc_form(prefill: str | None = None) -> list[AnyComponent]:
-            return self._build_form_page_components(
+            return self.library_pages.build_form_page_components(
                 title="Add disc",
-                form_components=self._build_new_disc_form_components(prefill_current=(prefill == "current")),
+                form_components=self.library_pages.build_new_disc_form_components(
+                    prefill_current=(prefill == "current")
+                ),
             )
 
         @self.app.post("/api/ui/discs", response_model=FastUI, response_model_exclude_none=True)
@@ -124,9 +121,9 @@ class UIController(APIController):
 
         @self.app.get("/api/ui/discs/{tag_id}/edit", response_model=FastUI, response_model_exclude_none=True)
         def edit_disc_form(tag_id: str) -> list[AnyComponent]:
-            return self._build_form_page_components(
+            return self.library_pages.build_form_page_components(
                 title=f"Edit disc {tag_id}",
-                form_components=self._build_edit_disc_form_components(tag_id),
+                form_components=self.library_pages.build_edit_disc_form_components(tag_id),
             )
 
         @self.app.post("/api/ui/discs/{tag_id}", response_model=FastUI, response_model_exclude_none=True)
@@ -166,9 +163,9 @@ class UIController(APIController):
 
         @self.app.get("/api/ui/discs/{tag_id}/delete", response_model=FastUI, response_model_exclude_none=True)
         def delete_disc_confirmation(tag_id: str) -> list[AnyComponent]:
-            return self._build_form_page_components(
+            return self.library_pages.build_form_page_components(
                 title=f"Delete disc {tag_id}",
-                form_components=self._build_delete_disc_form_components(tag_id),
+                form_components=self.library_pages.build_delete_disc_form_components(tag_id),
             )
 
         # Fast-UI buttons and forms do not support the DELETE method directly. So we cannot call DELETE on
@@ -186,11 +183,11 @@ class UIController(APIController):
 
         @self.app.get("/api/ui/settings", response_model=FastUI, response_model_exclude_none=True)
         def settings_page(toast: str | None = None, toast_message: str | None = None) -> list[AnyComponent]:
-            return self._build_settings_page_components(toast=toast, toast_message=toast_message)
+            return self.settings_pages.build_settings_page_components(toast=toast, toast_message=toast_message)
 
         @self.app.get("/api/ui/settings/{setting_path}/edit", response_model=FastUI, response_model_exclude_none=True)
         def edit_setting_form(setting_path: str) -> list[AnyComponent]:
-            return self._build_settings_edit_page_components(setting_path)
+            return self.settings_pages.build_settings_edit_page_components(setting_path)
 
         @self.app.post("/api/ui/settings/{setting_path}", response_model=FastUI, response_model_exclude_none=True)
         async def update_setting(
@@ -202,13 +199,15 @@ class UIController(APIController):
                 raise HTTPException(status_code=404, detail=f"Unknown setting path: {setting_path}")
 
             try:
-                patch = self._build_settings_patch(setting_path, form.value)
+                patch = self.settings_pages.build_settings_patch(setting_path, form.value)
                 result = self.settings_service.patch_persisted_settings(patch)
             except ValueError as err:
                 raise self._field_validation_error("value", str(err))
             except SettingsError as err:
-                if self._persisted_value_matches(setting_path, self._lookup_optional_dotted_path(patch, setting_path)):
-                    return self._build_settings_success_response(
+                if self.settings_pages.persisted_value_matches(
+                    setting_path, self.settings_pages.lookup_optional_dotted_path(patch, setting_path)
+                ):
+                    return self.settings_pages.build_settings_success_response(
                         "Settings saved, but effective settings are still unavailable."
                     )
                 raise self._field_validation_error("value", str(err))
@@ -217,15 +216,15 @@ class UIController(APIController):
             except Exception as err:
                 raise HTTPException(status_code=500, detail=f"Server error: {str(err)}")
 
-            return self._build_settings_success_response(str(result["message"]))
+            return self.settings_pages.build_settings_success_response(str(result["message"]))
 
         @self.app.post("/api/ui/settings/{setting_path}/reset", response_model=FastUI, response_model_exclude_none=True)
         async def reset_setting(setting_path: str) -> list[AnyComponent]:
-            return self._reset_setting(setting_path)
+            return self.settings_pages.reset_setting(setting_path)
 
         @self.app.get("/api/ui/sonos", response_model=FastUI, response_model_exclude_none=True)
         def sonos_page(toast: str | None = None, toast_message: str | None = None) -> list[AnyComponent]:
-            return self._build_sonos_page_components(toast=toast, toast_message=toast_message)
+            return self.sonos_pages.build_sonos_page_components(toast=toast, toast_message=toast_message)
 
         @self.app.get("/api/ui/sonos/edit", response_model=FastUI, response_model_exclude_none=True)
         def edit_sonos_form(
@@ -236,7 +235,7 @@ class UIController(APIController):
             field_errors = None
             if error_message:
                 field_errors = {self._sonos_field_name_for_error(error_message): error_message}
-            return self._build_sonos_edit_page_components(
+            return self.sonos_pages.build_sonos_edit_page_components(
                 error_message=error_message,
                 field_errors=field_errors,
                 submitted_uids=uids,
@@ -292,38 +291,6 @@ class UIController(APIController):
             c.FireEvent(event=GoToEvent(url=f"/?toast={toast_event_name}")),
         ]
 
-    def _build_settings_success_response(self, message: str) -> list[AnyComponent]:
-        return self.settings_pages.build_settings_success_response(message)
-
-    def _reset_setting(self, setting_path: str) -> list[AnyComponent]:
-        return self.settings_pages.reset_setting(setting_path)
-
-    def _build_sonos_page_components(
-        self,
-        toast: str | None = None,
-        toast_message: str | None = None,
-        error_message: str | None = None,
-    ) -> list[AnyComponent]:
-        return self.sonos_pages.build_sonos_page_components(
-            toast=toast,
-            toast_message=toast_message,
-            error_message=error_message,
-        )
-
-    def _build_sonos_edit_page_components(
-        self,
-        error_message: str | None = None,
-        field_errors: dict[str, str] | None = None,
-        submitted_uids: list[str] | None = None,
-        submitted_coordinator_uid: str | None = None,
-    ) -> list[AnyComponent]:
-        return self.sonos_pages.build_sonos_edit_page_components(
-            error_message=error_message,
-            field_errors=field_errors,
-            submitted_uids=submitted_uids,
-            submitted_coordinator_uid=submitted_coordinator_uid,
-        )
-
     def _reset_sonos_selection(self) -> list[AnyComponent]:
         selected_group_repository = SettingsSelectedSonosGroupRepository(self.settings_service)
         try:
@@ -333,7 +300,7 @@ class UIController(APIController):
                 return self.sonos_pages.build_sonos_success_response(
                     "Sonos selection cleared, but effective settings are still unavailable."
                 )
-            return self._build_sonos_page_components(error_message=str(err))
+            return self.sonos_pages.build_sonos_page_components(error_message=str(err))
         except HTTPException:
             raise
         except Exception as err:
@@ -371,116 +338,6 @@ class UIController(APIController):
             return message
 
         return f"{prefix}{speaker.name} [{speaker.uid}]"
-
-    def _build_index_page_components(self, toast: str | None = None) -> list[AnyComponent]:
-        return self.library_pages.build_index_page_components(toast=toast)
-
-    def _build_settings_page_components(
-        self,
-        toast: str | None = None,
-        toast_message: str | None = None,
-    ) -> list[AnyComponent]:
-        return self.settings_pages.build_settings_page_components(toast=toast, toast_message=toast_message)
-
-    def _build_settings_section_components(
-        self,
-        section: str,
-        settings: list[EditableSettingDisplay],
-    ) -> list[AnyComponent]:
-        return self.settings_pages.build_settings_section_components(section, settings)
-
-    def _build_settings_row(self, setting: EditableSettingDisplay, index: int) -> AnyComponent:
-        return self.settings_pages.build_settings_row(setting, index)
-
-    def _build_settings_edit_page_components(
-        self,
-        setting_path: str,
-        reset_error: str | None = None,
-    ) -> list[AnyComponent]:
-        return self.settings_pages.build_settings_edit_page_components(setting_path, reset_error=reset_error)
-
-    def _build_settings_edit_form(self, setting: EditableSettingDisplay) -> AnyComponent:
-        return self.settings_pages.build_settings_edit_form(setting)
-
-    def _build_settings_reset_form(self, setting_path: str) -> AnyComponent:
-        return self.settings_pages.build_settings_reset_form(setting_path)
-
-    def _get_settings_displays(self) -> tuple[list[EditableSettingDisplay], str | None]:
-        return self.settings_pages.get_settings_displays()
-
-    def _build_settings_badges(self, setting: EditableSettingDisplay) -> list[AnyComponent]:
-        return self.settings_pages.build_settings_badges(setting)
-
-    def _build_settings_value_summary(self, setting: EditableSettingDisplay) -> AnyComponent:
-        return self.settings_pages.build_settings_value_summary(setting)
-
-    def _build_settings_value_cell(self, label: str, value: str) -> AnyComponent:
-        return self.settings_pages.build_settings_value_cell(label, value)
-
-    def _build_settings_edit_guidance(self, setting: EditableSettingDisplay) -> str:
-        return self.settings_pages.build_settings_edit_guidance(setting)
-
-    def _build_settings_patch(self, setting_path: str, raw_value: str) -> JsonObject:
-        return self.settings_pages.build_settings_patch(setting_path, raw_value)
-
-    def _build_dotted_patch(self, dotted_path: str, value: JsonValue) -> JsonObject:
-        return self.settings_pages.build_dotted_patch(dotted_path, value)
-
-    def _persisted_value_matches(self, dotted_path: str, expected_value: object) -> bool:
-        return self.settings_pages.persisted_value_matches(dotted_path, expected_value)
-
-    def _has_persisted_value(self, dotted_path: str) -> bool:
-        return self.settings_pages.has_persisted_value(dotted_path)
-
-    def _lookup_optional_dotted_path(self, root: JsonObject, dotted_path: str) -> object:
-        return self.settings_pages.lookup_optional_dotted_path(root, dotted_path)
-
-    def _format_settings_display_value(self, setting_path: str, value: object) -> str:
-        return self.settings_pages.format_settings_display_value(setting_path, value)
-
-    def _format_settings_provenance(self, provenance: str) -> str:
-        return self.settings_pages.format_settings_provenance(provenance)
-
-    def _build_form_page_components(self, title: str, form_components: list[AnyComponent]) -> list[AnyComponent]:
-        return self.library_pages.build_form_page_components(title=title, form_components=form_components)
-
-    def _build_current_tag_banner_components(self, current_tag_status: CurrentTagStatus | None) -> list[AnyComponent]:
-        return self.library_pages.build_current_tag_banner_components(current_tag_status)
-
-    def _build_disc_library_components(self, discs: list[DiscTable]) -> list[AnyComponent]:
-        return self.library_pages.build_disc_library_components(discs)
-
-    def _build_disc_library_header(self) -> AnyComponent:
-        return self.library_pages._build_disc_library_header()
-
-    def _build_disc_library_row(self, disc: DiscTable) -> AnyComponent:
-        return self.library_pages._build_disc_library_row(disc)
-
-    def _build_disc_header_cell(self, label: str, class_name: str) -> AnyComponent:
-        return self.library_pages._build_disc_header_cell(label, class_name)
-
-    def _build_disc_value_cell(self, label: str, value: str | None, class_name: str) -> AnyComponent:
-        return self.library_pages._build_disc_value_cell(label, value, class_name)
-
-    def _build_new_disc_form_components(self, prefill_current: bool) -> list[AnyComponent]:
-        return self.library_pages.build_new_disc_form_components(prefill_current)
-
-    def _build_edit_disc_form_components(self, tag_id: str) -> list[AnyComponent]:
-        return self.library_pages.build_edit_disc_form_components(tag_id)
-
-    def _build_delete_disc_form_components(self, tag_id: str) -> list[AnyComponent]:
-        return self.library_pages.build_delete_disc_form_components(tag_id)
-
-    async def _current_tag_banner_event_stream(
-        self,
-        request: Request,
-        poll_interval_seconds: float = 0.5,
-    ) -> AsyncIterator[bytes]:
-        async for payload in self.library_pages.current_tag_banner_event_stream(request, poll_interval_seconds):
-            yield payload
-
-    def _serialize_current_tag_components(self, components: list[AnyComponent]) -> str:
-        return self.library_pages.serialize_current_tag_components(components)
 
     @staticmethod
     def _sonos_field_name_for_error(message: str) -> str:

--- a/tests/jukebox/adapters/inbound/admin/conftest.py
+++ b/tests/jukebox/adapters/inbound/admin/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+@pytest.fixture
+def walk_components():
+    def _walk(components):
+        for component in components:
+            yield component
+            children = getattr(component, "components", None)
+            if children:
+                yield from _walk(children)
+
+    return _walk

--- a/tests/jukebox/adapters/inbound/admin/test_ui_controller.py
+++ b/tests/jukebox/adapters/inbound/admin/test_ui_controller.py
@@ -1,7 +1,7 @@
 import json
 import sys
 from importlib import util
-from unittest.mock import AsyncMock, MagicMock, create_autospec
+from unittest.mock import MagicMock, create_autospec
 
 import pytest
 
@@ -1059,176 +1059,6 @@ def test_ui_controller_does_not_register_get_reset_setting_route():
 
 
 @pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
-def test_disc_library_components_render_empty_and_editable_states():
-    from jukebox.adapters.inbound.admin.ui_controller import DiscTable
-
-    controller = build_controller()
-    empty_components = controller._build_disc_library_components([])
-    populated_components = controller._build_disc_library_components(
-        [
-            DiscTable(
-                tag="tag-123",
-                uri="/music/song.mp3",
-                artist="Artist",
-                album="Album",
-                track="Track",
-                shuffle=True,
-            )
-        ]
-    )
-
-    assert empty_components[0].type == "Paragraph"
-    assert empty_components[0].text == "No disc found"
-    edit_button = next(
-        component
-        for component in walk_components(populated_components)
-        if component.type == "Button" and component.text == "Edit ✏️" and component.on_click is not None
-    )
-    assert edit_button.on_click.url == "/discs/tag-123/edit"
-
-
-@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
-def test_current_tag_banner_for_unknown_disc_offers_add_cta():
-    from jukebox.domain.entities import CurrentTagStatus
-
-    controller = build_controller()
-
-    components = controller._build_current_tag_banner_components(
-        CurrentTagStatus(tag_id="tag-123", known_in_library=False)
-    )
-    all_components = list(walk_components(components))
-    heading = next(component for component in all_components if component.type == "Heading")
-    button = next(component for component in all_components if component.type == "Button")
-
-    assert heading.text == "Unknown disc on reader"
-    assert button.text == "Add this disc"
-    assert button.on_click.url == "/discs/new?prefill=current"
-
-
-@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
-def test_current_tag_banner_for_known_disc_is_informational_only():
-    from jukebox.domain.entities import CurrentTagStatus
-
-    controller = build_controller()
-
-    components = controller._build_current_tag_banner_components(
-        CurrentTagStatus(tag_id="tag-123", known_in_library=True)
-    )
-    all_components = list(walk_components(components))
-    button = next(component for component in all_components if component.type == "Button")
-
-    assert any(component.type == "Heading" and component.text == "Known disc on reader" for component in all_components)
-    assert button.text == "Edit this disc"
-    assert button.on_click.url == "/discs/tag-123/edit"
-
-
-@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
-def test_new_disc_form_components_render_blank_add_form():
-    controller = build_controller()
-
-    components = controller._build_new_disc_form_components(prefill_current=False)
-    form = components[0]
-
-    assert form.type == "ModelForm"
-    assert form.submit_url == "/api/ui/discs"
-    assert form.initial is None
-
-
-@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
-def test_new_disc_form_components_can_prefill_current_tag():
-    from jukebox.domain.entities import CurrentTagStatus
-
-    controller = build_controller()
-    controller.get_current_tag_status.execute.return_value = CurrentTagStatus(tag_id="tag-123", known_in_library=False)
-
-    components = controller._build_new_disc_form_components(prefill_current=True)
-    form = components[0]
-
-    assert form.type == "ModelForm"
-    assert form.submit_url == "/api/ui/discs"
-    assert form.initial == {"tag": "tag-123", "shuffle": False}
-
-
-@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
-def test_edit_disc_form_components_prefill_existing_disc():
-    from jukebox.domain.entities import Disc, DiscMetadata, DiscOption
-
-    controller = build_controller()
-    controller.get_disc.execute.return_value = Disc(
-        uri="/music/song.mp3",
-        metadata=DiscMetadata(artist="Artist", album="Album", track="Track"),
-        option=DiscOption(shuffle=True),
-    )
-
-    components = controller._build_edit_disc_form_components("tag-123")
-    form = components[0]
-
-    assert form.type == "ModelForm"
-    assert form.submit_url == "/api/ui/discs/tag-123"
-    assert form.initial == {
-        "tag": "tag-123",
-        "uri": "/music/song.mp3",
-        "artist": "Artist",
-        "album": "Album",
-        "track": "Track",
-        "shuffle": True,
-    }
-
-
-@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
-def test_disc_form_helpers_return_errors_for_invalid_current_tag_state_or_missing_edit_target():
-    from jukebox.domain.entities import CurrentTagStatus
-
-    controller = build_controller()
-
-    controller.get_current_tag_status.execute.return_value = None
-    no_tag_components = controller._build_new_disc_form_components(prefill_current=True)
-    controller.get_current_tag_status.execute.return_value = CurrentTagStatus(tag_id="tag-123", known_in_library=True)
-    known_tag_components = controller._build_new_disc_form_components(prefill_current=True)
-    missing_tag_components = controller._build_edit_disc_form_components("")
-    controller.get_disc.execute.side_effect = ValueError("Missing disc")
-    missing_disc_components = controller._build_edit_disc_form_components("tag-123")
-
-    assert no_tag_components[0].type == "Error"
-    assert known_tag_components[0].type == "Error"
-    assert missing_tag_components[0].type == "Error"
-    assert missing_disc_components[0].type == "Error"
-
-
-@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
-def test_form_page_components_include_back_link_and_form():
-    controller = build_controller()
-    components = controller._build_form_page_components(
-        title="Add disc",
-        form_components=controller._build_new_disc_form_components(prefill_current=False),
-    )
-
-    page_components = list(walk_components(components))
-    assert components[0].type == "Page"
-    assert any(component.type == "Heading" and component.text == "Add disc" for component in page_components)
-    assert any(component.type == "ModelForm" for component in page_components)
-    assert any(component.type == "Link" and component.on_click.url == "/" for component in page_components)
-
-
-@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
-@pytest.mark.anyio
-async def test_current_tag_banner_event_stream_emits_serialized_updates():
-    from jukebox.domain.entities import CurrentTagStatus
-
-    controller = build_controller()
-    controller.get_current_tag_status.execute.side_effect = [CurrentTagStatus(tag_id="tag-123", known_in_library=False)]
-    request = MagicMock()
-    request.is_disconnected = AsyncMock(side_effect=[False])
-
-    stream = controller._current_tag_banner_event_stream(request, poll_interval_seconds=0)
-    # Avoid the Python 3.10+ `anext` builtin because this repo still supports Python 3.9.
-    first_chunk = await stream.__anext__()
-
-    assert first_chunk.decode("utf-8").startswith("data: [")
-    assert "Unknown disc on reader" in first_chunk.decode("utf-8")
-
-
-@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_create_disc_returns_success_toast():
     from jukebox.adapters.inbound.admin.ui_controller import DiscForm
@@ -1400,18 +1230,6 @@ async def test_delete_disc_returns_404_when_disc_not_found():
 
     assert err.value.status_code == 404
     assert "Disc not found" in err.value.detail
-
-
-@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
-def test_index_page_shows_remove_toast():
-    controller = build_controller()
-    components = controller._build_index_page_components(toast="toast-remove-disc-success")
-    all_components = list(walk_components(components))
-
-    remove_toast = next(
-        component for component in all_components if component.type == "Toast" and "removed" in str(component.body)
-    )
-    assert remove_toast.open_trigger.name == "toast-remove-disc-success"
 
 
 @pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")

--- a/tests/jukebox/adapters/inbound/admin/test_ui_controller.py
+++ b/tests/jukebox/adapters/inbound/admin/test_ui_controller.py
@@ -125,16 +125,8 @@ def build_controller():
     )
 
 
-def walk_components(components):
-    for component in components:
-        yield component
-        children = getattr(component, "components", None)
-        if children:
-            yield from walk_components(children)
-
-
 @pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
-def test_ui_controller_registers_fastui_routes_and_page_structure():
+def test_ui_controller_registers_fastui_routes_and_page_structure(walk_components):
     from jukebox.domain.entities import Disc, DiscMetadata, DiscOption
 
     controller = build_controller()
@@ -259,7 +251,7 @@ def test_ui_controller_registers_fastui_routes_and_page_structure():
 
 
 @pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
-def test_settings_page_groups_entries_and_shows_persisted_and_effective_values():
+def test_settings_page_groups_entries_and_shows_persisted_and_effective_values(walk_components):
     controller = build_controller()
 
     route = next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/ui/settings")
@@ -309,7 +301,7 @@ def test_settings_page_groups_entries_and_shows_persisted_and_effective_values()
 
 
 @pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
-def test_settings_edit_pages_render_select_text_and_json_fields():
+def test_settings_edit_pages_render_select_text_and_json_fields(walk_components):
     controller = build_controller()
     route = next(
         route
@@ -375,7 +367,7 @@ def test_settings_edit_pages_render_select_text_and_json_fields():
 
 
 @pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
-def test_sonos_page_renders_saved_selection_and_discovered_speakers():
+def test_sonos_page_renders_saved_selection_and_discovered_speakers(walk_components):
     controller = build_controller()
     route = next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/ui/sonos")
 
@@ -402,7 +394,7 @@ def test_sonos_page_renders_saved_selection_and_discovered_speakers():
 
 
 @pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
-def test_sonos_edit_page_renders_speaker_and_coordinator_selects():
+def test_sonos_edit_page_renders_speaker_and_coordinator_selects(walk_components):
     controller = build_controller()
     route = next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/ui/sonos/edit")
 
@@ -503,7 +495,7 @@ async def test_update_sonos_selection_returns_field_error_for_invalid_coordinato
 
 
 @pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
-def test_sonos_edit_page_renders_error_banner_and_preserves_submitted_values():
+def test_sonos_edit_page_renders_error_banner_and_preserves_submitted_values(walk_components):
     controller = build_controller()
     route = next(route for route in controller.app.routes if getattr(route, "path", None) == "/api/ui/sonos/edit")
 
@@ -630,7 +622,7 @@ async def test_reset_sonos_selection_calls_service_and_redirects():
 
 
 @pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
-def test_settings_pages_render_error_banner_when_effective_settings_are_unavailable():
+def test_settings_pages_render_error_banner_when_effective_settings_are_unavailable(walk_components):
     from jukebox.settings.errors import InvalidSettingsError
 
     controller = build_controller()
@@ -672,7 +664,7 @@ def test_settings_pages_render_error_banner_when_effective_settings_are_unavaila
 
 
 @pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
-def test_settings_page_renders_mixed_provenance_label():
+def test_settings_page_renders_mixed_provenance_label(walk_components):
     controller = build_controller()
     controller.settings_service.get_effective_settings_view.return_value["provenance"]["jukebox"]["player"]["sonos"][
         "selected_group"
@@ -689,7 +681,7 @@ def test_settings_page_renders_mixed_provenance_label():
 
 
 @pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
-def test_settings_edit_page_renders_empty_object_field_with_placeholder_when_no_value():
+def test_settings_edit_page_renders_empty_object_field_with_placeholder_when_no_value(walk_components):
     controller = build_controller()
     controller.settings_service.get_persisted_settings_view.return_value = {"schema_version": 1}
     controller.settings_service.get_effective_settings_view.return_value = {
@@ -1023,7 +1015,7 @@ async def test_reset_setting_calls_service_and_returns_refreshed_settings_page()
 
 @pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
-async def test_reset_setting_rerenders_edit_page_with_visible_error():
+async def test_reset_setting_rerenders_edit_page_with_visible_error(walk_components):
     from jukebox.settings.errors import InvalidSettingsError
 
     controller = build_controller()

--- a/tests/jukebox/adapters/inbound/admin/ui_pages/test_library_page_builder.py
+++ b/tests/jukebox/adapters/inbound/admin/ui_pages/test_library_page_builder.py
@@ -189,8 +189,7 @@ async def test_current_tag_banner_event_stream_emits_serialized_updates():
     request.is_disconnected = AsyncMock(side_effect=[False])
 
     stream = page_builder.current_tag_banner_event_stream(request, poll_interval_seconds=0)
-    # Avoid the Python 3.10+ `anext` builtin because this repo still supports Python 3.9.
-    first_chunk = await stream.__anext__()
+    first_chunk = await anext(stream)
 
     assert first_chunk.decode("utf-8").startswith("data: [")
     assert "Unknown disc on reader" in first_chunk.decode("utf-8")

--- a/tests/jukebox/adapters/inbound/admin/ui_pages/test_library_page_builder.py
+++ b/tests/jukebox/adapters/inbound/admin/ui_pages/test_library_page_builder.py
@@ -1,0 +1,216 @@
+from importlib import util
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+FASTUI_INSTALLED = util.find_spec("fastui") is not None
+
+
+def walk_components(components):
+    for component in components:
+        yield component
+        children = getattr(component, "components", None)
+        if children:
+            yield from walk_components(children)
+
+
+def build_library_page_builder():
+    from jukebox.adapters.inbound.admin.ui_pages.library import LibraryUIPageBuilder
+
+    list_discs = MagicMock()
+    get_disc = MagicMock()
+    get_current_tag_status = MagicMock()
+    list_discs.execute.return_value = {}
+    get_current_tag_status.execute.return_value = None
+
+    return LibraryUIPageBuilder(
+        list_discs=list_discs,
+        get_disc=get_disc,
+        get_current_tag_status=get_current_tag_status,
+    )
+
+
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
+def test_disc_library_components_render_empty_and_editable_states():
+    from jukebox.adapters.inbound.admin.ui_pages.library import DiscTable
+
+    page_builder = build_library_page_builder()
+    empty_components = page_builder.build_disc_library_components([])
+    populated_components = page_builder.build_disc_library_components(
+        [
+            DiscTable(
+                tag="tag-123",
+                uri="/music/song.mp3",
+                artist="Artist",
+                album="Album",
+                track="Track",
+                shuffle=True,
+            )
+        ]
+    )
+
+    assert empty_components[0].type == "Paragraph"
+    assert empty_components[0].text == "No disc found"
+    edit_button = next(
+        component
+        for component in walk_components(populated_components)
+        if component.type == "Button" and component.text == "Edit ✏️" and component.on_click is not None
+    )
+    assert edit_button.on_click.url == "/discs/tag-123/edit"
+
+
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
+def test_current_tag_banner_for_unknown_disc_offers_add_cta():
+    from jukebox.domain.entities import CurrentTagStatus
+
+    page_builder = build_library_page_builder()
+
+    components = page_builder.build_current_tag_banner_components(
+        CurrentTagStatus(tag_id="tag-123", known_in_library=False)
+    )
+    all_components = list(walk_components(components))
+    heading = next(component for component in all_components if component.type == "Heading")
+    button = next(component for component in all_components if component.type == "Button")
+
+    assert heading.text == "Unknown disc on reader"
+    assert button.text == "Add this disc"
+    assert button.on_click.url == "/discs/new?prefill=current"
+
+
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
+def test_current_tag_banner_for_known_disc_is_informational_only():
+    from jukebox.domain.entities import CurrentTagStatus
+
+    page_builder = build_library_page_builder()
+
+    components = page_builder.build_current_tag_banner_components(
+        CurrentTagStatus(tag_id="tag-123", known_in_library=True)
+    )
+    all_components = list(walk_components(components))
+    button = next(component for component in all_components if component.type == "Button")
+
+    assert any(component.type == "Heading" and component.text == "Known disc on reader" for component in all_components)
+    assert button.text == "Edit this disc"
+    assert button.on_click.url == "/discs/tag-123/edit"
+
+
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
+def test_new_disc_form_components_render_blank_add_form():
+    page_builder = build_library_page_builder()
+
+    components = page_builder.build_new_disc_form_components(prefill_current=False)
+    form = components[0]
+
+    assert form.type == "ModelForm"
+    assert form.submit_url == "/api/ui/discs"
+    assert form.initial is None
+
+
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
+def test_new_disc_form_components_can_prefill_current_tag():
+    from jukebox.domain.entities import CurrentTagStatus
+
+    page_builder = build_library_page_builder()
+    page_builder.get_current_tag_status.execute.return_value = CurrentTagStatus(
+        tag_id="tag-123", known_in_library=False
+    )
+
+    components = page_builder.build_new_disc_form_components(prefill_current=True)
+    form = components[0]
+
+    assert form.type == "ModelForm"
+    assert form.submit_url == "/api/ui/discs"
+    assert form.initial == {"tag": "tag-123", "shuffle": False}
+
+
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
+def test_edit_disc_form_components_prefill_existing_disc():
+    from jukebox.domain.entities import Disc, DiscMetadata, DiscOption
+
+    page_builder = build_library_page_builder()
+    page_builder.get_disc.execute.return_value = Disc(
+        uri="/music/song.mp3",
+        metadata=DiscMetadata(artist="Artist", album="Album", track="Track"),
+        option=DiscOption(shuffle=True),
+    )
+
+    components = page_builder.build_edit_disc_form_components("tag-123")
+    form = components[0]
+
+    assert form.type == "ModelForm"
+    assert form.submit_url == "/api/ui/discs/tag-123"
+    assert form.initial == {
+        "tag": "tag-123",
+        "uri": "/music/song.mp3",
+        "artist": "Artist",
+        "album": "Album",
+        "track": "Track",
+        "shuffle": True,
+    }
+
+
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
+def test_disc_form_helpers_return_errors_for_invalid_current_tag_state_or_missing_edit_target():
+    from jukebox.domain.entities import CurrentTagStatus
+
+    page_builder = build_library_page_builder()
+
+    page_builder.get_current_tag_status.execute.return_value = None
+    no_tag_components = page_builder.build_new_disc_form_components(prefill_current=True)
+    page_builder.get_current_tag_status.execute.return_value = CurrentTagStatus(tag_id="tag-123", known_in_library=True)
+    known_tag_components = page_builder.build_new_disc_form_components(prefill_current=True)
+    missing_tag_components = page_builder.build_edit_disc_form_components("")
+    page_builder.get_disc.execute.side_effect = ValueError("Missing disc")
+    missing_disc_components = page_builder.build_edit_disc_form_components("tag-123")
+
+    assert no_tag_components[0].type == "Error"
+    assert known_tag_components[0].type == "Error"
+    assert missing_tag_components[0].type == "Error"
+    assert missing_disc_components[0].type == "Error"
+
+
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
+def test_form_page_components_include_back_link_and_form():
+    page_builder = build_library_page_builder()
+    components = page_builder.build_form_page_components(
+        title="Add disc",
+        form_components=page_builder.build_new_disc_form_components(prefill_current=False),
+    )
+
+    page_components = list(walk_components(components))
+    assert components[0].type == "Page"
+    assert any(component.type == "Heading" and component.text == "Add disc" for component in page_components)
+    assert any(component.type == "ModelForm" for component in page_components)
+    assert any(component.type == "Link" and component.on_click.url == "/" for component in page_components)
+
+
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
+@pytest.mark.anyio
+async def test_current_tag_banner_event_stream_emits_serialized_updates():
+    from jukebox.domain.entities import CurrentTagStatus
+
+    page_builder = build_library_page_builder()
+    page_builder.get_current_tag_status.execute.side_effect = [
+        CurrentTagStatus(tag_id="tag-123", known_in_library=False)
+    ]
+    request = MagicMock()
+    request.is_disconnected = AsyncMock(side_effect=[False])
+
+    stream = page_builder.current_tag_banner_event_stream(request, poll_interval_seconds=0)
+    # Avoid the Python 3.10+ `anext` builtin because this repo still supports Python 3.9.
+    first_chunk = await stream.__anext__()
+
+    assert first_chunk.decode("utf-8").startswith("data: [")
+    assert "Unknown disc on reader" in first_chunk.decode("utf-8")
+
+
+@pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
+def test_index_page_shows_remove_toast():
+    page_builder = build_library_page_builder()
+    components = page_builder.build_index_page_components(toast="toast-remove-disc-success")
+    all_components = list(walk_components(components))
+
+    remove_toast = next(
+        component for component in all_components if component.type == "Toast" and "removed" in str(component.body)
+    )
+    assert remove_toast.open_trigger.name == "toast-remove-disc-success"

--- a/tests/jukebox/adapters/inbound/admin/ui_pages/test_library_page_builder.py
+++ b/tests/jukebox/adapters/inbound/admin/ui_pages/test_library_page_builder.py
@@ -6,14 +6,6 @@ import pytest
 FASTUI_INSTALLED = util.find_spec("fastui") is not None
 
 
-def walk_components(components):
-    for component in components:
-        yield component
-        children = getattr(component, "components", None)
-        if children:
-            yield from walk_components(children)
-
-
 def build_library_page_builder():
     from jukebox.adapters.inbound.admin.ui_pages.library import LibraryUIPageBuilder
 
@@ -31,7 +23,7 @@ def build_library_page_builder():
 
 
 @pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
-def test_disc_library_components_render_empty_and_editable_states():
+def test_disc_library_components_render_empty_and_editable_states(walk_components):
     from jukebox.adapters.inbound.admin.ui_pages.library import DiscTable
 
     page_builder = build_library_page_builder()
@@ -60,7 +52,7 @@ def test_disc_library_components_render_empty_and_editable_states():
 
 
 @pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
-def test_current_tag_banner_for_unknown_disc_offers_add_cta():
+def test_current_tag_banner_for_unknown_disc_offers_add_cta(walk_components):
     from jukebox.domain.entities import CurrentTagStatus
 
     page_builder = build_library_page_builder()
@@ -78,7 +70,7 @@ def test_current_tag_banner_for_unknown_disc_offers_add_cta():
 
 
 @pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
-def test_current_tag_banner_for_known_disc_is_informational_only():
+def test_current_tag_banner_for_known_disc_is_informational_only(walk_components):
     from jukebox.domain.entities import CurrentTagStatus
 
     page_builder = build_library_page_builder()
@@ -170,7 +162,7 @@ def test_disc_form_helpers_return_errors_for_invalid_current_tag_state_or_missin
 
 
 @pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
-def test_form_page_components_include_back_link_and_form():
+def test_form_page_components_include_back_link_and_form(walk_components):
     page_builder = build_library_page_builder()
     components = page_builder.build_form_page_components(
         title="Add disc",
@@ -205,7 +197,7 @@ async def test_current_tag_banner_event_stream_emits_serialized_updates():
 
 
 @pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
-def test_index_page_shows_remove_toast():
+def test_index_page_shows_remove_toast(walk_components):
     page_builder = build_library_page_builder()
     components = page_builder.build_index_page_components(toast="toast-remove-disc-success")
     all_components = list(walk_components(components))


### PR DESCRIPTION
Closes #220 

## Summary
- Remove wrapper methods in `UIController` that did nothing but delegate to `LibraryUIPageBuilder`, `SettingsUIPageBuilder`, and `SonosUIPageBuilder` (were useful as a transition)
- Route handlers now call page builders directly
- Move the wrapper-level tests to a dedicated `test_library_page_builder.py`
- Extract `walk_components` test helper into a shared conftest fixture
- Replace `__anext__()` workaround with the `anext()` builtin (since we're using Python 3.11+)

Extracting equivalent dedicated tests for settings and sonos page builders is a follow-up item (those tests were not directly affected by removing the controller wrappers).

## Test plan
- All tests pass (`uv run --extra ui pytest`)