### PR TITLE
✨ Migrate interactive library CLI to questionary

### DIFF
--- a/jukebox/adapters/inbound/admin/cli_controller.py
+++ b/jukebox/adapters/inbound/admin/cli_controller.py
@@ -1,5 +1,3 @@
-import logging
-
 import typer
 
 from jukebox.adapters.inbound.admin.cli_display import display_library_line, display_library_table
@@ -19,8 +17,6 @@ from jukebox.domain.use_cases.library.list_discs import ListDiscs
 from jukebox.domain.use_cases.library.remove_disc import RemoveDisc
 from jukebox.domain.use_cases.library.resolve_tag_id import ResolveTagId
 from jukebox.domain.use_cases.library.search_discs import SearchDiscs
-
-LOGGER = logging.getLogger("jukebox.admin")
 
 
 class CLIController:
@@ -59,8 +55,6 @@ class CLIController:
                 self.get_disc_flow(command)
             case CliSearchCommand():
                 self.search_discs_flow(command)
-            case _:
-                LOGGER.error("Command not implemented yet: command='%s'", command)
 
     def add_disc_flow(self, command: CliAddCommand) -> None:
         tag = self.resolve_tag_id.execute(command.tag, command.use_current_tag)

--- a/jukebox/adapters/inbound/admin/cli_controller.py
+++ b/jukebox/adapters/inbound/admin/cli_controller.py
@@ -18,7 +18,7 @@ from jukebox.domain.use_cases.library.remove_disc import RemoveDisc
 from jukebox.domain.use_cases.library.resolve_tag_id import ResolveTagId
 from jukebox.domain.use_cases.library.search_discs import SearchDiscs
 
-LOGGER = logging.getLogger("discstore")
+LOGGER = logging.getLogger("jukebox.admin")
 
 
 class CLIController:

--- a/jukebox/adapters/inbound/admin/cli_controller.py
+++ b/jukebox/adapters/inbound/admin/cli_controller.py
@@ -1,5 +1,7 @@
 import logging
 
+import typer
+
 from jukebox.adapters.inbound.admin.cli_display import display_library_line, display_library_table
 from jukebox.admin.library_commands import (
     CliAddCommand,
@@ -67,7 +69,7 @@ class CLIController:
 
         disc = Disc(uri=command.uri, metadata=metadata, option=option)
         self.add_disc.execute(tag, disc)
-        LOGGER.info("✅ Disc successfully added")
+        typer.echo("✅ Disc successfully added")
 
     def list_discs_flow(self, command: CliListCommand) -> None:
         discs = self.list_discs.execute()
@@ -77,12 +79,12 @@ class CLIController:
         if command.mode == "line":
             display_library_line(discs)
             return
-        LOGGER.error("Displaying mode not implemented yet: mode='%s'", command.mode)
+        typer.echo(f"Displaying mode not implemented yet: mode='{command.mode}'", err=True)
 
     def remove_disc_flow(self, command: CliRemoveCommand) -> None:
         tag = self.resolve_tag_id.execute(command.tag, command.use_current_tag)
         self.remove_disc.execute(tag)
-        LOGGER.info("🗑️ Disc successfully removed")
+        typer.echo("🗑️ Disc successfully removed")
 
     def edit_disc_flow(self, command: CliEditCommand) -> None:
         metadata_fields = {}
@@ -101,7 +103,7 @@ class CLIController:
             metadata=metadata,
             option=None,
         )
-        LOGGER.info("✅ Disc successfully edited")
+        typer.echo("✅ Disc successfully edited")
 
     def get_disc_flow(self, command: CliGetCommand) -> None:
         try:
@@ -115,12 +117,12 @@ class CLIController:
             print(f"  Playlist : {disc.metadata.playlist or '/'}")
             print(f"  Shuffle  : {disc.option.shuffle}")
         except ValueError as e:
-            LOGGER.error(str(e))
+            typer.echo(str(e), err=True)
 
     def search_discs_flow(self, command: CliSearchCommand) -> None:
         results = self.search_discs.execute(command.query)
         if not results:
-            LOGGER.info("No discs found matching '%s'", command.query)
+            typer.echo(f"No discs found matching '{command.query}'")
             return
-        LOGGER.info("Found %d disc(s) matching '%s':", len(results), command.query)
+        typer.echo(f"Found {len(results)} disc(s) matching '{command.query}':")
         display_library_table(results)

--- a/jukebox/adapters/inbound/admin/interactive_cli_controller.py
+++ b/jukebox/adapters/inbound/admin/interactive_cli_controller.py
@@ -8,13 +8,10 @@ from jukebox.domain.use_cases.library.get_current_tag_status import GetCurrentTa
 from jukebox.domain.use_cases.library.list_discs import ListDiscs
 from jukebox.domain.use_cases.library.remove_disc import RemoveDisc
 
-LOGGER = logging.getLogger("discstore")
+LOGGER = logging.getLogger("jukebox.admin")
 
 
 class InteractiveCLIController:
-    available_commands = "\n* " + "\n* ".join(["add", "remove", "list", "edit", "current", "exit", "help"])
-    help_message = f"\nAvailable commands: {available_commands}"
-
     def __init__(
         self,
         add_disc: AddDisc,
@@ -30,76 +27,77 @@ class InteractiveCLIController:
         self.get_current_tag_status = get_current_tag_status
 
     def run(self) -> None:
-        print(self.help_message)
-        while True:
-            command = input("discstore> ")
-            self.handle_command(command)
+        import questionary
 
-    def handle_command(self, command: str) -> None:
-        try:
-            match command:
-                case "add":
-                    self.add_disc_flow()
-                case "remove":
-                    self.remove_disc_flow()
-                case "list":
-                    self.list_discs_flow()
-                case "edit":
-                    self.edit_disc_flow()
-                case "current":
-                    self.current_tag_flow()
-                case "exit":
-                    print("See you soon!")
-                    exit(0)
-                case "help":
-                    print(self.help_message)
-                case _:
-                    print(f"Invalid command `{command}`")
-                    print(self.help_message)
-        except Exception as err:
-            print(f"Error: {err}")
-            LOGGER.error("Error during handling command: %s", err)
+        while True:
+            try:
+                command = questionary.select(
+                    "What do you want to do?",
+                    choices=["add", "remove", "list", "edit", "current"],
+                ).unsafe_ask()
+            except KeyboardInterrupt:
+                return
+
+            try:
+                match command:
+                    case "add":
+                        self.add_disc_flow()
+                    case "remove":
+                        self.remove_disc_flow()
+                    case "list":
+                        self.list_discs_flow()
+                    case "edit":
+                        self.edit_disc_flow()
+                    case "current":
+                        self.current_tag_flow()
+            except KeyboardInterrupt:
+                return
+            except Exception as err:
+                print(f"Error: {err}")
+                LOGGER.error("Error during handling command: %s", err)
 
     def add_disc_flow(self) -> None:
+        import questionary
+
         print("\n-- Add a disc --")
         current_tag_status = self.get_current_tag_status.execute()
         tag = self._prompt_for_tag(current_tag_status, action="add")
-        uri = input("discstore> add uri> ").strip()
-        option = DiscOption()
-        metadata = DiscMetadata()
-
-        disc = Disc(uri=uri, metadata=metadata, option=option)
+        uri = questionary.text("URI:").unsafe_ask()
+        disc = Disc(uri=uri.strip(), metadata=DiscMetadata(), option=DiscOption())
         self.add_disc.execute(tag, disc)
         print("✅ Disc successfully added")
 
     def list_discs_flow(self) -> None:
+        import questionary
+
         print("\n-- List all discs --")
-        mode = input("discstore> list mode(table/line)> ").strip()
+        mode = questionary.select(
+            "Display mode:",
+            choices=["table", "line"],
+        ).unsafe_ask()
 
         discs = self.list_discs.execute()
-        if mode == "table" or mode == "":
+        if mode == "table":
             display_library_table(discs)
-            return
-        if mode == "line":
+        else:
             display_library_line(discs)
-            return
-        print(f"Displaying mode not implemented yet: `{mode}`")
 
     def remove_disc_flow(self) -> None:
+        import questionary
+
         print("\n-- Remove a disc --")
-        tag = input("discstore> remove tag> ").strip()
-        self.remove_disc.execute(tag)
+        tag = questionary.text("Tag ID:").unsafe_ask()
+        self.remove_disc.execute(tag.strip())
         print("🗑️ Disc successfully removed")
 
     def edit_disc_flow(self) -> None:
+        import questionary
+
         print("\n-- Edit a disc --")
         current_tag_status = self.get_current_tag_status.execute()
         tag = self._prompt_for_tag(current_tag_status, action="edit")
-        uri = input("discstore> edit uri> ").strip()
-        option = DiscOption()
-        metadata = DiscMetadata()
-
-        self.edit_disc.execute(tag, uri, metadata, option)
+        uri = questionary.text("URI:").unsafe_ask()
+        self.edit_disc.execute(tag, uri.strip(), DiscMetadata(), DiscOption())
         print("✅ Disc successfully edited")
 
     def current_tag_flow(self) -> None:
@@ -113,20 +111,17 @@ class InteractiveCLIController:
         print(f"Known in library : {'yes' if current_tag_status.known_in_library else 'no'}")
 
     def _prompt_for_tag(self, current_tag_status: CurrentTagStatus | None, action: str) -> str:
+        import questionary
+
         default_tag = ""
         if current_tag_status is not None and (
             (action == "add" and not current_tag_status.known_in_library)
             or (action == "edit" and current_tag_status.known_in_library)
         ):
             default_tag = current_tag_status.tag_id
-        prompt = f"discstore> {action} tag"
-        if default_tag:
-            prompt += f" [{default_tag}]"
-        prompt += "> "
 
-        entered_tag = input(prompt).strip()
-        tag = entered_tag or default_tag
+        entered_tag = questionary.text(f"Tag ID ({action}):", default=default_tag).unsafe_ask()
+        tag = (entered_tag or "").strip() or default_tag
         if not tag:
             raise ValueError("A tag ID is required.")
-
         return tag

--- a/jukebox/adapters/inbound/admin/interactive_cli_controller.py
+++ b/jukebox/adapters/inbound/admin/interactive_cli_controller.py
@@ -1,5 +1,7 @@
 import logging
 
+import typer
+
 from jukebox.adapters.inbound.admin.cli_display import display_library_line, display_library_table
 from jukebox.domain.entities import CurrentTagStatus, Disc, DiscMetadata, DiscOption
 from jukebox.domain.use_cases.library.add_disc import AddDisc
@@ -53,7 +55,7 @@ class InteractiveCLIController:
             except KeyboardInterrupt:
                 return
             except Exception as err:
-                print(f"Error: {err}")
+                typer.echo(f"Error: {err}", err=True)
                 LOGGER.error("Error during handling command: %s", err)
 
     def add_disc_flow(self) -> None:

--- a/jukebox/adapters/inbound/admin/interactive_cli_controller.py
+++ b/jukebox/adapters/inbound/admin/interactive_cli_controller.py
@@ -1,5 +1,3 @@
-import logging
-
 import typer
 
 from jukebox.adapters.inbound.admin.cli_display import display_library_line, display_library_table
@@ -9,8 +7,6 @@ from jukebox.domain.use_cases.library.edit_disc import EditDisc
 from jukebox.domain.use_cases.library.get_current_tag_status import GetCurrentTagStatus
 from jukebox.domain.use_cases.library.list_discs import ListDiscs
 from jukebox.domain.use_cases.library.remove_disc import RemoveDisc
-
-LOGGER = logging.getLogger("jukebox.admin")
 
 
 class InteractiveCLIController:
@@ -56,7 +52,6 @@ class InteractiveCLIController:
                 return
             except Exception as err:
                 typer.echo(f"Error: {err}", err=True)
-                LOGGER.error("Error during handling command: %s", err)
 
     def add_disc_flow(self) -> None:
         import questionary

--- a/jukebox/adapters/inbound/cli_controller.py
+++ b/jukebox/adapters/inbound/cli_controller.py
@@ -1,4 +1,3 @@
-import logging
 import time
 from time import sleep
 
@@ -6,8 +5,6 @@ from jukebox.domain.entities import PlaybackSession, TagEvent
 from jukebox.domain.ports import ReaderPort
 from jukebox.domain.use_cases.handle_tag_event import HandleTagEvent
 from jukebox.shared.timing import DEFAULT_LOOP_INTERVAL_SECONDS
-
-LOGGER = logging.getLogger("jukebox")
 
 
 class CLIController:

--- a/tests/jukebox/adapters/inbound/admin/test_cli_controller.py
+++ b/tests/jukebox/adapters/inbound/admin/test_cli_controller.py
@@ -123,7 +123,7 @@ def test_get_disc_flow_logs_error_when_current_tag_is_missing(caplog, capsys):
     controller.resolve_tag_id.execute.side_effect = ValueError("No current tag is available.")
     command = CliGetCommand(type="get", use_current_tag=True)
 
-    with caplog.at_level("ERROR", logger="discstore"):
+    with caplog.at_level("ERROR", logger="jukebox.admin"):
         controller.get_disc_flow(command)
 
     controller.get_disc.execute.assert_not_called()
@@ -137,7 +137,7 @@ def test_get_disc_flow_logs_error_when_tag_is_missing(caplog, capsys):
     controller.get_disc.execute.side_effect = ValueError("Tag not found: tag_id='missing-tag'")
     command = CliGetCommand(type="get", tag="missing-tag")
 
-    with caplog.at_level("ERROR", logger="discstore"):
+    with caplog.at_level("ERROR", logger="jukebox.admin"):
         controller.get_disc_flow(command)
 
     controller.get_disc.execute.assert_called_once_with("missing-tag")

--- a/tests/jukebox/adapters/inbound/admin/test_cli_controller.py
+++ b/tests/jukebox/adapters/inbound/admin/test_cli_controller.py
@@ -118,31 +118,31 @@ def test_get_disc_flow_resolves_current_tag_without_clearing(capsys):
     ]
 
 
-def test_get_disc_flow_logs_error_when_current_tag_is_missing(caplog, capsys):
+def test_get_disc_flow_outputs_error_when_current_tag_is_missing(capsys):
     controller = build_controller()
     controller.resolve_tag_id.execute.side_effect = ValueError("No current tag is available.")
     command = CliGetCommand(type="get", use_current_tag=True)
 
-    with caplog.at_level("ERROR", logger="jukebox.admin"):
-        controller.get_disc_flow(command)
+    controller.get_disc_flow(command)
 
     controller.get_disc.execute.assert_not_called()
-    assert "No current tag is available." in caplog.text
-    assert capsys.readouterr().out == ""
+    output = capsys.readouterr()
+    assert "No current tag is available." in output.err
+    assert output.out == ""
 
 
-def test_get_disc_flow_logs_error_when_tag_is_missing(caplog, capsys):
+def test_get_disc_flow_outputs_error_when_tag_is_missing(capsys):
     controller = build_controller()
     controller.resolve_tag_id.execute.return_value = "missing-tag"
     controller.get_disc.execute.side_effect = ValueError("Tag not found: tag_id='missing-tag'")
     command = CliGetCommand(type="get", tag="missing-tag")
 
-    with caplog.at_level("ERROR", logger="jukebox.admin"):
-        controller.get_disc_flow(command)
+    controller.get_disc_flow(command)
 
     controller.get_disc.execute.assert_called_once_with("missing-tag")
-    assert "Tag not found: tag_id='missing-tag'" in caplog.text
-    assert capsys.readouterr().out == ""
+    output = capsys.readouterr()
+    assert "Tag not found: tag_id='missing-tag'" in output.err
+    assert output.out == ""
 
 
 def test_run_propagates_command_errors():

--- a/tests/jukebox/adapters/inbound/admin/test_interactive_cli_controller.py
+++ b/tests/jukebox/adapters/inbound/admin/test_interactive_cli_controller.py
@@ -14,11 +14,17 @@ def build_controller():
     )
 
 
+def _mock_text(*responses):
+    """Replace questionary.text so each .unsafe_ask() call returns the next response."""
+    mock_ask = MagicMock(side_effect=responses)
+    return MagicMock(return_value=MagicMock(unsafe_ask=mock_ask))
+
+
 def test_handle_current_command_displays_current_tag(capsys):
     controller = build_controller()
     controller.get_current_tag_status.execute.return_value = CurrentTagStatus(tag_id="tag-123", known_in_library=False)
 
-    controller.handle_command("current")
+    controller.current_tag_flow()
 
     controller.get_current_tag_status.execute.assert_called_once_with()
     assert capsys.readouterr().out.splitlines() == [
@@ -33,7 +39,7 @@ def test_add_disc_flow_uses_current_tag_default_for_unknown_disc():
     controller = build_controller()
     controller.get_current_tag_status.execute.return_value = CurrentTagStatus(tag_id="tag-123", known_in_library=False)
 
-    with patch("builtins.input", side_effect=["", "/music/song.mp3"]), patch("builtins.print"):
+    with patch("questionary.text", _mock_text("", "/music/song.mp3")), patch("builtins.print"):
         controller.add_disc_flow()
 
     controller.add_disc.execute.assert_called_once_with(
@@ -46,7 +52,7 @@ def test_edit_disc_flow_uses_current_tag_as_default():
     controller = build_controller()
     controller.get_current_tag_status.execute.return_value = CurrentTagStatus(tag_id="tag-456", known_in_library=True)
 
-    with patch("builtins.input", side_effect=["", "/music/updated.mp3"]), patch("builtins.print"):
+    with patch("questionary.text", _mock_text("", "/music/updated.mp3")), patch("builtins.print"):
         controller.edit_disc_flow()
 
     controller.edit_disc.execute.assert_called_once_with(
@@ -61,7 +67,7 @@ def test_add_disc_flow_does_not_default_to_known_library_tag():
     controller = build_controller()
     controller.get_current_tag_status.execute.return_value = CurrentTagStatus(tag_id="tag-123", known_in_library=True)
 
-    with patch("builtins.input", side_effect=["other-tag", "/music/song.mp3"]), patch("builtins.print"):
+    with patch("questionary.text", _mock_text("other-tag", "/music/song.mp3")), patch("builtins.print"):
         controller.add_disc_flow()
 
     controller.add_disc.execute.assert_called_once_with(
@@ -73,7 +79,7 @@ def test_add_disc_flow_does_not_default_to_known_library_tag():
 def test_remove_disc_flow_removes_requested_tag():
     controller = build_controller()
 
-    with patch("builtins.input", side_effect=["tag-123"]), patch("builtins.print"):
+    with patch("questionary.text", _mock_text("tag-123")), patch("builtins.print"):
         controller.remove_disc_flow()
 
     controller.remove_disc.execute.assert_called_once_with("tag-123")
@@ -83,7 +89,7 @@ def test_remove_disc_flow_propagates_remove_failures():
     controller = build_controller()
     controller.remove_disc.execute.side_effect = ValueError("Tag does not exist")
 
-    with patch("builtins.input", side_effect=["tag-123"]), patch("builtins.print"):
+    with patch("questionary.text", _mock_text("tag-123")), patch("builtins.print"):
         try:
             controller.remove_disc_flow()
         except ValueError as err:
@@ -96,7 +102,7 @@ def test_edit_disc_flow_requires_explicit_tag_when_current_tag_is_unknown():
     controller = build_controller()
     controller.get_current_tag_status.execute.return_value = CurrentTagStatus(tag_id="tag-456", known_in_library=False)
 
-    with patch("builtins.input", side_effect=[""]), patch("builtins.print"):
+    with patch("questionary.text", _mock_text("")), patch("builtins.print"):
         try:
             controller.edit_disc_flow()
         except ValueError as err:
@@ -109,7 +115,7 @@ def test_add_disc_flow_requires_a_tag_when_no_current_tag_exists():
     controller = build_controller()
     controller.get_current_tag_status.execute.return_value = None
 
-    with patch("builtins.input", side_effect=[""]), patch("builtins.print"):
+    with patch("questionary.text", _mock_text("")), patch("builtins.print"):
         try:
             controller.add_disc_flow()
         except ValueError as err:

--- a/tests/jukebox/adapters/inbound/admin/test_interactive_cli_controller.py
+++ b/tests/jukebox/adapters/inbound/admin/test_interactive_cli_controller.py
@@ -20,6 +20,11 @@ def _mock_text(*responses):
     return MagicMock(return_value=MagicMock(unsafe_ask=mock_ask))
 
 
+def _mock_select(response):
+    """Replace questionary.select so .unsafe_ask() returns response."""
+    return MagicMock(return_value=MagicMock(unsafe_ask=MagicMock(return_value=response)))
+
+
 def test_handle_current_command_displays_current_tag(capsys):
     controller = build_controller()
     controller.get_current_tag_status.execute.return_value = CurrentTagStatus(tag_id="tag-123", known_in_library=False)
@@ -122,3 +127,62 @@ def test_add_disc_flow_requires_a_tag_when_no_current_tag_exists():
             assert str(err) == "A tag ID is required."
         else:
             raise AssertionError("Expected ValueError")
+
+
+def test_list_discs_flow_displays_table(capsys):
+    controller = build_controller()
+    controller.list_discs.execute.return_value = []
+
+    with (
+        patch("questionary.select", _mock_select("table")),
+        patch("builtins.print"),
+        patch("jukebox.adapters.inbound.admin.interactive_cli_controller.display_library_table") as mock_table,
+        patch("jukebox.adapters.inbound.admin.interactive_cli_controller.display_library_line") as mock_line,
+    ):
+        controller.list_discs_flow()
+
+    mock_table.assert_called_once_with([])
+    mock_line.assert_not_called()
+
+
+def test_list_discs_flow_displays_line(capsys):
+    controller = build_controller()
+    controller.list_discs.execute.return_value = []
+
+    with (
+        patch("questionary.select", _mock_select("line")),
+        patch("builtins.print"),
+        patch("jukebox.adapters.inbound.admin.interactive_cli_controller.display_library_table") as mock_table,
+        patch("jukebox.adapters.inbound.admin.interactive_cli_controller.display_library_line") as mock_line,
+    ):
+        controller.list_discs_flow()
+
+    mock_line.assert_called_once_with([])
+    mock_table.assert_not_called()
+
+
+def test_run_exits_on_keyboard_interrupt():
+    controller = build_controller()
+    mock_select = MagicMock(return_value=MagicMock(unsafe_ask=MagicMock(side_effect=KeyboardInterrupt)))
+
+    with patch("questionary.select", mock_select):
+        controller.run()
+
+
+def test_run_dispatches_command_then_exits():
+    controller = build_controller()
+    controller.get_current_tag_status.execute.return_value = CurrentTagStatus(tag_id="tag-1", known_in_library=False)
+    select_responses = iter(["current", KeyboardInterrupt()])
+
+    def mock_unsafe_ask():
+        val = next(select_responses)
+        if isinstance(val, KeyboardInterrupt):
+            raise val
+        return val
+
+    mock_select = MagicMock(return_value=MagicMock(unsafe_ask=mock_unsafe_ask))
+
+    with patch("questionary.select", mock_select), patch("builtins.print"):
+        controller.run()
+
+    controller.get_current_tag_status.execute.assert_called_once_with()


### PR DESCRIPTION
## Summary

- Replace all `input()` prompts in `InteractiveCLIController` with `questionary.select` (command menu, list display mode) and `questionary.text` (tag ID, URI inputs)
- Rename `discstore` logger to `jukebox.admin` in both admin CLI controllers
- Fix Ctrl+C exit: use `unsafe_ask()` so `KeyboardInterrupt` propagates to the loop's `except` clause instead of being swallowed by `ask()`
- Replace `LOGGER.info/error` with `typer.echo` for user-facing messages in `CLIController` (admin) — success/search output to stdout, errors to stderr via `err=True`
- Route error output to stderr via `typer.echo(err=True)` in `InteractiveCLIController`
- Remove unused `LOGGER` from `jukebox/adapters/inbound/cli_controller.py`
- Add missing tests: `list_discs_flow` (table/line), `run()` dispatch and exit

Part of #234, closes #255.

## Test plan

- `uv run jukebox-admin library interactive`: verify questionary prompts appear, Ctrl+C exits cleanly, error messages go to stderr