### PR TITLE
✨ Replace display_library_table with rich.Table

### DIFF
--- a/jukebox/adapters/inbound/admin/cli_controller.py
+++ b/jukebox/adapters/inbound/admin/cli_controller.py
@@ -1,6 +1,6 @@
 import typer
 
-from jukebox.adapters.inbound.admin.cli_display import display_library_line, display_library_table
+from jukebox.adapters.inbound.admin.cli_display import display_disc, display_library_line, display_library_table
 from jukebox.admin.library_commands import (
     CliAddCommand,
     CliEditCommand,
@@ -103,13 +103,7 @@ class CLIController:
         try:
             tag = self.resolve_tag_id.execute(command.tag, command.use_current_tag)
             disc = self.get_disc.execute(tag)
-            print(f"\n📀 Disc: {tag}")
-            print(f"  URI      : {disc.uri}")
-            print(f"  Artist   : {disc.metadata.artist or '/'}")
-            print(f"  Album    : {disc.metadata.album or '/'}")
-            print(f"  Track    : {disc.metadata.track or '/'}")
-            print(f"  Playlist : {disc.metadata.playlist or '/'}")
-            print(f"  Shuffle  : {disc.option.shuffle}")
+            display_disc(tag, disc)
         except ValueError as e:
             typer.echo(str(e), err=True)
 

--- a/jukebox/adapters/inbound/admin/cli_display.py
+++ b/jukebox/adapters/inbound/admin/cli_display.py
@@ -1,6 +1,7 @@
-from jukebox.domain.entities import Disc
+from rich.console import Console
+from rich.table import Table
 
-MAX_COL_WIDTH = 20
+from jukebox.domain.entities import Disc
 
 
 def display_library_line(discs: dict[str, Disc]) -> None:
@@ -20,39 +21,29 @@ def display_library_line(discs: dict[str, Disc]) -> None:
         print("-" * 30)
 
 
-def truncate(text: str, max_length: int) -> str:
-    if len(text) <= max_length:
-        return text
-    return text[: max_length - 3] + "..."
-
-
 def display_library_table(discs: dict[str, Disc]) -> None:
     if not discs:
         print("The library is empty")
         return
 
-    headers = ["ID", "URI", "Artist", "Album", "Track", "Playlist", "Shuffle"]
-    rows = []
+    table = Table(title="Discs Library")
+    table.add_column("ID", no_wrap=True, max_width=20)
+    table.add_column("URI", no_wrap=True, max_width=20)
+    table.add_column("Artist", no_wrap=True, max_width=20)
+    table.add_column("Album", no_wrap=True, max_width=20)
+    table.add_column("Track", no_wrap=True, max_width=20)
+    table.add_column("Playlist", no_wrap=True, max_width=20)
+    table.add_column("Shuffle")
+
     for disc_id, disc in discs.items():
-        rows.append(
-            [
-                truncate(str(disc_id), MAX_COL_WIDTH),
-                truncate(disc.uri, MAX_COL_WIDTH),
-                truncate(disc.metadata.artist or "/", MAX_COL_WIDTH),
-                truncate(disc.metadata.album or "/", MAX_COL_WIDTH),
-                truncate(disc.metadata.track or "/", MAX_COL_WIDTH),
-                truncate(disc.metadata.playlist or "/", MAX_COL_WIDTH),
-                str(disc.option.shuffle),
-            ]
+        table.add_row(
+            str(disc_id),
+            disc.uri,
+            disc.metadata.artist or "/",
+            disc.metadata.album or "/",
+            disc.metadata.track or "/",
+            disc.metadata.playlist or "/",
+            str(disc.option.shuffle),
         )
 
-    cols = list(zip(*([headers] + rows)))
-    col_widths = [max(len(str(item)) for item in col) for col in cols]
-
-    def format_line(line):
-        return " | ".join(f"{str(item):<{col_widths[i]}}" for i, item in enumerate(line))
-
-    print(format_line(headers))
-    print("-+-".join("-" * w for w in col_widths))
-    for row in rows:
-        print(format_line(row))
+    Console().print(table)

--- a/jukebox/adapters/inbound/admin/cli_display.py
+++ b/jukebox/adapters/inbound/admin/cli_display.py
@@ -4,6 +4,16 @@ from rich.table import Table
 from jukebox.domain.entities import Disc
 
 
+def display_disc(tag_id: str, disc: Disc) -> None:
+    print(f"\n📀 Disc: {tag_id}")
+    print(f"  URI      : {disc.uri}")
+    print(f"  Artist   : {disc.metadata.artist or '/'}")
+    print(f"  Album    : {disc.metadata.album or '/'}")
+    print(f"  Track    : {disc.metadata.track or '/'}")
+    print(f"  Playlist : {disc.metadata.playlist or '/'}")
+    print(f"  Shuffle  : {disc.option.shuffle}")
+
+
 def display_library_line(discs: dict[str, Disc]) -> None:
     if not discs:
         print("The library is empty")

--- a/tests/jukebox/adapters/inbound/admin/test_cli_display.py
+++ b/tests/jukebox/adapters/inbound/admin/test_cli_display.py
@@ -1,7 +1,9 @@
 import sys
 from io import StringIO
+from unittest.mock import MagicMock, patch
 
 import pytest
+from rich.table import Table
 
 from jukebox.adapters.inbound.admin.cli_display import display_library_line, display_library_table
 from jukebox.domain.entities import Disc, DiscMetadata, DiscOption
@@ -56,10 +58,18 @@ ID : xyz789
 
 
 def test_display_library_table(sample_discs):
-    output = capture_output(display_library_table, sample_discs).split("\n")
-    assert len(output) == 5
-    assert output[0] == "ID     | URI                | Artist         | Album      | Track      | Playlist | Shuffle"  # fmt: skip
-    assert output[1] == "-------+--------------------+----------------+------------+------------+----------+--------"  # fmt: skip
-    assert output[2] == "abc123 | /path/to/music.mp3 | Test Artist    | Test Album | Test Track | /        | True   "  # fmt: skip
-    assert output[3] == "xyz789 | /another/track.mp3 | Another Artist | /          | /          | /        | False  "  # fmt: skip
-    assert output[4] == ""
+    with patch("jukebox.adapters.inbound.admin.cli_display.Console") as mock_console_cls:
+        mock_console = MagicMock()
+        mock_console_cls.return_value = mock_console
+        display_library_table(sample_discs)
+
+    mock_console.print.assert_called_once()
+    table = mock_console.print.call_args[0][0]
+
+    assert isinstance(table, Table)
+    assert table.title == "Discs Library"
+    assert table.row_count == 2
+    assert [col.header for col in table.columns] == ["ID", "URI", "Artist", "Album", "Track", "Playlist", "Shuffle"]
+    assert list(table.columns[0]._cells) == ["abc123", "xyz789"]
+    assert list(table.columns[1]._cells) == ["/path/to/music.mp3", "/another/track.mp3"]
+    assert list(table.columns[2]._cells) == ["Test Artist", "Another Artist"]


### PR DESCRIPTION
## Summary

- Replace manual ASCII table rendering in `display_library_table` with `rich.Table`, removes column width calculation, truncation logic, and separator formatting
- Add `Table(title="Discs Library")` with `no_wrap=True, max_width=20` on text columns
- Extract `display_disc(tag_id, disc)` to `cli_display.py` and reuse in `CLIController.get_disc_flow`, removing inline duplication

## Test plan

- [ ] Manual: `uv run jukebox-admin library list`: verify Rich table renders correctly
- [ ] Manual: `uv run jukebox-admin library get`: verify disc display unchanged