### PR TITLE
♻️ address review findings on rich.Table migration

### DIFF
--- a/jukebox/adapters/inbound/admin/cli_display.py
+++ b/jukebox/adapters/inbound/admin/cli_display.py
@@ -6,14 +6,15 @@ from jukebox.domain.entities import Disc
 MAX_COL_WIDTH = 20
 
 
-def display_disc(tag_id: str, disc: Disc) -> None:
-    print(f"\n📀 Disc: {tag_id}")
-    print(f"  URI      : {disc.uri}")
-    print(f"  Artist   : {disc.metadata.artist or '/'}")
-    print(f"  Album    : {disc.metadata.album or '/'}")
-    print(f"  Track    : {disc.metadata.track or '/'}")
-    print(f"  Playlist : {disc.metadata.playlist or '/'}")
-    print(f"  Shuffle  : {disc.option.shuffle}")
+def display_disc(tag_id: str, disc: Disc, console: Console | None = None) -> None:
+    _console = console or Console()
+    _console.print(f"\n📀 Disc: {tag_id}")
+    _console.print(f"  URI      : {disc.uri}")
+    _console.print(f"  Artist   : {disc.metadata.artist or '/'}")
+    _console.print(f"  Album    : {disc.metadata.album or '/'}")
+    _console.print(f"  Track    : {disc.metadata.track or '/'}")
+    _console.print(f"  Playlist : {disc.metadata.playlist or '/'}")
+    _console.print(f"  Shuffle  : {disc.option.shuffle}")
 
 
 def display_library_line(discs: dict[str, Disc]) -> None:

--- a/jukebox/adapters/inbound/admin/cli_display.py
+++ b/jukebox/adapters/inbound/admin/cli_display.py
@@ -37,7 +37,7 @@ def display_library_line(discs: dict[str, Disc]) -> None:
 def display_library_table(discs: dict[str, Disc], console: Console | None = None) -> None:
     _console = console or Console()
     if not discs:
-        print("The library is empty")
+        _console.print("The library is empty")
         return
 
     table = Table(title="Discs Library")

--- a/jukebox/adapters/inbound/admin/cli_display.py
+++ b/jukebox/adapters/inbound/admin/cli_display.py
@@ -33,7 +33,8 @@ def display_library_line(discs: dict[str, Disc]) -> None:
         print("-" * 30)
 
 
-def display_library_table(discs: dict[str, Disc]) -> None:
+def display_library_table(discs: dict[str, Disc], console: Console | None = None) -> None:
+    _console = console or Console()
     if not discs:
         print("The library is empty")
         return
@@ -58,4 +59,4 @@ def display_library_table(discs: dict[str, Disc]) -> None:
             str(disc.option.shuffle),
         )
 
-    Console().print(table)
+    _console.print(table)

--- a/jukebox/adapters/inbound/admin/cli_display.py
+++ b/jukebox/adapters/inbound/admin/cli_display.py
@@ -3,6 +3,8 @@ from rich.table import Table
 
 from jukebox.domain.entities import Disc
 
+MAX_COL_WIDTH = 20
+
 
 def display_disc(tag_id: str, disc: Disc) -> None:
     print(f"\n📀 Disc: {tag_id}")
@@ -37,12 +39,12 @@ def display_library_table(discs: dict[str, Disc]) -> None:
         return
 
     table = Table(title="Discs Library")
-    table.add_column("ID", no_wrap=True, max_width=20)
-    table.add_column("URI", no_wrap=True, max_width=20)
-    table.add_column("Artist", no_wrap=True, max_width=20)
-    table.add_column("Album", no_wrap=True, max_width=20)
-    table.add_column("Track", no_wrap=True, max_width=20)
-    table.add_column("Playlist", no_wrap=True, max_width=20)
+    table.add_column("ID", no_wrap=True, max_width=MAX_COL_WIDTH)
+    table.add_column("URI", no_wrap=True, max_width=MAX_COL_WIDTH)
+    table.add_column("Artist", no_wrap=True, max_width=MAX_COL_WIDTH)
+    table.add_column("Album", no_wrap=True, max_width=MAX_COL_WIDTH)
+    table.add_column("Track", no_wrap=True, max_width=MAX_COL_WIDTH)
+    table.add_column("Playlist", no_wrap=True, max_width=MAX_COL_WIDTH)
     table.add_column("Shuffle")
 
     for disc_id, disc in discs.items():

--- a/tests/jukebox/adapters/inbound/admin/test_cli_display.py
+++ b/tests/jukebox/adapters/inbound/admin/test_cli_display.py
@@ -1,9 +1,8 @@
 import sys
 from io import StringIO
-from unittest.mock import MagicMock, patch
 
 import pytest
-from rich.table import Table
+from rich.console import Console
 
 from jukebox.adapters.inbound.admin.cli_display import display_library_line, display_library_table
 from jukebox.domain.entities import Disc, DiscMetadata, DiscOption
@@ -58,18 +57,16 @@ ID : xyz789
 
 
 def test_display_library_table(sample_discs):
-    with patch("jukebox.adapters.inbound.admin.cli_display.Console") as mock_console_cls:
-        mock_console = MagicMock()
-        mock_console_cls.return_value = mock_console
-        display_library_table(sample_discs)
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=False, no_color=True, width=200)
+    display_library_table(sample_discs, console=console)
+    output = buf.getvalue()
 
-    mock_console.print.assert_called_once()
-    table = mock_console.print.call_args[0][0]
-
-    assert isinstance(table, Table)
-    assert table.title == "Discs Library"
-    assert table.row_count == 2
-    assert [col.header for col in table.columns] == ["ID", "URI", "Artist", "Album", "Track", "Playlist", "Shuffle"]
-    assert list(table.columns[0]._cells) == ["abc123", "xyz789"]
-    assert list(table.columns[1]._cells) == ["/path/to/music.mp3", "/another/track.mp3"]
-    assert list(table.columns[2]._cells) == ["Test Artist", "Another Artist"]
+    assert "Discs Library" in output
+    assert "abc123" in output
+    assert "xyz789" in output
+    assert "/path/to/music.mp3" in output
+    assert "Test Artist" in output
+    assert "Another Artist" in output
+    assert "ID" in output
+    assert "URI" in output

--- a/tests/jukebox/adapters/inbound/admin/test_cli_display.py
+++ b/tests/jukebox/adapters/inbound/admin/test_cli_display.py
@@ -63,6 +63,12 @@ ID : xyz789
     )
 
 
+def test_display_library_table_empty(console_capture):
+    console, buf = console_capture
+    display_library_table({}, console=console)
+    assert "The library is empty" in buf.getvalue()
+
+
 def test_display_library_table(sample_discs, console_capture):
     console, buf = console_capture
     display_library_table(sample_discs, console=console)

--- a/tests/jukebox/adapters/inbound/admin/test_cli_display.py
+++ b/tests/jukebox/adapters/inbound/admin/test_cli_display.py
@@ -4,7 +4,7 @@ from io import StringIO
 import pytest
 from rich.console import Console
 
-from jukebox.adapters.inbound.admin.cli_display import display_library_line, display_library_table
+from jukebox.adapters.inbound.admin.cli_display import display_disc, display_library_line, display_library_table
 from jukebox.domain.entities import Disc, DiscMetadata, DiscOption
 
 
@@ -70,3 +70,33 @@ def test_display_library_table(sample_discs):
     assert "Another Artist" in output
     assert "ID" in output
     assert "URI" in output
+
+
+def test_display_disc(sample_discs):
+    disc = sample_discs["abc123"]
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=False, no_color=True, width=200)
+    display_disc("abc123", disc, console=console)
+    output = buf.getvalue()
+
+    assert "📀 Disc: abc123" in output
+    assert "/path/to/music.mp3" in output
+    assert "Test Artist" in output
+    assert "Test Album" in output
+    assert "Test Track" in output
+    assert "Playlist : /" in output
+    assert "True" in output
+
+
+def test_display_disc_shows_fallback_for_missing_metadata():
+    disc = Disc(uri="/track.mp3", metadata=DiscMetadata(), option=DiscOption())
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=False, no_color=True, width=200)
+    display_disc("tag-1", disc, console=console)
+    output = buf.getvalue()
+
+    assert "tag-1" in output
+    assert "Artist   : /" in output
+    assert "Album    : /" in output
+    assert "Track    : /" in output
+    assert "Playlist : /" in output

--- a/tests/jukebox/adapters/inbound/admin/test_cli_display.py
+++ b/tests/jukebox/adapters/inbound/admin/test_cli_display.py
@@ -20,6 +20,13 @@ def sample_discs() -> dict[str, Disc]:
     }
 
 
+@pytest.fixture
+def console_capture() -> tuple[Console, StringIO]:
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=False, no_color=True, width=200)
+    return console, buf
+
+
 def capture_output(func, *args, **kwargs):
     old_stdout = sys.stdout
     sys.stdout = StringIO()
@@ -56,9 +63,8 @@ ID : xyz789
     )
 
 
-def test_display_library_table(sample_discs):
-    buf = StringIO()
-    console = Console(file=buf, force_terminal=False, no_color=True, width=200)
+def test_display_library_table(sample_discs, console_capture):
+    console, buf = console_capture
     display_library_table(sample_discs, console=console)
     output = buf.getvalue()
 
@@ -72,10 +78,9 @@ def test_display_library_table(sample_discs):
     assert "URI" in output
 
 
-def test_display_disc(sample_discs):
+def test_display_disc(sample_discs, console_capture):
     disc = sample_discs["abc123"]
-    buf = StringIO()
-    console = Console(file=buf, force_terminal=False, no_color=True, width=200)
+    console, buf = console_capture
     display_disc("abc123", disc, console=console)
     output = buf.getvalue()
 
@@ -88,10 +93,9 @@ def test_display_disc(sample_discs):
     assert "True" in output
 
 
-def test_display_disc_shows_fallback_for_missing_metadata():
+def test_display_disc_shows_fallback_for_missing_metadata(console_capture):
     disc = Disc(uri="/track.mp3", metadata=DiscMetadata(), option=DiscOption())
-    buf = StringIO()
-    console = Console(file=buf, force_terminal=False, no_color=True, width=200)
+    console, buf = console_capture
     display_disc("tag-1", disc, console=console)
     output = buf.getvalue()
 


### PR DESCRIPTION
## Summary

Follow-up to #267, addressing code review findings:

- Restore `MAX_COL_WIDTH = 20` module-level constant (was deleted in #267)
- Inject `Console` as optional parameter in `display_library_table` and `display_disc` — removes need to mock `Console` in tests
- Replace `_cells` private Rich API in tests with rendered string assertions via `Console(file=StringIO(), force_terminal=False)`
- Migrate `display_disc` to `Console` for consistency with `display_library_table`
- Add missing tests for `display_disc` (happy path + missing metadata fallback)