### PR TITLE
docs: update architecture diagram in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,14 +57,22 @@ uv run --extra ui pytest
 `jukebox` follows **Hexagonal Architecture** (Ports & Adapters):
 
 ```
-<module>/
+jukebox/
 ├── domain/
 │   ├── entities/        # Pydantic value objects
-│   ├── repositories/    # Abstract port interfaces
+│   ├── ports/           # Abstract port interfaces (PlayerPort, ReaderPort)
+│   ├── repositories/    # Abstract repository interfaces (LibraryRepository, CurrentTagRepository)
 │   └── use_cases/       # Business logic (no external deps)
 ├── adapters/
 │   ├── inbound/         # CLI, API, UI controllers
-│   └── outbound/        # Players, readers, JSON persistence
+│   │   └── admin/       # Admin-specific inbound adapters (CLI, API, UI)
+│   └── outbound/        # Persistence and external service adapters
+│       ├── players/     # Player adapters (dryrun, sonos)
+│       └── readers/     # Reader adapters (dryrun, pn532)
+├── admin/               # Admin app wiring and command handlers
+├── settings/            # Settings resolution, persistence, and validation
+├── shared/              # Cross-cutting utilities (logger, timing, errors)
+├── sonos/               # Sonos-specific domain logic
 └── di_container.py      # Wires all dependencies
 ```
 


### PR DESCRIPTION
## Summary

- Fix `domain/repositories/` comment — it holds repository interfaces, not port interfaces
- Add missing `domain/ports/` directory (PlayerPort, ReaderPort)
- Document `adapters/inbound/admin/` and `outbound/players/`, `outbound/readers/` subdirectories
- Add `admin/`, `settings/`, `shared/`, `sonos/` modules absent from the diagram
- Rename `<module>/` to `jukebox/` — the diagram is jukebox-specific, not a generic template

## Test plan

- [ ] Verify diagram matches `find jukebox -maxdepth 2 -type d | sort`

🤖 Generated with [Claude Code](https://claude.com/claude-code)