### PR TITLE
👷 Skip ty check on no-extras CI variant

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -81,6 +81,10 @@ jobs:
         run: uv run pytest
 
       - name: Type check with ty
+        # Skip on the no-extras variant: optional dependencies (fastapi, fastui, pn532, ...)
+        # are guarded at runtime via `try/except ModuleNotFoundError`, but ty cannot infer
+        # that semantically and reports false-positive `unresolved-import` errors.
+        if: matrix.extras != ''
         # TODO: remove `grep -v || true` once ty supports a flag to suppress warnings (https://github.com/astral-sh/ty/issues/2169)
         # grep -v filters out warnings from the GitHub annotations output to keep the PR review
         # interface readable. Warnings are still visible locally and should not be forgotten.


### PR DESCRIPTION
## Summary
- `ty check` runs on every matrix variant, including the `extras: ""` job (Python 3.13, no optional deps installed).
- On that variant, modules guarded by `try/except ModuleNotFoundError` (`fastapi`, `fastui`, `pn532`, ...) are legitimately missing, so ty reports `unresolved-import` errors as GitHub annotations on every PR touching optional adapters.
- The runtime guards already raise `MissingOptionalDependencyError` cleanly; ty just cannot infer that pattern statically.

Closes #278

## Change
Restrict the ty step to matrix variants that install extras:

```yaml
- name: Type check with ty
  if: matrix.extras != ''
  ...
```

Other steps (ruff format/check, pytest) keep running on the no-extras variant, so we still validate that the base install does not import-crash and that conditional `pytest.skip` paths work.

## Test plan
- CI run on this PR: ty step is skipped on the `3.13 / ""` job, executed on the three `--all-extras` jobs
- No `unresolved-import` annotations surface on the PR
- Local reproduction: `uv sync` (no extras) + `uv run ty check` still shows the noise, `uv sync --all-extras` + `uv run ty check` is clean