### PR TITLE
🚨 Fix ty invalid-assignment on setdefault (JsonObject)

### DIFF
--- a/jukebox/admin/di_container.py
+++ b/jukebox/admin/di_container.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from jukebox.adapters.outbound.json_library_adapter import JsonLibraryAdapter
 from jukebox.adapters.outbound.sonos_discovery_adapter import SoCoSonosDiscoveryAdapter
 from jukebox.adapters.outbound.text_current_tag_adapter import TextCurrentTagAdapter
@@ -13,6 +15,7 @@ from jukebox.settings.file_settings_repository import FileSettingsRepository
 from jukebox.settings.resolve import SettingsService as SettingsServiceImpl
 from jukebox.settings.resolve import build_environment_settings_overrides
 from jukebox.settings.service_protocols import SettingsService
+from jukebox.settings.types import JsonObject
 from jukebox.shared.config_utils import get_current_tag_path
 from jukebox.sonos.service import DefaultSonosService, SonosService
 
@@ -24,16 +27,18 @@ def build_settings_service(
     library: str | None,
     command: object | None,
 ) -> SettingsService:
-    cli_overrides = {}
+    cli_overrides: JsonObject = {}
 
     if library is not None:
-        cli_overrides.setdefault("paths", {})["library_path"] = library
+        cast(JsonObject, cli_overrides.setdefault("paths", {}))["library_path"] = library
 
     if isinstance(command, ApiCommand) and command.port is not None:
-        cli_overrides.setdefault("admin", {}).setdefault("api", {})["port"] = command.port
+        admin = cast(JsonObject, cli_overrides.setdefault("admin", {}))
+        cast(JsonObject, admin.setdefault("api", {}))["port"] = command.port
 
     if isinstance(command, UiCommand) and command.port is not None:
-        cli_overrides.setdefault("admin", {}).setdefault("ui", {})["port"] = command.port
+        admin = cast(JsonObject, cli_overrides.setdefault("admin", {}))
+        cast(JsonObject, admin.setdefault("ui", {}))["port"] = command.port
 
     return SettingsServiceImpl(
         repository=FileSettingsRepository(),

--- a/jukebox/settings/resolve.py
+++ b/jukebox/settings/resolve.py
@@ -31,16 +31,18 @@ _MISSING = object()
 
 
 def build_environment_settings_overrides() -> JsonObject:
-    overrides = {}
+    overrides: JsonObject = {}
 
     library_path = os.environ.get("JUKEBOX_LIBRARY_PATH")
     if library_path is not None:
-        overrides.setdefault("paths", {})["library_path"] = library_path
+        cast(JsonObject, overrides.setdefault("paths", {}))["library_path"] = library_path
 
     sonos_host = os.environ.get("JUKEBOX_SONOS_HOST")
     sonos_name = os.environ.get("JUKEBOX_SONOS_NAME")
     if sonos_host is not None or sonos_name is not None:
-        sonos_overrides = overrides.setdefault("jukebox", {}).setdefault("player", {}).setdefault("sonos", {})
+        jukebox = cast(JsonObject, overrides.setdefault("jukebox", {}))
+        player = cast(JsonObject, jukebox.setdefault("player", {}))
+        sonos_overrides = cast(JsonObject, player.setdefault("sonos", {}))
         sonos_overrides["manual_host"] = sonos_host
         sonos_overrides["manual_name"] = sonos_name
         sonos_overrides["selected_group"] = None


### PR DESCRIPTION
## Summary

- `JsonObject = dict[str, JsonValue]` — calling `.setdefault(key, {})` returns `JsonValue` (the value type), not `JsonObject`.
- ty cannot narrow the union, so it reports `invalid-assignment` and `unresolved-attribute` when chaining calls or subscripting on the result.
- Both `jukebox/settings/resolve.py` and `jukebox/admin/di_container.py` used this pattern for building nested override dicts.

## Change

Wrap each `setdefault` return value with `cast(JsonObject, ...)` at call sites where we know the value is a dict. No runtime behaviour change.

```python
# before
overrides.setdefault("paths", {})["library_path"] = library_path

# after
cast(JsonObject, overrides.setdefault("paths", {}))["library_path"] = library_path
```

## Test plan

- [ ] `uv run --extra ui ty check` → `All checks passed!`
- [ ] `uv run pytest` still green
- [ ] CI: ty step runs on `--all-extras` jobs and reports no `invalid-assignment` or `unresolved-attribute` errors