### PR TITLE
✅ Drop tautological response.model_dump assertion in PATCH disc tests

### DIFF
--- a/tests/jukebox/adapters/inbound/admin/test_api_controller.py
+++ b/tests/jukebox/adapters/inbound/admin/test_api_controller.py
@@ -384,28 +384,21 @@ def test_patch_current_tag_disc_returns_422_when_null_assigned_to_non_nullable_o
 
 
 @pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
-def test_patch_current_tag_disc_clears_nullable_metadata_field():
+def test_patch_current_tag_disc_forwards_null_metadata_to_edit_disc():
     get_current_tag_status = create_autospec(GetCurrentTagStatus, instance=True, spec_set=True)
     get_current_tag_status.execute.return_value = CurrentTagStatus(tag_id="tag-123", known_in_library=True)
     edit_disc = MagicMock()
     edit_disc.execute.return_value = Disc(
         uri="/music/song.mp3",
-        metadata=DiscMetadata(artist=None, album="Album", track="Track"),
-        option=DiscOption(shuffle=False),
+        metadata=DiscMetadata(album="Album", track="Track"),
+        option=DiscOption(),
     )
     controller = build_controller(get_current_tag_status=get_current_tag_status, edit_disc=edit_disc)
     route = get_route(controller, "/api/v1/current-tag/disc", "PATCH")
 
     response = route.endpoint(DiscPatchInput(metadata=DiscPatchMetadataInput(artist=None)))
 
-    assert response.model_dump() == {
-        "disc": {
-            "metadata": {"album": "Album", "artist": None, "playlist": None, "track": "Track"},
-            "option": {"is_test": False, "shuffle": False},
-            "uri": "/music/song.mp3",
-        },
-        "tag_id": "tag-123",
-    }
+    assert response.tag_id == "tag-123"
     edit_disc.execute.assert_called_once_with(
         "tag-123",
         None,
@@ -600,7 +593,7 @@ def test_patch_disc_returns_404_when_missing():
 
 
 @pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
-def test_patch_disc_clears_nullable_metadata_field():
+def test_patch_disc_forwards_null_metadata_to_edit_disc():
     edit_disc = MagicMock()
     edit_disc.execute.return_value = "the_value_returned_by_the_EditDisc_use_case"
     controller = build_controller(edit_disc=edit_disc)


### PR DESCRIPTION
## Summary

The `response.model_dump() == {...}` assertions in `test_patch_current_tag_disc_clears_nullable_metadata_field` (and its sibling) verified the **mock** of `EditDisc`, not the clearing behaviour. The asserted `artist: None` in the response payload came straight from the mock's `return_value`, so the test passed regardless of what the controller actually did with the input.

The real clearing semantics are already covered at the use case layer by `test_edit_clears_metadata_field` in `tests/jukebox/domain/use_cases/library/test_edit_disc.py`, which exercises `EditDisc` against a `MockRepo` and asserts on the repo state.

## What changed

- Removed the misleading `response.model_dump() == {...}` block from `test_patch_current_tag_disc_clears_nullable_metadata_field`. Kept the controller-level contract: `edit_disc.execute.assert_called_once_with(..., DiscMetadata(artist=None), ...)` plus a minimal `response.tag_id` sanity check on the `CurrentTagDiscOutput` wrapping.
- Renamed both tests to reflect the actual controller-layer guarantee:
  - `test_patch_current_tag_disc_clears_nullable_metadata_field` → `test_patch_current_tag_disc_forwards_null_metadata_to_edit_disc`
  - `test_patch_disc_clears_nullable_metadata_field` → `test_patch_disc_forwards_null_metadata_to_edit_disc`

## Why this split

The controller test verifies HTTP↔use case mapping. The use case test verifies the clearing semantics against a real repository port (`MockRepo`). Conflating both inside one controller test created the illusion of end-to-end coverage while only validating mock setup.

## Test plan

- [x] `uv run --extra api pytest tests/jukebox/adapters/inbound/admin/test_api_controller.py -k "forwards_null_metadata or returns_422_when_null_assigned"` → 4/4 pass
- [x] CI green

Closes #216