### PR TITLE
👷 use client-id instead of app-id

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Get app user ID


### PR DESCRIPTION
Input 'app-id' has been deprecated with message: Use 'client-id' instead.

Observed in annotations of https://github.com/Gudsfile/jukebox/actions/runs/27728670263