### PR TITLE
♻️ Decouple SyncCurrentTag from HandleTagEvent via CurrentTagSession

### DIFF
--- a/jukebox/adapters/inbound/cli_controller.py
+++ b/jukebox/adapters/inbound/cli_controller.py
@@ -1,7 +1,7 @@
 import time
 from time import sleep
 
-from jukebox.domain.entities import PlaybackSession, TagEvent
+from jukebox.domain.entities import CurrentTagSession, PlaybackSession, TagEvent
 from jukebox.domain.ports import ReaderPort
 from jukebox.domain.use_cases.handle_tag_event import HandleTagEvent
 from jukebox.domain.use_cases.sync_current_tag import SyncCurrentTag
@@ -26,12 +26,13 @@ class CLIController:
     def run(self):
         """Run the main event loop."""
         session = PlaybackSession()
+        current_tag_session = CurrentTagSession()
 
         while True:
             loop_started = time.monotonic()
             tag_id = self.reader.read()
             tag_event = TagEvent(tag_id=tag_id, timestamp=time.monotonic())
-            self.sync_current_tag.execute(tag_event, session)
+            self.sync_current_tag.execute(tag_event, current_tag_session)
             session = self.handle_tag_event.execute(tag_event, session)
             remaining_sleep = self.loop_interval_seconds - (time.monotonic() - loop_started)
             if remaining_sleep > 0:

--- a/jukebox/adapters/inbound/cli_controller.py
+++ b/jukebox/adapters/inbound/cli_controller.py
@@ -4,6 +4,7 @@ from time import sleep
 from jukebox.domain.entities import PlaybackSession, TagEvent
 from jukebox.domain.ports import ReaderPort
 from jukebox.domain.use_cases.handle_tag_event import HandleTagEvent
+from jukebox.domain.use_cases.sync_current_tag import SyncCurrentTag
 from jukebox.shared.timing import DEFAULT_LOOP_INTERVAL_SECONDS
 
 
@@ -14,10 +15,12 @@ class CLIController:
         self,
         reader: ReaderPort,
         handle_tag_event: HandleTagEvent,
+        sync_current_tag: SyncCurrentTag,
         loop_interval_seconds: float = DEFAULT_LOOP_INTERVAL_SECONDS,
     ):
         self.reader = reader
         self.handle_tag_event = handle_tag_event
+        self.sync_current_tag = sync_current_tag
         self.loop_interval_seconds = loop_interval_seconds
 
     def run(self):
@@ -28,6 +31,7 @@ class CLIController:
             loop_started = time.monotonic()
             tag_id = self.reader.read()
             tag_event = TagEvent(tag_id=tag_id, timestamp=time.monotonic())
+            self.sync_current_tag.execute(tag_event, session)
             session = self.handle_tag_event.execute(tag_event, session)
             remaining_sleep = self.loop_interval_seconds - (time.monotonic() - loop_started)
             if remaining_sleep > 0:

--- a/jukebox/app.py
+++ b/jukebox/app.py
@@ -115,13 +115,14 @@ def _run(state: JukeboxCliState) -> None:
         settings_service = build_settings_service(**{k: v for k, v in asdict(state).items() if k != "verbose"})
         runtime_resolver = build_runtime_resolver(settings_service)
         runtime_config = runtime_resolver.resolve(verbose=state.verbose)
-        reader, handle_tag_event = build_jukebox(runtime_config)
+        reader, handle_tag_event, sync_current_tag = build_jukebox(runtime_config)
     except SettingsError as err:
         _exit_error(str(err))
 
     controller = CLIController(
         reader=reader,
         handle_tag_event=handle_tag_event,
+        sync_current_tag=sync_current_tag,
         loop_interval_seconds=runtime_config.loop_interval_seconds,
     )
     controller.run()

--- a/jukebox/di_container.py
+++ b/jukebox/di_container.py
@@ -10,6 +10,7 @@ from jukebox.domain.use_cases.apply_current_tag_action import ApplyCurrentTagAct
 from jukebox.domain.use_cases.determine_action import DetermineAction
 from jukebox.domain.use_cases.determine_current_tag_action import DetermineCurrentTagAction
 from jukebox.domain.use_cases.handle_tag_event import HandleTagEvent
+from jukebox.domain.use_cases.sync_current_tag import SyncCurrentTag
 from jukebox.settings.entities import ResolvedJukeboxRuntimeConfig
 from jukebox.settings.file_settings_repository import FileSettingsRepository
 from jukebox.settings.resolve import SettingsService as SettingsServiceImpl
@@ -139,18 +140,17 @@ def build_jukebox(
         pause_delay=config.pause_delay_seconds,
         max_pause_duration=config.pause_duration_seconds,
     )
-    determine_current_tag_action = DetermineCurrentTagAction()
-    apply_current_tag_action = ApplyCurrentTagAction(current_tag_repository=current_tag_repository)
-
+    sync_current_tag = SyncCurrentTag(
+        determine_current_tag_action=DetermineCurrentTagAction(),
+        apply_current_tag_action=ApplyCurrentTagAction(current_tag_repository=current_tag_repository),
+    )
     handle_tag_event = HandleTagEvent(
         player=player,
         library=library,
         determine_action=determine_action,
-        determine_current_tag_action=determine_current_tag_action,
-        apply_current_tag_action=apply_current_tag_action,
     )
 
-    return reader, handle_tag_event
+    return reader, handle_tag_event, sync_current_tag
 
 
 def build_sonos_playback_target_resolver() -> SonosPlaybackTargetResolver:

--- a/jukebox/domain/entities/__init__.py
+++ b/jukebox/domain/entities/__init__.py
@@ -1,4 +1,5 @@
 from .current_tag_action import CurrentTagAction
+from .current_tag_session import CurrentTagSession
 from .current_tag_status import CurrentTagStatus
 from .disc import Disc, DiscMetadata, DiscOption
 from .library import Library
@@ -8,6 +9,7 @@ from .tag_event import TagEvent
 
 __all__ = [
     "CurrentTagAction",
+    "CurrentTagSession",
     "CurrentTagStatus",
     "PlaybackAction",
     "PlaybackCommandRetry",

--- a/jukebox/domain/entities/current_tag_session.py
+++ b/jukebox/domain/entities/current_tag_session.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class CurrentTagSession(BaseModel):
+    """Tracks the physical NFC reader state for the current-tag feature."""
+
+    physical_tag: str | None = None
+    physical_tag_removed_at: float | None = None
+    # Stamped by SyncCurrentTag.execute in a finally block; None only before the first call.
+    last_event_timestamp: float | None = None

--- a/jukebox/domain/entities/playback_session.py
+++ b/jukebox/domain/entities/playback_session.py
@@ -30,19 +30,9 @@ class PlaybackCommandRetry(BaseModel):
 
 
 class PlaybackSession(BaseModel):
-    """Tracks the current logical playback and physical reader states."""
+    """Tracks the logical playback state."""
 
-    # Logical playback state
     playing_tag: str | None = None
     paused_at: float | None = None
     playing_tag_removed_at: float | None = None
-
-    # Physical reader state
-    physical_tag: str | None = None
-    physical_tag_removed_at: float | None = None
-
-    # Timestamp
-    last_event_timestamp: float | None = None
-
-    # Playback command retry state
     playback_command_retry: PlaybackCommandRetry | None = None

--- a/jukebox/domain/use_cases/__init__.py
+++ b/jukebox/domain/use_cases/__init__.py
@@ -2,5 +2,6 @@ from .apply_current_tag_action import ApplyCurrentTagAction
 from .determine_action import DetermineAction
 from .determine_current_tag_action import DetermineCurrentTagAction
 from .handle_tag_event import HandleTagEvent
+from .sync_current_tag import SyncCurrentTag
 
-__all__ = ["ApplyCurrentTagAction", "DetermineAction", "DetermineCurrentTagAction", "HandleTagEvent"]
+__all__ = ["ApplyCurrentTagAction", "DetermineAction", "DetermineCurrentTagAction", "HandleTagEvent", "SyncCurrentTag"]

--- a/jukebox/domain/use_cases/apply_current_tag_action.py
+++ b/jukebox/domain/use_cases/apply_current_tag_action.py
@@ -1,6 +1,6 @@
 import logging
 
-from jukebox.domain.entities import CurrentTagAction, PlaybackSession, TagEvent
+from jukebox.domain.entities import CurrentTagAction, CurrentTagSession, TagEvent
 from jukebox.domain.repositories import CurrentTagRepository
 
 LOGGER = logging.getLogger("jukebox")
@@ -12,7 +12,7 @@ class ApplyCurrentTagAction:
     def __init__(self, current_tag_repository: CurrentTagRepository):
         self.current_tag_repository = current_tag_repository
 
-    def execute(self, action: CurrentTagAction, tag_event: TagEvent, session: PlaybackSession) -> None:
+    def execute(self, action: CurrentTagAction, tag_event: TagEvent, session: CurrentTagSession) -> None:
         match action:
             case CurrentTagAction.SET:
                 if tag_event.tag_id is None:

--- a/jukebox/domain/use_cases/determine_current_tag_action.py
+++ b/jukebox/domain/use_cases/determine_current_tag_action.py
@@ -1,4 +1,4 @@
-from jukebox.domain.entities import CurrentTagAction, PlaybackSession, TagEvent
+from jukebox.domain.entities import CurrentTagAction, CurrentTagSession, TagEvent
 
 CURRENT_TAG_ABSENCE_GRACE_SECONDS = 1.0
 
@@ -9,7 +9,7 @@ class DetermineCurrentTagAction:
     def __init__(self, grace_seconds: float = CURRENT_TAG_ABSENCE_GRACE_SECONDS):
         self.grace_seconds = grace_seconds
 
-    def execute(self, tag_event: TagEvent, session: PlaybackSession) -> CurrentTagAction:
+    def execute(self, tag_event: TagEvent, session: CurrentTagSession) -> CurrentTagAction:
         if tag_event.tag_id is not None:
             if session.physical_tag == tag_event.tag_id:
                 if session.physical_tag_removed_at is None:

--- a/jukebox/domain/use_cases/handle_tag_event.py
+++ b/jukebox/domain/use_cases/handle_tag_event.py
@@ -119,7 +119,6 @@ class HandleTagEvent:
             case _:
                 LOGGER.warning("`%s` action is not implemented yet", action.value)
 
-        session.last_event_timestamp = tag_event.timestamp
         return session
 
     def _run_playback_command(

--- a/jukebox/domain/use_cases/handle_tag_event.py
+++ b/jukebox/domain/use_cases/handle_tag_event.py
@@ -5,37 +5,30 @@ from jukebox.domain.entities import PlaybackAction, PlaybackCommandRetry, Playba
 from jukebox.domain.errors import PlaybackError
 from jukebox.domain.ports import PlayerPort
 from jukebox.domain.repositories import LibraryRepository
-from jukebox.domain.use_cases.apply_current_tag_action import ApplyCurrentTagAction
 from jukebox.domain.use_cases.determine_action import DetermineAction
-from jukebox.domain.use_cases.determine_current_tag_action import DetermineCurrentTagAction
 
 LOGGER = logging.getLogger("jukebox")
 PLAYBACK_RETRY_DELAYS_SECONDS = (0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0)
 
 
 class HandleTagEvent:
-    """Orchestrates the handling of a tag detection event."""
+    """Orchestrates playback handling for a tag detection event."""
 
     def __init__(
         self,
         player: PlayerPort,
         library: LibraryRepository,
         determine_action: DetermineAction,
-        determine_current_tag_action: DetermineCurrentTagAction,
-        apply_current_tag_action: ApplyCurrentTagAction,
         retry_delays_seconds: tuple[float, ...] = PLAYBACK_RETRY_DELAYS_SECONDS,
     ):
         self.player = player
         self.library = library
         self.determine_action = determine_action
-        self.determine_current_tag_action = determine_current_tag_action
-        self.apply_current_tag_action = apply_current_tag_action
         if not retry_delays_seconds:
             raise ValueError("retry_delays_seconds must not be empty")
         self.retry_delays_seconds = retry_delays_seconds
 
     def execute(self, tag_event: TagEvent, session: PlaybackSession) -> PlaybackSession:
-        self._sync_current_tag_best_effort(tag_event, session)
         action = self.determine_action.execute(tag_event, session)
 
         LOGGER.debug(
@@ -128,17 +121,6 @@ class HandleTagEvent:
 
         session.last_event_timestamp = tag_event.timestamp
         return session
-
-    def _sync_current_tag_best_effort(self, tag_event: TagEvent, session: PlaybackSession) -> None:
-        try:
-            action = self.determine_current_tag_action.execute(tag_event, session)
-            self.apply_current_tag_action.execute(action, tag_event, session)
-        except Exception as err:
-            LOGGER.warning(
-                "Failed to sync current tag state; continuing tag handling: tag_id=%r, error=%s",
-                tag_event.tag_id,
-                err,
-            )
 
     def _run_playback_command(
         self,

--- a/jukebox/domain/use_cases/sync_current_tag.py
+++ b/jukebox/domain/use_cases/sync_current_tag.py
@@ -1,6 +1,6 @@
 import logging
 
-from jukebox.domain.entities import PlaybackSession, TagEvent
+from jukebox.domain.entities import CurrentTagSession, TagEvent
 from jukebox.domain.use_cases.apply_current_tag_action import ApplyCurrentTagAction
 from jukebox.domain.use_cases.determine_current_tag_action import DetermineCurrentTagAction
 
@@ -18,10 +18,10 @@ class SyncCurrentTag:
         self.determine_current_tag_action = determine_current_tag_action
         self.apply_current_tag_action = apply_current_tag_action
 
-    def execute(self, tag_event: TagEvent, session: PlaybackSession) -> None:
+    def execute(self, tag_event: TagEvent, current_tag_session: CurrentTagSession) -> None:
         try:
-            action = self.determine_current_tag_action.execute(tag_event, session)
-            self.apply_current_tag_action.execute(action, tag_event, session)
+            action = self.determine_current_tag_action.execute(tag_event, current_tag_session)
+            self.apply_current_tag_action.execute(action, tag_event, current_tag_session)
         except Exception as err:
             LOGGER.warning(
                 "Failed to sync current tag state; continuing, tag state may be stale: tag_id=%r, error=%s",

--- a/jukebox/domain/use_cases/sync_current_tag.py
+++ b/jukebox/domain/use_cases/sync_current_tag.py
@@ -1,0 +1,32 @@
+import logging
+
+from jukebox.domain.entities import PlaybackSession, TagEvent
+from jukebox.domain.use_cases.apply_current_tag_action import ApplyCurrentTagAction
+from jukebox.domain.use_cases.determine_current_tag_action import DetermineCurrentTagAction
+
+LOGGER = logging.getLogger("jukebox")
+
+
+class SyncCurrentTag:
+    """Best-effort sync of physical current tag state with repository and session."""
+
+    def __init__(
+        self,
+        determine_current_tag_action: DetermineCurrentTagAction,
+        apply_current_tag_action: ApplyCurrentTagAction,
+    ):
+        self.determine_current_tag_action = determine_current_tag_action
+        self.apply_current_tag_action = apply_current_tag_action
+
+    def execute(self, tag_event: TagEvent, session: PlaybackSession) -> None:
+        try:
+            action = self.determine_current_tag_action.execute(tag_event, session)
+            self.apply_current_tag_action.execute(action, tag_event, session)
+        except Exception as err:
+            LOGGER.warning(
+                "Failed to sync current tag state; continuing, tag state may be stale: tag_id=%r, error=%s",
+                tag_event.tag_id,
+                err,
+            )
+        finally:
+            current_tag_session.last_event_timestamp = tag_event.timestamp

--- a/tests/jukebox/adapters/inbound/test_cli_controller.py
+++ b/tests/jukebox/adapters/inbound/test_cli_controller.py
@@ -1,11 +1,25 @@
-from unittest.mock import create_autospec, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 
 from jukebox.adapters.inbound.cli_controller import CLIController
 from jukebox.domain.entities import PlaybackSession
 from jukebox.domain.ports import ReaderPort
+from jukebox.domain.use_cases.apply_current_tag_action import ApplyCurrentTagAction
+from jukebox.domain.use_cases.determine_current_tag_action import DetermineCurrentTagAction
 from jukebox.domain.use_cases.handle_tag_event import HandleTagEvent
+from jukebox.domain.use_cases.sync_current_tag import SyncCurrentTag
+
+
+def _make_controller(reader, handle_tag_event, sync_current_tag=None, loop_interval_seconds=0.1):
+    if sync_current_tag is None:
+        sync_current_tag = create_autospec(SyncCurrentTag, instance=True, spec_set=True)
+    return CLIController(
+        reader=reader,
+        handle_tag_event=handle_tag_event,
+        sync_current_tag=sync_current_tag,
+        loop_interval_seconds=loop_interval_seconds,
+    )
 
 
 def test_run_sleeps_only_for_remaining_loop_interval():
@@ -13,7 +27,7 @@ def test_run_sleeps_only_for_remaining_loop_interval():
     reader.read.side_effect = ["tag-1", KeyboardInterrupt()]
     handle_tag_event = create_autospec(HandleTagEvent, instance=True, spec_set=True)
     handle_tag_event.execute.return_value = PlaybackSession()
-    controller = CLIController(reader=reader, handle_tag_event=handle_tag_event, loop_interval_seconds=0.1)
+    controller = _make_controller(reader=reader, handle_tag_event=handle_tag_event)
 
     with (
         patch("jukebox.adapters.inbound.cli_controller.time.monotonic", side_effect=[100.0, 100.03, 100.04, 100.1]),
@@ -31,7 +45,7 @@ def test_run_skips_sleep_when_reader_already_used_the_interval():
     reader.read.side_effect = ["tag-1", KeyboardInterrupt()]
     handle_tag_event = create_autospec(HandleTagEvent, instance=True, spec_set=True)
     handle_tag_event.execute.return_value = PlaybackSession()
-    controller = CLIController(reader=reader, handle_tag_event=handle_tag_event, loop_interval_seconds=0.1)
+    controller = _make_controller(reader=reader, handle_tag_event=handle_tag_event)
 
     with (
         patch("jukebox.adapters.inbound.cli_controller.time.monotonic", side_effect=[100.0, 100.11, 100.12, 100.2]),
@@ -42,3 +56,46 @@ def test_run_skips_sleep_when_reader_already_used_the_interval():
 
     mock_sleep.assert_not_called()
     handle_tag_event.execute.assert_called_once()
+
+
+def test_sync_current_tag_failure_does_not_block_playback():
+    reader = create_autospec(ReaderPort, instance=True, spec_set=True)
+    reader.read.side_effect = ["tag-1", KeyboardInterrupt()]
+    handle_tag_event = create_autospec(HandleTagEvent, instance=True, spec_set=True)
+    handle_tag_event.execute.return_value = PlaybackSession()
+    mock_repository = MagicMock()
+    mock_repository.set.side_effect = OSError("disk full")
+    sync_current_tag = SyncCurrentTag(
+        determine_current_tag_action=DetermineCurrentTagAction(),
+        apply_current_tag_action=ApplyCurrentTagAction(current_tag_repository=mock_repository),
+    )
+    controller = _make_controller(reader=reader, handle_tag_event=handle_tag_event, sync_current_tag=sync_current_tag)
+
+    with (
+        patch("jukebox.adapters.inbound.cli_controller.time.monotonic", return_value=100.0),
+        patch("jukebox.adapters.inbound.cli_controller.sleep"),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        controller.run()
+
+    handle_tag_event.execute.assert_called_once()
+
+
+def test_sync_current_tag_called_before_handle_tag_event():
+    call_order = []
+    reader = create_autospec(ReaderPort, instance=True, spec_set=True)
+    reader.read.side_effect = ["tag-1", KeyboardInterrupt()]
+    handle_tag_event = create_autospec(HandleTagEvent, instance=True, spec_set=True)
+    handle_tag_event.execute.side_effect = lambda *_: call_order.append("handle") or PlaybackSession()
+    sync_current_tag = create_autospec(SyncCurrentTag, instance=True, spec_set=True)
+    sync_current_tag.execute.side_effect = lambda *_: call_order.append("sync")
+    controller = _make_controller(reader=reader, handle_tag_event=handle_tag_event, sync_current_tag=sync_current_tag)
+
+    with (
+        patch("jukebox.adapters.inbound.cli_controller.time.monotonic", return_value=100.0),
+        patch("jukebox.adapters.inbound.cli_controller.sleep"),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        controller.run()
+
+    assert call_order == ["sync", "handle"]

--- a/tests/jukebox/adapters/inbound/test_cli_controller.py
+++ b/tests/jukebox/adapters/inbound/test_cli_controller.py
@@ -1,12 +1,10 @@
-from unittest.mock import MagicMock, create_autospec, patch
+from unittest.mock import create_autospec, patch
 
 import pytest
 
 from jukebox.adapters.inbound.cli_controller import CLIController
-from jukebox.domain.entities import PlaybackSession
+from jukebox.domain.entities import CurrentTagSession, PlaybackSession
 from jukebox.domain.ports import ReaderPort
-from jukebox.domain.use_cases.apply_current_tag_action import ApplyCurrentTagAction
-from jukebox.domain.use_cases.determine_current_tag_action import DetermineCurrentTagAction
 from jukebox.domain.use_cases.handle_tag_event import HandleTagEvent
 from jukebox.domain.use_cases.sync_current_tag import SyncCurrentTag
 
@@ -58,37 +56,15 @@ def test_run_skips_sleep_when_reader_already_used_the_interval():
     handle_tag_event.execute.assert_called_once()
 
 
-def test_sync_current_tag_failure_does_not_block_playback():
-    reader = create_autospec(ReaderPort, instance=True, spec_set=True)
-    reader.read.side_effect = ["tag-1", KeyboardInterrupt()]
-    handle_tag_event = create_autospec(HandleTagEvent, instance=True, spec_set=True)
-    handle_tag_event.execute.return_value = PlaybackSession()
-    mock_repository = MagicMock()
-    mock_repository.set.side_effect = OSError("disk full")
-    sync_current_tag = SyncCurrentTag(
-        determine_current_tag_action=DetermineCurrentTagAction(),
-        apply_current_tag_action=ApplyCurrentTagAction(current_tag_repository=mock_repository),
-    )
-    controller = _make_controller(reader=reader, handle_tag_event=handle_tag_event, sync_current_tag=sync_current_tag)
-
-    with (
-        patch("jukebox.adapters.inbound.cli_controller.time.monotonic", return_value=100.0),
-        patch("jukebox.adapters.inbound.cli_controller.sleep"),
-        pytest.raises(KeyboardInterrupt),
-    ):
-        controller.run()
-
-    handle_tag_event.execute.assert_called_once()
-
-
 def test_sync_current_tag_called_before_handle_tag_event():
     call_order = []
+    captured_sessions = []
     reader = create_autospec(ReaderPort, instance=True, spec_set=True)
-    reader.read.side_effect = ["tag-1", KeyboardInterrupt()]
+    reader.read.side_effect = ["tag-1", "tag-1", KeyboardInterrupt()]
     handle_tag_event = create_autospec(HandleTagEvent, instance=True, spec_set=True)
     handle_tag_event.execute.side_effect = lambda *_: call_order.append("handle") or PlaybackSession()
     sync_current_tag = create_autospec(SyncCurrentTag, instance=True, spec_set=True)
-    sync_current_tag.execute.side_effect = lambda *_: call_order.append("sync")
+    sync_current_tag.execute.side_effect = lambda _ev, sess: (call_order.append("sync"), captured_sessions.append(sess))
     controller = _make_controller(reader=reader, handle_tag_event=handle_tag_event, sync_current_tag=sync_current_tag)
 
     with (
@@ -98,4 +74,6 @@ def test_sync_current_tag_called_before_handle_tag_event():
     ):
         controller.run()
 
-    assert call_order == ["sync", "handle"]
+    assert call_order == ["sync", "handle", "sync", "handle"]
+    assert all(isinstance(s, CurrentTagSession) for s in captured_sessions)
+    assert captured_sessions[0] is captured_sessions[1]

--- a/tests/jukebox/domain/use_cases/test_apply_current_tag_action.py
+++ b/tests/jukebox/domain/use_cases/test_apply_current_tag_action.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from jukebox.domain.entities import CurrentTagAction, PlaybackSession, TagEvent
+from jukebox.domain.entities import CurrentTagAction, CurrentTagSession, TagEvent
 from jukebox.domain.use_cases.apply_current_tag_action import ApplyCurrentTagAction
 
 
@@ -17,7 +17,7 @@ def apply(mock_repository):
 
 
 def test_set_writes_repository_and_updates_session(apply, mock_repository):
-    session = PlaybackSession(physical_tag_removed_at=1.0)
+    session = CurrentTagSession(physical_tag_removed_at=1.0)
     apply.execute(CurrentTagAction.SET, TagEvent(tag_id="tag-1", timestamp=100.0), session)
 
     mock_repository.set.assert_called_once_with("tag-1")
@@ -26,7 +26,7 @@ def test_set_writes_repository_and_updates_session(apply, mock_repository):
 
 
 def test_set_with_none_tag_id_logs_error_and_does_nothing(apply, mock_repository, caplog):
-    session = PlaybackSession(physical_tag="existing-tag", physical_tag_removed_at=1.23)
+    session = CurrentTagSession(physical_tag="existing-tag", physical_tag_removed_at=1.23)
 
     with caplog.at_level("ERROR", logger="jukebox"):
         apply.execute(CurrentTagAction.SET, TagEvent(tag_id=None, timestamp=100.0), session)
@@ -38,7 +38,7 @@ def test_set_with_none_tag_id_logs_error_and_does_nothing(apply, mock_repository
 
 
 def test_clear_writes_repository_and_clears_session(apply, mock_repository):
-    session = PlaybackSession(physical_tag="tag-1", physical_tag_removed_at=1.0)
+    session = CurrentTagSession(physical_tag="tag-1", physical_tag_removed_at=1.0)
     apply.execute(CurrentTagAction.CLEAR, TagEvent(tag_id=None, timestamp=100.0), session)
 
     mock_repository.clear.assert_called_once_with()
@@ -47,7 +47,7 @@ def test_clear_writes_repository_and_clears_session(apply, mock_repository):
 
 
 def test_restore_clears_removal_timestamp(apply, mock_repository):
-    session = PlaybackSession(physical_tag="tag-1", physical_tag_removed_at=99.0)
+    session = CurrentTagSession(physical_tag="tag-1", physical_tag_removed_at=99.0)
     apply.execute(CurrentTagAction.RESTORE, TagEvent(tag_id="tag-1", timestamp=100.0), session)
 
     mock_repository.set.assert_not_called()
@@ -56,7 +56,7 @@ def test_restore_clears_removal_timestamp(apply, mock_repository):
 
 
 def test_remove_sets_removal_timestamp(apply, mock_repository):
-    session = PlaybackSession(physical_tag="tag-1")
+    session = CurrentTagSession(physical_tag="tag-1")
     apply.execute(CurrentTagAction.REMOVE, TagEvent(tag_id=None, timestamp=100.5), session)
 
     mock_repository.set.assert_not_called()
@@ -65,7 +65,7 @@ def test_remove_sets_removal_timestamp(apply, mock_repository):
 
 
 def test_keep_does_nothing(apply, mock_repository):
-    session = PlaybackSession(physical_tag="tag-1", physical_tag_removed_at=99.0)
+    session = CurrentTagSession(physical_tag="tag-1", physical_tag_removed_at=99.0)
     apply.execute(CurrentTagAction.KEEP, TagEvent(tag_id="tag-1", timestamp=100.0), session)
 
     mock_repository.set.assert_not_called()

--- a/tests/jukebox/domain/use_cases/test_determine_current_tag_action.py
+++ b/tests/jukebox/domain/use_cases/test_determine_current_tag_action.py
@@ -1,6 +1,6 @@
 import pytest
 
-from jukebox.domain.entities import CurrentTagAction, PlaybackSession, TagEvent
+from jukebox.domain.entities import CurrentTagAction, CurrentTagSession, TagEvent
 from jukebox.domain.use_cases.determine_current_tag_action import DetermineCurrentTagAction
 
 
@@ -11,7 +11,7 @@ def determine_current_tag_action():
 
 def test_keep_when_same_tag_already_physical(determine_current_tag_action):
     """Should keep when tag is present and matches the current physical tag."""
-    session = PlaybackSession(physical_tag="tag-1", physical_tag_removed_at=None)
+    session = CurrentTagSession(physical_tag="tag-1", physical_tag_removed_at=None)
     tag_event = TagEvent(tag_id="tag-1", timestamp=100.0)
 
     action = determine_current_tag_action.execute(tag_event, session)
@@ -22,7 +22,7 @@ def test_keep_when_same_tag_already_physical(determine_current_tag_action):
 @pytest.mark.parametrize("physical_tag_removed_at", (None, 50.0, 99.5, 100.0, 105.0, 150.0))
 def test_set_when_new_tag_detected(determine_current_tag_action, physical_tag_removed_at):
     """Should set when a tag is present but different from the current physical tag"""
-    session = PlaybackSession(physical_tag=None, physical_tag_removed_at=physical_tag_removed_at)
+    session = CurrentTagSession(physical_tag=None, physical_tag_removed_at=physical_tag_removed_at)
     tag_event = TagEvent(tag_id="tag-1", timestamp=100.0)
 
     action = determine_current_tag_action.execute(tag_event, session)
@@ -33,7 +33,7 @@ def test_set_when_new_tag_detected(determine_current_tag_action, physical_tag_re
 @pytest.mark.parametrize("physical_tag_removed_at", (None, 50.0, 99.5, 100.0, 105.0, 150.0))
 def test_set_when_different_tag_replaces_physical(determine_current_tag_action, physical_tag_removed_at):
     """Should set when a different tag replaces the existing physical tag."""
-    session = PlaybackSession(physical_tag="tag-1", physical_tag_removed_at=physical_tag_removed_at)
+    session = CurrentTagSession(physical_tag="tag-1", physical_tag_removed_at=physical_tag_removed_at)
     tag_event = TagEvent(tag_id="tag-2", timestamp=100.0)
 
     action = determine_current_tag_action.execute(tag_event, session)
@@ -44,7 +44,7 @@ def test_set_when_different_tag_replaces_physical(determine_current_tag_action, 
 @pytest.mark.parametrize("physical_tag_removed_at", (None, 50.0, 99.5, 100.0, 105.0, 150.0))
 def test_keep_when_no_tag_and_no_physical_tag(determine_current_tag_action, physical_tag_removed_at):
     """Should keep when no tag is detected and no physical tag is tracked."""
-    session = PlaybackSession(physical_tag=None, physical_tag_removed_at=physical_tag_removed_at)
+    session = CurrentTagSession(physical_tag=None, physical_tag_removed_at=physical_tag_removed_at)
     tag_event = TagEvent(tag_id=None, timestamp=100.0)
 
     action = determine_current_tag_action.execute(tag_event, session)
@@ -54,7 +54,7 @@ def test_keep_when_no_tag_and_no_physical_tag(determine_current_tag_action, phys
 
 def test_remove_when_tag_just_removed_within_grace_period(determine_current_tag_action):
     """Should remove when tag disappears and removal has not been recorded yet."""
-    session = PlaybackSession(physical_tag="tag-1", physical_tag_removed_at=None, last_event_timestamp=99.5)
+    session = CurrentTagSession(physical_tag="tag-1", physical_tag_removed_at=None, last_event_timestamp=99.5)
     tag_event = TagEvent(tag_id=None, timestamp=100.0)
 
     action = determine_current_tag_action.execute(tag_event, session)
@@ -64,7 +64,7 @@ def test_remove_when_tag_just_removed_within_grace_period(determine_current_tag_
 
 def test_keep_when_no_tag_within_grace_period(determine_current_tag_action):
     """Should keep when no tag is detected but still within the grace period."""
-    session = PlaybackSession(physical_tag="tag-1", physical_tag_removed_at=99.95)
+    session = CurrentTagSession(physical_tag="tag-1", physical_tag_removed_at=99.95)
     tag_event = TagEvent(tag_id=None, timestamp=100.0)
 
     action = determine_current_tag_action.execute(tag_event, session)
@@ -74,7 +74,7 @@ def test_keep_when_no_tag_within_grace_period(determine_current_tag_action):
 
 def test_clear_when_no_tag_after_grace_period(determine_current_tag_action):
     """Should clear when no tag is detected and the grace period has elapsed."""
-    session = PlaybackSession(physical_tag="tag-1", physical_tag_removed_at=99.0)
+    session = CurrentTagSession(physical_tag="tag-1", physical_tag_removed_at=99.0)
     tag_event = TagEvent(tag_id=None, timestamp=100.0)
 
     action = determine_current_tag_action.execute(tag_event, session)
@@ -84,7 +84,7 @@ def test_clear_when_no_tag_after_grace_period(determine_current_tag_action):
 
 def test_grace_period_boundary_is_exclusive(determine_current_tag_action):
     """Should keep at exactly the grace boundary (strictly less than)."""
-    session = PlaybackSession(physical_tag="tag-1", physical_tag_removed_at=99.1)
+    session = CurrentTagSession(physical_tag="tag-1", physical_tag_removed_at=99.1)
     tag_event = TagEvent(tag_id=None, timestamp=100.0)
 
     action = determine_current_tag_action.execute(tag_event, session)
@@ -94,7 +94,7 @@ def test_grace_period_boundary_is_exclusive(determine_current_tag_action):
 
 def test_restore_when_tag_returns_after_removal(determine_current_tag_action):
     """Should restore when tag is detected and the still within the grace period."""
-    session = PlaybackSession(physical_tag="tag-1", physical_tag_removed_at=100.0)
+    session = CurrentTagSession(physical_tag="tag-1", physical_tag_removed_at=100.0)
     tag_event = TagEvent(tag_id="tag-1", timestamp=100.5)
 
     action = determine_current_tag_action.execute(tag_event, session)
@@ -104,7 +104,7 @@ def test_restore_when_tag_returns_after_removal(determine_current_tag_action):
 
 def test_clear_when_tag_just_removed_after_grace_period(determine_current_tag_action):
     """Should clear when no tag is detected and removal has not been recorded yet but the grace period has elapsed."""
-    session = PlaybackSession(physical_tag="tag-1", physical_tag_removed_at=None, last_event_timestamp=99.0)
+    session = CurrentTagSession(physical_tag="tag-1", physical_tag_removed_at=None, last_event_timestamp=99.0)
     tag_event = TagEvent(tag_id=None, timestamp=100.0)
 
     action = determine_current_tag_action.execute(tag_event, session)

--- a/tests/jukebox/domain/use_cases/test_handle_tag_event.py
+++ b/tests/jukebox/domain/use_cases/test_handle_tag_event.py
@@ -11,9 +11,7 @@ from jukebox.domain.entities import (
     TagEvent,
 )
 from jukebox.domain.errors import PlaybackError
-from jukebox.domain.use_cases.apply_current_tag_action import ApplyCurrentTagAction
 from jukebox.domain.use_cases.determine_action import DetermineAction
-from jukebox.domain.use_cases.determine_current_tag_action import DetermineCurrentTagAction
 from jukebox.domain.use_cases.handle_tag_event import HandleTagEvent
 
 
@@ -43,32 +41,12 @@ def determine_action():
 
 
 @pytest.fixture
-def determine_current_tag_action():
-    """Create a DetermineCurrentTagAction instance."""
-    return DetermineCurrentTagAction()
-
-
-@pytest.fixture
-def mock_current_tag_repository():
-    return MagicMock()
-
-
-@pytest.fixture
-def apply_current_tag_action(mock_current_tag_repository):
-    return ApplyCurrentTagAction(current_tag_repository=mock_current_tag_repository)
-
-
-@pytest.fixture
-def handle_tag_event(
-    mock_player, mock_library, determine_action, determine_current_tag_action, apply_current_tag_action
-):
+def handle_tag_event(mock_player, mock_library, determine_action):
     """Create a HandleTagEvent instance."""
     return HandleTagEvent(
         player=mock_player,
         library=mock_library,
         determine_action=determine_action,
-        determine_current_tag_action=determine_current_tag_action,
-        apply_current_tag_action=apply_current_tag_action,
     )
 
 
@@ -86,73 +64,6 @@ def test_handle_play_action_with_existing_disc(handle_tag_event, mock_player, mo
     assert new_session.playing_tag == "test-tag"
     assert new_session.paused_at is None
     assert new_session.playing_tag_removed_at is None
-
-
-def test_current_tag_survives_brief_missed_reads_and_clears_after_absence_grace(
-    handle_tag_event, mock_current_tag_repository
-):
-    session = PlaybackSession()
-
-    session = handle_tag_event.execute(TagEvent(tag_id="tag-1", timestamp=100.0), session)
-    session = handle_tag_event.execute(TagEvent(tag_id=None, timestamp=100.4), session)
-
-    mock_current_tag_repository.clear.assert_not_called()
-    assert session.physical_tag_removed_at == pytest.approx(100.4)
-
-    session = handle_tag_event.execute(TagEvent(tag_id=None, timestamp=100.6), session)
-    mock_current_tag_repository.clear.assert_not_called()
-    assert session.physical_tag_removed_at == pytest.approx(100.4)
-
-    session = handle_tag_event.execute(TagEvent(tag_id="tag-1", timestamp=100.8), session)
-    assert mock_current_tag_repository.set.call_count == 1
-    assert session.physical_tag_removed_at is None
-
-    session = handle_tag_event.execute(TagEvent(tag_id=None, timestamp=101.9), session)
-
-    mock_current_tag_repository.clear.assert_called_once_with()
-    assert session.physical_tag is None
-
-
-def test_unknown_tag_promotes_to_known_without_rewriting_current_tag(
-    handle_tag_event, mock_current_tag_repository, mock_library, mock_player
-):
-    promoted_disc = Disc(uri="uri:promoted", metadata=DiscMetadata(), option=DiscOption(shuffle=True))
-    mock_library.get_disc.side_effect = [None, promoted_disc]
-    session = PlaybackSession()
-
-    session = handle_tag_event.execute(TagEvent(tag_id="promote-tag", timestamp=100.0), session)
-    session = handle_tag_event.execute(TagEvent(tag_id="promote-tag", timestamp=100.2), session)
-
-    assert mock_current_tag_repository.set.call_count == 1
-    assert session.physical_tag == "promote-tag"
-    mock_player.play.assert_called_once_with("uri:promoted", True)
-
-
-def test_current_tag_set_failure_does_not_block_playback(handle_tag_event, mock_current_tag_repository, mock_player):
-    mock_current_tag_repository.set.side_effect = OSError("disk full")
-    session = PlaybackSession()
-
-    new_session = handle_tag_event.execute(TagEvent(tag_id="known-tag", timestamp=100.0), session)
-
-    mock_player.play.assert_called_once_with("uri:123", False)
-    assert new_session.playing_tag == "known-tag"
-
-
-def test_current_tag_clear_failure_does_not_block_pause(handle_tag_event, mock_current_tag_repository, mock_player):
-    handle_tag_event.determine_action.pause_delay = 0.25
-    mock_current_tag_repository.clear.side_effect = OSError("permission denied")
-    session = PlaybackSession(
-        playing_tag="known-tag",
-        physical_tag="known-tag",
-        physical_tag_removed_at=0.99,
-        playing_tag_removed_at=0.24,
-        last_event_timestamp=100.0,
-    )
-
-    new_session = handle_tag_event.execute(TagEvent(tag_id=None, timestamp=100.02), session)
-
-    mock_player.pause.assert_called_once()
-    assert new_session.paused_at == 100.02
 
 
 def test_handle_play_action_with_shuffle(handle_tag_event, mock_player, mock_library):
@@ -181,6 +92,23 @@ def test_handle_play_action_with_nonexistent_disc(handle_tag_event, mock_player,
     handle_tag_event.execute(tag_event, session)
 
     mock_player.play.assert_not_called()
+
+
+def test_tag_without_disc_plays_when_disc_becomes_available(handle_tag_event, mock_player, mock_library):
+    """Should play on second read when disc wasn't in library on first read."""
+    promoted_disc = Disc(
+        uri="uri:promoted",
+        metadata=DiscMetadata(),
+        option=DiscOption(shuffle=True),
+    )
+    mock_library.get_disc.side_effect = [None, promoted_disc]
+    session = PlaybackSession()
+
+    session = handle_tag_event.execute(TagEvent(tag_id="promote-tag", timestamp=100.0), session)
+    mock_player.play.assert_not_called()
+
+    handle_tag_event.execute(TagEvent(tag_id="promote-tag", timestamp=100.2), session)
+    mock_player.play.assert_called_once_with("uri:promoted", True)
 
 
 def test_handle_resume_action(handle_tag_event, mock_player):

--- a/tests/jukebox/domain/use_cases/test_handle_tag_event.py
+++ b/tests/jukebox/domain/use_cases/test_handle_tag_event.py
@@ -132,7 +132,6 @@ def test_handle_pause_action(handle_tag_event, mock_player):
         playing_tag="test-tag",
         paused_at=None,
         playing_tag_removed_at=5.0,
-        last_event_timestamp=100.0,
     )
     tag_event = TagEvent(tag_id=None, timestamp=100.2)
 
@@ -152,7 +151,6 @@ def test_handle_pause_then_stop_after_max_pause_duration(handle_tag_event, mock_
         playing_tag="test-tag",
         paused_at=None,
         playing_tag_removed_at=99.76,
-        last_event_timestamp=100.0,
     )
 
     session = handle_tag_event.execute(TagEvent(tag_id=None, timestamp=100.02), session)
@@ -212,7 +210,6 @@ def test_handle_waiting_action(handle_tag_event, mock_player):
         playing_tag="test-tag",
         paused_at=None,
         playing_tag_removed_at=None,
-        last_event_timestamp=100.0,
     )
     tag_event = TagEvent(tag_id=None, timestamp=100.25)
 
@@ -232,7 +229,6 @@ def test_handle_waiting_preserves_removal_timestamp_on_subsequent_occurrences(ha
         playing_tag="test-tag",
         paused_at=None,
         playing_tag_removed_at=99.25,
-        last_event_timestamp=100.0,
     )
     tag_event = TagEvent(tag_id=None, timestamp=100.25)
 
@@ -247,7 +243,6 @@ def test_handle_idle_action(handle_tag_event):
     """Should not overwrite paused timestamp when action is IDLE."""
     session = PlaybackSession(
         paused_at=10.0,
-        last_event_timestamp=100.0,
     )
     tag_event = TagEvent(tag_id=None, timestamp=100.25)
 
@@ -288,7 +283,6 @@ def test_same_tag_detection_resets_logical_removal_grace_period(handle_tag_event
         playing_tag="test-tag",
         paused_at=None,
         playing_tag_removed_at=None,
-        last_event_timestamp=99.75,
     )
 
     session = handle_tag_event.execute(TagEvent(tag_id=None, timestamp=100.0), session)
@@ -307,8 +301,6 @@ def test_same_tag_detection_resets_logical_removal_grace_period(handle_tag_event
 def test_same_tag_returns_after_pause_resumes_immediately(handle_tag_event, mock_player):
     session = PlaybackSession(
         playing_tag="test-tag",
-        physical_tag="test-tag",
-        last_event_timestamp=100.0,
     )
 
     # First missed read starts the grace window.

--- a/tests/jukebox/domain/use_cases/test_sync_current_tag.py
+++ b/tests/jukebox/domain/use_cases/test_sync_current_tag.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from jukebox.domain.entities import CurrentTagAction, CurrentTagSession, TagEvent
+from jukebox.domain.entities import CurrentTagAction, PlaybackSession, TagEvent
 from jukebox.domain.use_cases.apply_current_tag_action import ApplyCurrentTagAction
 from jukebox.domain.use_cases.determine_current_tag_action import DetermineCurrentTagAction
 from jukebox.domain.use_cases.sync_current_tag import SyncCurrentTag
@@ -29,33 +29,27 @@ def sync(mock_determine, mock_apply):
 
 
 def test_execute_calls_determine_then_apply(sync, mock_determine, mock_apply):
-    session = CurrentTagSession()
+    session = PlaybackSession()
     event = TagEvent(tag_id="tag-1", timestamp=100.0)
 
     sync.execute(event, session)
 
     mock_determine.execute.assert_called_once_with(event, session)
     mock_apply.execute.assert_called_once_with(CurrentTagAction.SET, event, session)
-    assert session.last_event_timestamp == pytest.approx(100.0)
 
 
 def test_execute_swallows_exception_from_determine(sync, mock_determine, mock_apply):
     mock_determine.execute.side_effect = RuntimeError("boom")
-    session = CurrentTagSession()
 
-    sync.execute(TagEvent(tag_id="tag-1", timestamp=100.0), session)
+    sync.execute(TagEvent(tag_id="tag-1", timestamp=100.0), PlaybackSession())
 
     mock_apply.execute.assert_not_called()
-    assert session.last_event_timestamp == pytest.approx(100.0)
 
 
 def test_execute_swallows_exception_from_apply(sync, mock_determine, mock_apply):
     mock_apply.execute.side_effect = OSError("disk full")
-    session = CurrentTagSession()
 
-    sync.execute(TagEvent(tag_id="tag-1", timestamp=100.0), session)
-
-    assert session.last_event_timestamp == pytest.approx(100.0)
+    sync.execute(TagEvent(tag_id="tag-1", timestamp=100.0), PlaybackSession())
 
 
 # Integration tests — real use cases, mock repository only
@@ -75,12 +69,14 @@ def sync_integration(mock_repository):
 
 
 def _sync(sync_integration, session, tag_id, timestamp):
-    """Simulate one SyncCurrentTag loop tick."""
-    sync_integration.execute(TagEvent(tag_id=tag_id, timestamp=timestamp), session)
+    """Simulate one CLIController loop iteration: sync then advance last_event_timestamp."""
+    event = TagEvent(tag_id=tag_id, timestamp=timestamp)
+    sync_integration.execute(event, session)
+    session.last_event_timestamp = timestamp  # normally set by HandleTagEvent
 
 
 def test_current_tag_survives_brief_missed_reads_and_clears_after_absence_grace(sync_integration, mock_repository):
-    session = CurrentTagSession()
+    session = PlaybackSession()
 
     _sync(sync_integration, session, "tag-1", 100.0)
     _sync(sync_integration, session, None, 100.4)
@@ -102,11 +98,11 @@ def test_current_tag_survives_brief_missed_reads_and_clears_after_absence_grace(
     assert session.physical_tag is None
 
 
-def test_keep_action_does_not_rewrite_repository(sync_integration, mock_repository):
-    session = CurrentTagSession()
+def test_unknown_tag_promotes_to_known_without_rewriting_current_tag(sync_integration, mock_repository):
+    session = PlaybackSession()
 
-    _sync(sync_integration, session, "tag-1", 100.0)
-    _sync(sync_integration, session, "tag-1", 100.2)
+    _sync(sync_integration, session, "promote-tag", 100.0)
+    _sync(sync_integration, session, "promote-tag", 100.2)
 
     assert mock_repository.set.call_count == 1
-    assert session.physical_tag == "tag-1"
+    assert session.physical_tag == "promote-tag"

--- a/tests/jukebox/domain/use_cases/test_sync_current_tag.py
+++ b/tests/jukebox/domain/use_cases/test_sync_current_tag.py
@@ -1,0 +1,112 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from jukebox.domain.entities import CurrentTagAction, CurrentTagSession, TagEvent
+from jukebox.domain.use_cases.apply_current_tag_action import ApplyCurrentTagAction
+from jukebox.domain.use_cases.determine_current_tag_action import DetermineCurrentTagAction
+from jukebox.domain.use_cases.sync_current_tag import SyncCurrentTag
+
+
+@pytest.fixture
+def mock_determine():
+    determine = MagicMock(spec=DetermineCurrentTagAction)
+    determine.execute.return_value = CurrentTagAction.SET
+    return determine
+
+
+@pytest.fixture
+def mock_apply():
+    return MagicMock(spec=ApplyCurrentTagAction)
+
+
+@pytest.fixture
+def sync(mock_determine, mock_apply):
+    return SyncCurrentTag(
+        determine_current_tag_action=mock_determine,
+        apply_current_tag_action=mock_apply,
+    )
+
+
+def test_execute_calls_determine_then_apply(sync, mock_determine, mock_apply):
+    session = CurrentTagSession()
+    event = TagEvent(tag_id="tag-1", timestamp=100.0)
+
+    sync.execute(event, session)
+
+    mock_determine.execute.assert_called_once_with(event, session)
+    mock_apply.execute.assert_called_once_with(CurrentTagAction.SET, event, session)
+    assert session.last_event_timestamp == pytest.approx(100.0)
+
+
+def test_execute_swallows_exception_from_determine(sync, mock_determine, mock_apply):
+    mock_determine.execute.side_effect = RuntimeError("boom")
+    session = CurrentTagSession()
+
+    sync.execute(TagEvent(tag_id="tag-1", timestamp=100.0), session)
+
+    mock_apply.execute.assert_not_called()
+    assert session.last_event_timestamp == pytest.approx(100.0)
+
+
+def test_execute_swallows_exception_from_apply(sync, mock_determine, mock_apply):
+    mock_apply.execute.side_effect = OSError("disk full")
+    session = CurrentTagSession()
+
+    sync.execute(TagEvent(tag_id="tag-1", timestamp=100.0), session)
+
+    assert session.last_event_timestamp == pytest.approx(100.0)
+
+
+# Integration tests — real use cases, mock repository only
+
+
+@pytest.fixture
+def mock_repository():
+    return MagicMock()
+
+
+@pytest.fixture
+def sync_integration(mock_repository):
+    return SyncCurrentTag(
+        determine_current_tag_action=DetermineCurrentTagAction(),
+        apply_current_tag_action=ApplyCurrentTagAction(current_tag_repository=mock_repository),
+    )
+
+
+def _sync(sync_integration, session, tag_id, timestamp):
+    """Simulate one SyncCurrentTag loop tick."""
+    sync_integration.execute(TagEvent(tag_id=tag_id, timestamp=timestamp), session)
+
+
+def test_current_tag_survives_brief_missed_reads_and_clears_after_absence_grace(sync_integration, mock_repository):
+    session = CurrentTagSession()
+
+    _sync(sync_integration, session, "tag-1", 100.0)
+    _sync(sync_integration, session, None, 100.4)
+
+    mock_repository.clear.assert_not_called()
+    assert session.physical_tag_removed_at == pytest.approx(100.4)
+
+    _sync(sync_integration, session, None, 100.6)
+    mock_repository.clear.assert_not_called()
+    assert session.physical_tag_removed_at == pytest.approx(100.4)
+
+    _sync(sync_integration, session, "tag-1", 100.8)
+    assert mock_repository.set.call_count == 1
+    assert session.physical_tag_removed_at is None
+
+    _sync(sync_integration, session, None, 101.9)
+
+    mock_repository.clear.assert_called_once_with()
+    assert session.physical_tag is None
+
+
+def test_keep_action_does_not_rewrite_repository(sync_integration, mock_repository):
+    session = CurrentTagSession()
+
+    _sync(sync_integration, session, "tag-1", 100.0)
+    _sync(sync_integration, session, "tag-1", 100.2)
+
+    assert mock_repository.set.call_count == 1
+    assert session.physical_tag == "tag-1"

--- a/tests/jukebox/domain/use_cases/test_sync_current_tag.py
+++ b/tests/jukebox/domain/use_cases/test_sync_current_tag.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from jukebox.domain.entities import CurrentTagAction, PlaybackSession, TagEvent
+from jukebox.domain.entities import CurrentTagAction, CurrentTagSession, TagEvent
 from jukebox.domain.use_cases.apply_current_tag_action import ApplyCurrentTagAction
 from jukebox.domain.use_cases.determine_current_tag_action import DetermineCurrentTagAction
 from jukebox.domain.use_cases.sync_current_tag import SyncCurrentTag
@@ -29,7 +29,7 @@ def sync(mock_determine, mock_apply):
 
 
 def test_execute_calls_determine_then_apply(sync, mock_determine, mock_apply):
-    session = PlaybackSession()
+    session = CurrentTagSession()
     event = TagEvent(tag_id="tag-1", timestamp=100.0)
 
     sync.execute(event, session)
@@ -41,7 +41,7 @@ def test_execute_calls_determine_then_apply(sync, mock_determine, mock_apply):
 def test_execute_swallows_exception_from_determine(sync, mock_determine, mock_apply):
     mock_determine.execute.side_effect = RuntimeError("boom")
 
-    sync.execute(TagEvent(tag_id="tag-1", timestamp=100.0), PlaybackSession())
+    sync.execute(TagEvent(tag_id="tag-1", timestamp=100.0), CurrentTagSession())
 
     mock_apply.execute.assert_not_called()
 
@@ -49,7 +49,7 @@ def test_execute_swallows_exception_from_determine(sync, mock_determine, mock_ap
 def test_execute_swallows_exception_from_apply(sync, mock_determine, mock_apply):
     mock_apply.execute.side_effect = OSError("disk full")
 
-    sync.execute(TagEvent(tag_id="tag-1", timestamp=100.0), PlaybackSession())
+    sync.execute(TagEvent(tag_id="tag-1", timestamp=100.0), CurrentTagSession())
 
 
 # Integration tests — real use cases, mock repository only
@@ -69,14 +69,12 @@ def sync_integration(mock_repository):
 
 
 def _sync(sync_integration, session, tag_id, timestamp):
-    """Simulate one CLIController loop iteration: sync then advance last_event_timestamp."""
-    event = TagEvent(tag_id=tag_id, timestamp=timestamp)
-    sync_integration.execute(event, session)
-    session.last_event_timestamp = timestamp  # normally set by HandleTagEvent
+    """Simulate one CLIController loop iteration."""
+    sync_integration.execute(TagEvent(tag_id=tag_id, timestamp=timestamp), session)
 
 
 def test_current_tag_survives_brief_missed_reads_and_clears_after_absence_grace(sync_integration, mock_repository):
-    session = PlaybackSession()
+    session = CurrentTagSession()
 
     _sync(sync_integration, session, "tag-1", 100.0)
     _sync(sync_integration, session, None, 100.4)
@@ -98,11 +96,11 @@ def test_current_tag_survives_brief_missed_reads_and_clears_after_absence_grace(
     assert session.physical_tag is None
 
 
-def test_unknown_tag_promotes_to_known_without_rewriting_current_tag(sync_integration, mock_repository):
-    session = PlaybackSession()
+def test_keep_action_does_not_rewrite_repository(sync_integration, mock_repository):
+    session = CurrentTagSession()
 
-    _sync(sync_integration, session, "promote-tag", 100.0)
-    _sync(sync_integration, session, "promote-tag", 100.2)
+    _sync(sync_integration, session, "tag-1", 100.0)
+    _sync(sync_integration, session, "tag-1", 100.2)
 
     assert mock_repository.set.call_count == 1
-    assert session.physical_tag == "promote-tag"
+    assert session.physical_tag == "tag-1"

--- a/tests/jukebox/test_jukebox_app.py
+++ b/tests/jukebox/test_jukebox_app.py
@@ -43,7 +43,7 @@ def test_main_uses_resolved_runtime_config(app_mocks):
     runtime_resolver.resolve.return_value = runtime_config
     app_mocks.build_settings_service.return_value = settings_service
     app_mocks.build_runtime_resolver.return_value = runtime_resolver
-    app_mocks.build_jukebox.return_value = (MagicMock(), MagicMock())
+    app_mocks.build_jukebox.return_value = (MagicMock(), MagicMock(), MagicMock())
 
     result = runner.invoke(app.app)
 
@@ -160,8 +160,8 @@ def test_main_builds_runtime_from_cli_arguments(mocker, app_mocks, args, expecte
     runtime_resolver = MagicMock()
     runtime_resolver.resolve.return_value = runtime_config
     app_mocks.build_runtime_resolver.return_value = runtime_resolver
-    reader, handle_tag_event = MagicMock(), MagicMock()
-    app_mocks.build_jukebox.return_value = (reader, handle_tag_event)
+    reader, handle_tag_event, sync_current_tag = MagicMock(), MagicMock(), MagicMock()
+    app_mocks.build_jukebox.return_value = (reader, handle_tag_event, sync_current_tag)
     controller = MagicMock()
     app_mocks.controller_class.return_value = controller
 
@@ -178,6 +178,7 @@ def test_main_builds_runtime_from_cli_arguments(mocker, app_mocks, args, expecte
     app_mocks.controller_class.assert_called_once_with(
         reader=reader,
         handle_tag_event=handle_tag_event,
+        sync_current_tag=sync_current_tag,
         loop_interval_seconds=loop_interval_seconds,
     )
     controller.run.assert_called_once()

--- a/tests/jukebox/test_jukebox_di_container.py
+++ b/tests/jukebox/test_jukebox_di_container.py
@@ -53,7 +53,7 @@ class TestBuildJukebox:
             verbose=False,
         )
 
-        reader, handle_tag_event = build_jukebox(config)
+        reader, handle_tag_event, sync_current_tag = build_jukebox(config)
 
         mock_library.assert_called_once_with("/test/library.json")
         mock_current_tag.assert_called_once_with("/test/current-tag.txt")
@@ -95,7 +95,7 @@ class TestBuildJukebox:
         )
         sonos_playback_target_resolver = MagicMock()
 
-        reader, handle_tag_event = build_jukebox(
+        reader, handle_tag_event, sync_current_tag = build_jukebox(
             config,
             sonos_playback_target_resolver=sonos_playback_target_resolver,
         )
@@ -134,7 +134,7 @@ class TestBuildJukebox:
         )
         sonos_playback_target_resolver = MagicMock()
 
-        reader, handle_tag_event = build_jukebox(
+        reader, handle_tag_event, sync_current_tag = build_jukebox(
             config,
             sonos_playback_target_resolver=sonos_playback_target_resolver,
         )
@@ -171,7 +171,7 @@ class TestBuildJukebox:
             verbose=False,
         )
 
-        reader, handle_tag_event = build_jukebox(config)
+        reader, handle_tag_event, sync_current_tag = build_jukebox(config)
 
         mock_library.assert_called_once_with("/test/library.json")
         mock_current_tag.assert_called_once_with("/test/current-tag.txt")
@@ -203,7 +203,7 @@ class TestBuildJukebox:
             verbose=False,
         )
 
-        reader, handle_tag_event = build_jukebox(config)
+        reader, handle_tag_event, sync_current_tag = build_jukebox(config)
 
         assert reader == mock_reader.return_value
         assert handle_tag_event.determine_action.pause_delay == 0.2


### PR DESCRIPTION
## Summary

- Extract `SyncCurrentTag` as a standalone use case orchestrating `DetermineCurrentTagAction` and `ApplyCurrentTagAction`
- Move `SyncCurrentTag` call from `HandleTagEvent` to `CLIController`, called before playback handling each loop tick
- Introduce `CurrentTagSession` entity owning `physical_tag`, `physical_tag_removed_at`, `last_event_timestamp`, previously mixed into `PlaybackSession`
- `PlaybackSession` now tracks logical playback state only; `CLIController` maintains both sessions independently
- `SyncCurrentTag.execute` advances `last_event_timestamp` in a `finally` block so the contract is self-contained regardless of whether sync succeeds

## Motivation

`HandleTagEvent` was orchestrating two unrelated concerns: playback control and physical NFC tag state sync. These are now two separate, independently testable use cases with their own session objects.

`last_event_timestamp` was previously stamped by the caller after each `execute` call, creating an invisible contract for future callers. It is now always set inside `SyncCurrentTag.execute` via `finally`.

## Test plan

- Dryrun smoke test: PLAY -> WAITING -> PAUSE -> IDLE flow verified
- `current-tag.txt` written on tag detection, deleted on CLEAR, verified end-to-end
- Web UI starts correctly (and current-tag banner works)