### PR TITLE
♻️ Guard against KeyError escape from validate_settings_rules

### DIFF
--- a/jukebox/admin/command_handlers.py
+++ b/jukebox/admin/command_handlers.py
@@ -58,7 +58,7 @@ def _build_server_app(
     try:
         return build_app(library_path, services)
     except ModuleNotFoundError as err:
-        if err.name in {"fastapi", "fastui"} or "requires the optional" in str(err):
+        if err.name in {"fastapi", "fastui"}:
             _raise_optional_extra_error(command_name, extra_name, source_command, err)
         raise
 

--- a/jukebox/settings/resolve.py
+++ b/jukebox/settings/resolve.py
@@ -184,7 +184,7 @@ class SettingsService:
 
         try:
             validate_settings_rules(effective_settings.model_dump(mode="python"), updated_paths)
-        except ValueError as err:
+        except (ValueError, KeyError) as err:
             raise InvalidSettingsError(f"Invalid settings update: {err}") from err
 
         persisted_after = _build_updated_persisted_settings(

--- a/tests/jukebox/admin/test_command_handlers.py
+++ b/tests/jukebox/admin/test_command_handlers.py
@@ -956,3 +956,39 @@ def test_execute_server_command_propagates_missing_optional_dependency_error(moc
         )
 
     assert str(err.value) == str(expected)
+
+
+@pytest.mark.parametrize(
+    ("command", "extra_name", "builder_name", "missing_module"),
+    [
+        (ApiCommand(type="api", port=1234), "api", "build_api_app", "fastapi"),
+        (UiCommand(type="ui", port=1234), "ui", "build_ui_app", "fastui"),
+    ],
+)
+def test_execute_server_command_reports_missing_optional_dependencies_from_build_app(
+    mocker, command, extra_name, builder_name, missing_module
+):
+    services = build_services()
+    services.settings.resolve_admin_runtime.return_value = ResolvedAdminRuntimeConfig(
+        library_path="/resolved/library.json",
+        api_port=8000,
+        ui_port=9000,
+        verbose=False,
+    )
+    mocker.patch.dict("sys.modules", {"uvicorn": MagicMock()})
+    build_api_app = MagicMock()
+    build_ui_app = MagicMock()
+    target_builder = build_api_app if builder_name == "build_api_app" else build_ui_app
+    target_builder.side_effect = ModuleNotFoundError(f"No module named '{missing_module}'", name=missing_module)
+
+    with pytest.raises(MissingOptionalDependencyError) as exc_info:
+        execute_server_command(
+            verbose=False,
+            command=command,
+            services=services,
+            build_api_app=build_api_app,
+            build_ui_app=build_ui_app,
+            source_command="jukebox-admin",
+        )
+
+    assert f"`jukebox-admin {extra_name}` requires the optional `{extra_name}` dependencies." in str(exc_info.value)

--- a/tests/jukebox/settings/test_settings_service_mutation_validation.py
+++ b/tests/jukebox/settings/test_settings_service_mutation_validation.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 
+from jukebox.settings import resolve as resolve_module
 from jukebox.settings.errors import InvalidSettingsError
 from jukebox.settings.file_settings_repository import FileSettingsRepository
 from jukebox.settings.resolve import SettingsService
@@ -296,6 +297,20 @@ def test_settings_service_preserves_inactive_reader_subtree_when_switching_reade
     runtime_config = resolve_jukebox_runtime(service)
     assert runtime_config.reader_type == "pn532"
     assert runtime_config.pn532_read_timeout_seconds == 0.2
+
+
+def test_settings_service_set_wraps_validation_rule_key_error_as_invalid_settings_error(tmp_path, mocker):
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(json.dumps({"schema_version": 1}), encoding="utf-8")
+    service = SettingsService(repository=FileSettingsRepository(str(settings_path)))
+    mocker.patch.object(
+        resolve_module, "validate_settings_rules", side_effect=KeyError("jukebox.runtime.loop_interval_seconds")
+    )
+
+    with pytest.raises(InvalidSettingsError, match="Invalid settings update"):
+        service.set_persisted_value("jukebox.playback.pause_delay_seconds", "5.0")
+
+    assert json.loads(settings_path.read_text(encoding="utf-8")) == {"schema_version": 1}
 
 
 def test_settings_service_patch_rejects_malformed_inactive_reader_branch_transactionally(tmp_path):


### PR DESCRIPTION
## Summary

Refs #169

- `validate_settings_rules` could theoretically raise a `KeyError` if a future rule bypasses the `get_rules_supported_by_settings` pre-filter. The catch is added defensively so any such escape is wrapped as an actionable `InvalidSettingsError` rather than a generic crash.
- A code path that was never reachable has been removed.
