### PR TITLE
♻️ Surface settings errors with typed codes and paths

### DIFF
--- a/jukebox/adapters/outbound/players/sonos_player_adapter.py
+++ b/jukebox/adapters/outbound/players/sonos_player_adapter.py
@@ -11,7 +11,7 @@ from urllib3.exceptions import HTTPError
 from jukebox.domain.errors import PlaybackError
 from jukebox.domain.ports import PlayerPort
 from jukebox.settings.entities import ResolvedSonosGroupRuntime
-from jukebox.settings.errors import InvalidSettingsError
+from jukebox.settings.errors import ErrorCode, InvalidSettingsError
 from jukebox.sonos.service import (
     SonosPlaybackTarget,
     SonosPlaybackTargetResolver,
@@ -66,7 +66,10 @@ class SonosPlayerAdapter(PlayerPort):
 
             speaker_info = self._refresh_speaker_metadata()
         except (HTTPError, OSError, RequestException, RuntimeError, SoCoException, SoCoUPnPException) as err:
-            raise InvalidSettingsError(f"Failed to initialize Sonos player: {err}") from err
+            raise InvalidSettingsError(
+                f"Failed to initialize Sonos player: {err}",
+                code=ErrorCode.INVALID_EFFECTIVE,
+            ) from err
 
         LOGGER.info(
             "Found `%s` with software version: %s",

--- a/jukebox/admin/cli_presentation.py
+++ b/jukebox/admin/cli_presentation.py
@@ -5,6 +5,7 @@ from typing import cast
 
 from jukebox.settings.definitions import SETTINGS, get_setting_definition, is_editable_setting_path
 from jukebox.settings.errors import (
+    ErrorCode,
     InvalidSettingsError,
     MalformedSettingsFileError,
     SettingsError,
@@ -385,40 +386,29 @@ def _render_cli_error_message(err: BaseException) -> str:
 
 
 def _render_invalid_settings_error(err: InvalidSettingsError) -> str:
-    message = str(err)
-
-    if message.startswith("Unsupported settings path for write: '") or message.startswith(
-        "Unsupported settings path for reset: '"
-    ):
-        dotted_path = _extract_quoted_path(message)
-        if dotted_path is not None:
-            return (
-                f"Unsupported settings path: '{dotted_path}'. Use `jukebox-admin settings show --effective --json` "
-                "to inspect supported editable paths."
-            )
-        return "Unsupported settings path."
-
-    if message.startswith("Settings value for '"):
-        dotted_path = _extract_quoted_path(message)
-        if "must be valid JSON" in message:
-            return f"Invalid value for '{dotted_path or 'setting'}'. Pass a JSON object or `null`."
-        if "must be a JSON object or null" in message:
-            return f"Invalid value for '{dotted_path or 'setting'}'. Expected a JSON object or `null`."
-
-    if message.startswith("Invalid settings update:"):
-        return f"Settings update rejected: {_extract_compact_detail(message)}"
-
-    if message.startswith("Invalid settings file at '"):
-        filepath = _extract_quoted_path(message)
-        detail = _extract_compact_detail(message)
-        if filepath is not None:
-            return f"Persisted settings are invalid at '{filepath}': {detail}"
-        return f"Persisted settings are invalid: {detail}"
-
-    if message.startswith("Invalid effective settings"):
-        return f"Effective settings are invalid: {_extract_compact_detail(message)}"
-
-    return message
+    match err.code:
+        case ErrorCode.UNSUPPORTED_PATH:
+            if err.path is not None:
+                return (
+                    f"Unsupported settings path: '{err.path}'. Use `jukebox-admin settings show --effective --json` "
+                    "to inspect supported editable paths."
+                )
+            return "Unsupported settings path."
+        case ErrorCode.INVALID_JSON_VALUE:
+            return f"Invalid value for '{err.path or 'setting'}'. Pass a JSON object or `null`."
+        case ErrorCode.INVALID_JSON_TYPE:
+            return f"Invalid value for '{err.path or 'setting'}'. Expected a JSON object or `null`."
+        case ErrorCode.INVALID_UPDATE:
+            return f"Settings update rejected: {_extract_compact_detail(str(err))}"
+        case ErrorCode.INVALID_FILE:
+            detail = _extract_compact_detail(str(err))
+            if err.path is not None:
+                return f"Persisted settings are invalid at '{err.path}': {detail}"
+            return f"Persisted settings are invalid: {detail}"
+        case ErrorCode.INVALID_EFFECTIVE:
+            return f"Effective settings are invalid: {_extract_compact_detail(str(err))}"
+        case _:
+            return str(err)
 
 
 def _extract_compact_detail(message: str) -> str:

--- a/jukebox/admin/cli_presentation.py
+++ b/jukebox/admin/cli_presentation.py
@@ -3,6 +3,8 @@ import re
 from collections.abc import Iterable, Mapping
 from typing import cast
 
+from pydantic import ValidationError
+
 from jukebox.settings.definitions import SETTINGS, get_setting_definition, is_editable_setting_path
 from jukebox.settings.errors import (
     ErrorCode,
@@ -399,16 +401,32 @@ def _render_invalid_settings_error(err: InvalidSettingsError) -> str:
         case ErrorCode.INVALID_JSON_TYPE:
             return f"Invalid value for '{err.path or 'setting'}'. Expected a JSON object or `null`."
         case ErrorCode.INVALID_UPDATE:
-            return f"Settings update rejected: {_extract_compact_detail(str(err))}"
+            return f"Settings update rejected: {_extract_error_detail(err)}"
         case ErrorCode.INVALID_FILE:
-            detail = _extract_compact_detail(str(err))
+            detail = _extract_error_detail(err)
             if err.path is not None:
                 return f"Persisted settings are invalid at '{err.path}': {detail}"
             return f"Persisted settings are invalid: {detail}"
         case ErrorCode.INVALID_EFFECTIVE:
-            return f"Effective settings are invalid: {_extract_compact_detail(str(err))}"
+            return f"Effective settings are invalid: {_extract_error_detail(err)}"
+        case ErrorCode.UNKNOWN_PATH:
+            return str(err)
         case _:
             return str(err)
+
+
+def _extract_error_detail(err: InvalidSettingsError) -> str:
+    if isinstance(err.__cause__, ValidationError):
+        return _format_validation_errors(err.__cause__)
+    return _extract_compact_detail(str(err))
+
+
+def _format_validation_errors(cause: ValidationError) -> str:
+    parts = []
+    for error in cause.errors(include_url=False):
+        location = ".".join(str(loc) for loc in error["loc"])
+        parts.append(f"{location}: {error['msg']}" if location else error["msg"])
+    return "; ".join(parts)
 
 
 def _extract_compact_detail(message: str) -> str:

--- a/jukebox/settings/errors.py
+++ b/jukebox/settings/errors.py
@@ -1,3 +1,6 @@
+from enum import StrEnum
+
+
 class SettingsError(Exception):
     """Base exception for settings failures."""
 
@@ -6,8 +9,25 @@ class MalformedSettingsFileError(SettingsError):
     """Raised when the settings file cannot be parsed as JSON."""
 
 
+class ErrorCode(StrEnum):
+    """Exhaustive set of structured codes that drive CLI and API error presentation."""
+
+    UNSUPPORTED_PATH = "unsupported_path"
+    UNKNOWN_PATH = "unknown_path"
+    INVALID_JSON_VALUE = "invalid_json_value"
+    INVALID_JSON_TYPE = "invalid_json_type"
+    INVALID_UPDATE = "invalid_update"
+    INVALID_EFFECTIVE = "invalid_effective"
+    INVALID_FILE = "invalid_file"
+
+
 class InvalidSettingsError(SettingsError):
     """Raised when persisted or effective settings are invalid."""
+
+    def __init__(self, message: str, *, code: ErrorCode, path: str | None = None):
+        super().__init__(message)
+        self.code = code
+        self.path = path
 
 
 class UnsupportedSettingsVersionError(SettingsError):

--- a/jukebox/settings/file_settings_repository.py
+++ b/jukebox/settings/file_settings_repository.py
@@ -7,7 +7,7 @@ from pydantic import ValidationError
 
 from .dict_utils import deep_merge
 from .entities import PersistedAppSettings, SparsePersistedAppSettings
-from .errors import InvalidSettingsError, MalformedSettingsFileError
+from .errors import ErrorCode, InvalidSettingsError, MalformedSettingsFileError
 from .migration import CURRENT_SETTINGS_SCHEMA_VERSION, migrate_settings_data
 from .types import JsonObject
 
@@ -30,7 +30,10 @@ class FileSettingsRepository:
         except json.JSONDecodeError as err:
             raise MalformedSettingsFileError(f"Malformed settings file at '{self.filepath}': {err}") from err
 
-        migrated_data, migrated = migrate_settings_data(raw_data)
+        try:
+            migrated_data, migrated = migrate_settings_data(raw_data)
+        except InvalidSettingsError as err:
+            raise InvalidSettingsError(str(err), code=err.code, path=self.filepath) from err
 
         try:
             SparsePersistedAppSettings.model_validate(migrated_data)
@@ -38,7 +41,11 @@ class FileSettingsRepository:
                 deep_merge(PersistedAppSettings().model_dump(mode="python"), migrated_data)
             )
         except ValidationError as err:
-            raise InvalidSettingsError(f"Invalid settings file at '{self.filepath}': {err}") from err
+            raise InvalidSettingsError(
+                f"Invalid settings file at '{self.filepath}': {err}",
+                code=ErrorCode.INVALID_FILE,
+                path=self.filepath,
+            ) from err
 
         if migrated:
             self._write_data(migrated_data)
@@ -53,7 +60,11 @@ class FileSettingsRepository:
                 deep_merge(PersistedAppSettings().model_dump(mode="python"), raw_data)
             )
         except ValidationError as err:
-            raise InvalidSettingsError(f"Invalid settings file at '{self.filepath}': {err}") from err
+            raise InvalidSettingsError(
+                f"Invalid settings file at '{self.filepath}': {err}",
+                code=ErrorCode.INVALID_FILE,
+                path=self.filepath,
+            ) from err
 
     def save_persisted_settings_data(self, data: JsonObject) -> None:
         self._write_data(data)

--- a/jukebox/settings/migration.py
+++ b/jukebox/settings/migration.py
@@ -1,6 +1,6 @@
 import copy
 
-from .errors import InvalidSettingsError, UnsupportedSettingsVersionError
+from .errors import ErrorCode, InvalidSettingsError, UnsupportedSettingsVersionError
 from .types import JsonObject, JsonValue
 
 CURRENT_SETTINGS_SCHEMA_VERSION = 1
@@ -8,7 +8,7 @@ CURRENT_SETTINGS_SCHEMA_VERSION = 1
 
 def migrate_settings_data(data: JsonValue) -> tuple[JsonObject, bool]:
     if not isinstance(data, dict):
-        raise InvalidSettingsError("The settings file root must be a JSON object.")
+        raise InvalidSettingsError("The settings file root must be a JSON object.", code=ErrorCode.INVALID_FILE)
 
     migrated_data = copy.deepcopy(data)
     schema_version = migrated_data.get("schema_version")
@@ -18,7 +18,7 @@ def migrate_settings_data(data: JsonValue) -> tuple[JsonObject, bool]:
         return migrated_data, True
 
     if not isinstance(schema_version, int):
-        raise InvalidSettingsError("The settings file schema_version must be an integer.")
+        raise InvalidSettingsError("The settings file schema_version must be an integer.", code=ErrorCode.INVALID_FILE)
 
     if schema_version == CURRENT_SETTINGS_SCHEMA_VERSION:
         return migrated_data, False

--- a/jukebox/settings/resolve.py
+++ b/jukebox/settings/resolve.py
@@ -204,6 +204,7 @@ class SettingsService:
         try:
             validate_settings_rules(effective_settings.model_dump(mode="python"), updated_paths)
         except (ValueError, KeyError) as err:
+            # Rule validation raises plain exceptions, not ValidationError — presentation falls back to text parsing.
             raise InvalidSettingsError(f"Invalid settings update: {err}", code=ErrorCode.INVALID_UPDATE) from err
 
         persisted_after = _build_updated_persisted_settings(

--- a/jukebox/settings/resolve.py
+++ b/jukebox/settings/resolve.py
@@ -22,7 +22,7 @@ from .entities import (
     PersistedAppSettings,
     ResolvedAdminRuntimeConfig,
 )
-from .errors import InvalidSettingsError
+from .errors import ErrorCode, InvalidSettingsError
 from .repositories import SettingsRepository
 from .types import JsonObject, JsonValue
 from .validation_rules import validate_settings_rules
@@ -104,7 +104,11 @@ class SettingsService:
 
     def set_persisted_value(self, dotted_path: str, raw_value: str) -> JsonObject:
         if not is_editable_setting_path(dotted_path):
-            raise InvalidSettingsError(f"Unsupported settings path for write: '{dotted_path}'")
+            raise InvalidSettingsError(
+                f"Unsupported settings path for write: '{dotted_path}'",
+                code=ErrorCode.UNSUPPORTED_PATH,
+                path=dotted_path,
+            )
 
         current_data = self.repository.load_persisted().model_dump(mode="python")
         updated_data = copy.deepcopy(current_data)
@@ -114,7 +118,11 @@ class SettingsService:
     def reset_persisted_value(self, dotted_path: str) -> JsonObject:
         editable_paths = get_editable_paths_for_prefix(dotted_path)
         if not editable_paths:
-            raise InvalidSettingsError(f"Unsupported settings path for reset: '{dotted_path}'")
+            raise InvalidSettingsError(
+                f"Unsupported settings path for reset: '{dotted_path}'",
+                code=ErrorCode.UNSUPPORTED_PATH,
+                path=dotted_path,
+            )
 
         current_data = self.repository.load_persisted().model_dump(mode="python")
         defaults_data = PersistedAppSettings().model_dump(mode="python")
@@ -126,11 +134,13 @@ class SettingsService:
 
     def patch_persisted_settings(self, patch: JsonObject) -> JsonObject:
         if not isinstance(patch, dict) or not patch:
-            raise InvalidSettingsError("Settings patch must be a non-empty JSON object.")
+            raise InvalidSettingsError("Settings patch must be a non-empty JSON object.", code=ErrorCode.INVALID_UPDATE)
 
         updated_paths = sorted(_collect_patch_paths(patch))
         if not updated_paths:
-            raise InvalidSettingsError("Settings patch must include at least one editable field.")
+            raise InvalidSettingsError(
+                "Settings patch must include at least one editable field.", code=ErrorCode.INVALID_UPDATE
+            )
 
         current_data = self.repository.load_persisted().model_dump(mode="python")
         updated_data = deep_merge(current_data, patch)
@@ -146,19 +156,28 @@ class SettingsService:
         try:
             AppSettings.model_validate(file_merged)
         except ValidationError as err:
-            raise InvalidSettingsError(f"Invalid effective settings from persisted settings: {err}") from err
+            raise InvalidSettingsError(
+                f"Invalid effective settings from persisted settings: {err}",
+                code=ErrorCode.INVALID_EFFECTIVE,
+            ) from err
 
         env_merged = deep_merge(file_merged, self.env_overrides)
         try:
             AppSettings.model_validate(env_merged)
         except ValidationError as err:
-            raise InvalidSettingsError(f"Invalid effective settings after environment overrides: {err}") from err
+            raise InvalidSettingsError(
+                f"Invalid effective settings after environment overrides: {err}",
+                code=ErrorCode.INVALID_EFFECTIVE,
+            ) from err
 
         cli_merged = deep_merge(env_merged, self.cli_overrides)
         try:
             effective_settings = AppSettings.model_validate(cli_merged)
         except ValidationError as err:
-            raise InvalidSettingsError(f"Invalid effective settings after CLI overrides: {err}") from err
+            raise InvalidSettingsError(
+                f"Invalid effective settings after CLI overrides: {err}",
+                code=ErrorCode.INVALID_EFFECTIVE,
+            ) from err
 
         return effective_settings
 
@@ -173,19 +192,19 @@ class SettingsService:
         try:
             persisted_settings = PersistedAppSettings.model_validate(updated_data)
         except ValidationError as err:
-            raise InvalidSettingsError(f"Invalid settings update: {err}") from err
+            raise InvalidSettingsError(f"Invalid settings update: {err}", code=ErrorCode.INVALID_UPDATE) from err
 
         try:
             effective_settings = AppSettings.model_validate(
                 deep_merge(AppSettings().model_dump(mode="python"), persisted_settings.model_dump(mode="python"))
             )
         except ValidationError as err:
-            raise InvalidSettingsError(f"Invalid settings update: {err}") from err
+            raise InvalidSettingsError(f"Invalid settings update: {err}", code=ErrorCode.INVALID_UPDATE) from err
 
         try:
             validate_settings_rules(effective_settings.model_dump(mode="python"), updated_paths)
         except (ValueError, KeyError) as err:
-            raise InvalidSettingsError(f"Invalid settings update: {err}") from err
+            raise InvalidSettingsError(f"Invalid settings update: {err}", code=ErrorCode.INVALID_UPDATE) from err
 
         persisted_after = _build_updated_persisted_settings(
             persisted_before,
@@ -314,11 +333,19 @@ def _collect_patch_paths(node: JsonObject, prefix: str | None = None) -> set[str
 
         if isinstance(value, dict):
             if not has_editable_setting_descendants(dotted_path):
-                raise InvalidSettingsError(f"Unsupported settings path for write: '{dotted_path}'")
+                raise InvalidSettingsError(
+                    f"Unsupported settings path for write: '{dotted_path}'",
+                    code=ErrorCode.UNSUPPORTED_PATH,
+                    path=dotted_path,
+                )
             paths.update(_collect_patch_paths(value, dotted_path))
             continue
 
-        raise InvalidSettingsError(f"Unsupported settings path for write: '{dotted_path}'")
+        raise InvalidSettingsError(
+            f"Unsupported settings path for write: '{dotted_path}'",
+            code=ErrorCode.UNSUPPORTED_PATH,
+            path=dotted_path,
+        )
 
     return paths
 
@@ -328,7 +355,11 @@ def _get_dotted_path(data: JsonObject, dotted_path: str) -> JsonValue:
 
     for part in dotted_path.split("."):
         if not isinstance(current, dict) or part not in current:
-            raise InvalidSettingsError(f"Unknown settings path: '{dotted_path}'")
+            raise InvalidSettingsError(
+                f"Unknown settings path: '{dotted_path}'",
+                code=ErrorCode.UNKNOWN_PATH,
+                path=dotted_path,
+            )
         current = current[part]
 
     return copy.deepcopy(current)
@@ -406,9 +437,17 @@ def _parse_raw_setting_value(dotted_path: str, raw_value: str) -> JsonValue:
     try:
         parsed_value = json.loads(raw_value)
     except json.JSONDecodeError as err:
-        raise InvalidSettingsError(f"Settings value for '{dotted_path}' must be valid JSON.") from err
+        raise InvalidSettingsError(
+            f"Settings value for '{dotted_path}' must be valid JSON.",
+            code=ErrorCode.INVALID_JSON_VALUE,
+            path=dotted_path,
+        ) from err
 
     if parsed_value is not None and not isinstance(parsed_value, dict):
-        raise InvalidSettingsError(f"Settings value for '{dotted_path}' must be a JSON object or null.")
+        raise InvalidSettingsError(
+            f"Settings value for '{dotted_path}' must be a JSON object or null.",
+            code=ErrorCode.INVALID_JSON_TYPE,
+            path=dotted_path,
+        )
 
     return cast(JsonValue, parsed_value)

--- a/jukebox/settings/runtime_resolver.py
+++ b/jukebox/settings/runtime_resolver.py
@@ -7,7 +7,7 @@ from jukebox.pn532.profiles import SpiConnectionParams, resolve_connection_param
 from jukebox.sonos.service import SonosService
 
 from .entities import AppSettings, Pn532ReaderSettings, ResolvedJukeboxRuntimeConfig, ResolvedSonosGroupRuntime
-from .errors import InvalidSettingsError
+from .errors import ErrorCode, InvalidSettingsError
 from .service_protocols import RuntimeSettingsService
 from .validation_rules import validate_settings_rules
 
@@ -43,7 +43,10 @@ class JukeboxRuntimeResolver:
                 verbose=verbose,
             )
         except (ValidationError, ValueError) as err:
-            raise InvalidSettingsError(self.settings_service.format_invalid_settings_error(str(err))) from err
+            raise InvalidSettingsError(
+                self.settings_service.format_invalid_settings_error(str(err)),
+                code=ErrorCode.INVALID_EFFECTIVE,
+            ) from err
 
     def _resolve_active_sonos_target(self, effective_settings: AppSettings) -> ActiveSonosTarget:
         player_settings = effective_settings.jukebox.player

--- a/tests/jukebox/adapters/inbound/admin/api/test_settings_router.py
+++ b/tests/jukebox/adapters/inbound/admin/api/test_settings_router.py
@@ -10,7 +10,7 @@ if FASTAPI_INSTALLED:
 
     from jukebox.adapters.inbound.admin.api.models import SettingsPatchInput, SettingsResetInput
     from jukebox.adapters.inbound.admin.api.settings_router import build_settings_router
-    from jukebox.settings.errors import InvalidSettingsError
+    from jukebox.settings.errors import ErrorCode, InvalidSettingsError
 
 
 def build_router(*, settings_service=None):
@@ -190,7 +190,9 @@ def test_patch_settings_updates_player_settings(get_route):
 @pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
 def test_patch_settings_returns_400_for_invalid_settings_write(get_route):
     settings_service = MagicMock()
-    settings_service.patch_persisted_settings.side_effect = InvalidSettingsError("Unsupported settings path")
+    settings_service.patch_persisted_settings.side_effect = InvalidSettingsError(
+        "Unsupported settings path", code=ErrorCode.UNSUPPORTED_PATH
+    )
     router = build_router(settings_service=settings_service)
     route = get_route(router, "/api/v1/settings", "PATCH")
 
@@ -277,7 +279,9 @@ def test_reset_settings_accepts_section_path(get_route):
 @pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
 def test_reset_settings_returns_400_for_invalid_reset_path(get_route):
     settings_service = MagicMock()
-    settings_service.reset_persisted_value.side_effect = InvalidSettingsError("Unsupported settings path")
+    settings_service.reset_persisted_value.side_effect = InvalidSettingsError(
+        "Unsupported settings path", code=ErrorCode.UNSUPPORTED_PATH
+    )
     router = build_router(settings_service=settings_service)
     route = get_route(router, "/api/v1/settings/reset", "POST")
 

--- a/tests/jukebox/adapters/inbound/admin/test_ui_controller.py
+++ b/tests/jukebox/adapters/inbound/admin/test_ui_controller.py
@@ -268,7 +268,7 @@ async def test_update_sonos_selection_saves_single_speaker_selection():
 @pytest.mark.anyio
 async def test_update_sonos_selection_redirects_when_write_succeeds_but_effective_settings_stay_invalid():
     from jukebox.adapters.inbound.admin.ui_controller import SonosSelectionForm
-    from jukebox.settings.errors import InvalidSettingsError
+    from jukebox.settings.errors import ErrorCode, InvalidSettingsError
 
     controller = build_controller()
 
@@ -288,7 +288,9 @@ async def test_update_sonos_selection_redirects_when_write_succeeds_but_effectiv
                 }
             },
         }
-        raise InvalidSettingsError("Invalid effective settings after environment overrides.")
+        raise InvalidSettingsError(
+            "Invalid effective settings after environment overrides.", code=ErrorCode.INVALID_EFFECTIVE
+        )
 
     controller.settings_service.patch_persisted_settings.side_effect = raise_after_persist
     route = next(
@@ -471,7 +473,7 @@ async def test_update_setting_returns_field_error_for_non_object_json():
 @pytest.mark.anyio
 async def test_update_setting_redirects_when_write_succeeds_but_effective_settings_stay_invalid():
     from jukebox.adapters.inbound.admin.ui_controller import SettingValueForm
-    from jukebox.settings.errors import InvalidSettingsError
+    from jukebox.settings.errors import ErrorCode, InvalidSettingsError
 
     controller = build_controller()
 
@@ -493,7 +495,9 @@ async def test_update_setting_redirects_when_write_succeeds_but_effective_settin
                 }
             },
         }
-        raise InvalidSettingsError("Invalid effective settings after environment overrides.")
+        raise InvalidSettingsError(
+            "Invalid effective settings after environment overrides.", code=ErrorCode.INVALID_EFFECTIVE
+        )
 
     controller.settings_service.patch_persisted_settings.side_effect = raise_after_persist
     route = next(
@@ -516,10 +520,12 @@ async def test_update_setting_returns_field_error_for_shared_validation_failure(
     from fastapi import HTTPException
 
     from jukebox.adapters.inbound.admin.ui_controller import SettingValueForm
-    from jukebox.settings.errors import InvalidSettingsError
+    from jukebox.settings.errors import ErrorCode, InvalidSettingsError
 
     controller = build_controller()
-    controller.settings_service.patch_persisted_settings.side_effect = InvalidSettingsError("Invalid settings update.")
+    controller.settings_service.patch_persisted_settings.side_effect = InvalidSettingsError(
+        "Invalid settings update.", code=ErrorCode.INVALID_UPDATE
+    )
     route = next(
         route
         for route in controller.app.routes
@@ -543,7 +549,7 @@ async def test_update_setting_returns_field_error_for_shared_validation_failure(
 @pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_reset_setting_redirects_when_reset_succeeds_but_effective_settings_stay_invalid():
-    from jukebox.settings.errors import InvalidSettingsError
+    from jukebox.settings.errors import ErrorCode, InvalidSettingsError
 
     controller = build_controller()
 
@@ -566,7 +572,9 @@ async def test_reset_setting_redirects_when_reset_succeeds_but_effective_setting
                 }
             },
         }
-        raise InvalidSettingsError("Invalid effective settings after environment overrides.")
+        raise InvalidSettingsError(
+            "Invalid effective settings after environment overrides.", code=ErrorCode.INVALID_EFFECTIVE
+        )
 
     controller.settings_service.reset_persisted_value.side_effect = raise_after_reset
     route = next(
@@ -604,10 +612,12 @@ async def test_reset_setting_calls_service_and_returns_refreshed_settings_page()
 @pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 @pytest.mark.anyio
 async def test_reset_setting_rerenders_edit_page_with_visible_error(walk_components):
-    from jukebox.settings.errors import InvalidSettingsError
+    from jukebox.settings.errors import ErrorCode, InvalidSettingsError
 
     controller = build_controller()
-    controller.settings_service.reset_persisted_value.side_effect = InvalidSettingsError("Invalid settings update.")
+    controller.settings_service.reset_persisted_value.side_effect = InvalidSettingsError(
+        "Invalid settings update.", code=ErrorCode.INVALID_UPDATE
+    )
     route = next(
         route
         for route in controller.app.routes

--- a/tests/jukebox/adapters/inbound/admin/ui_pages/test_settings_page_builder.py
+++ b/tests/jukebox/adapters/inbound/admin/ui_pages/test_settings_page_builder.py
@@ -189,11 +189,11 @@ def test_settings_edit_pages_render_select_text_and_json_fields(walk_components)
 
 @pytest.mark.skipif(not FASTUI_INSTALLED, reason="FastUI dependencies are not installed")
 def test_settings_pages_render_error_banner_when_effective_settings_are_unavailable(walk_components):
-    from jukebox.settings.errors import InvalidSettingsError
+    from jukebox.settings.errors import ErrorCode, InvalidSettingsError
 
     page_builder = build_settings_page_builder()
     page_builder.settings_service.get_effective_settings_view.side_effect = InvalidSettingsError(
-        "Invalid effective settings after environment overrides."
+        "Invalid effective settings after environment overrides.", code=ErrorCode.INVALID_EFFECTIVE
     )
 
     settings_page = page_builder.build_settings_page_components()[0]

--- a/tests/jukebox/admin/test_cli_presentation.py
+++ b/tests/jukebox/admin/test_cli_presentation.py
@@ -705,6 +705,86 @@ def test_render_cli_error_for_invalid_effective_settings_preserves_failing_paths
     )
 
 
+def test_render_cli_error_uses_structured_validation_errors_when_cause_is_available():
+    from pydantic import BaseModel, ValidationError
+
+    class FakeModel(BaseModel):
+        field_a: int
+        field_b: int
+
+    cause = None
+    try:
+        FakeModel.model_validate({"field_a": "bad", "field_b": "also_bad"})
+    except ValidationError as e:
+        cause = e
+
+    assert cause is not None
+    try:
+        raise InvalidSettingsError(f"Invalid settings update: {cause}", code=ErrorCode.INVALID_UPDATE) from cause
+    except InvalidSettingsError as err:
+        message = render_cli_error(err)
+
+    assert message == (
+        "Settings update rejected: "
+        "field_a: Input should be a valid integer, unable to parse string as an integer; "
+        "field_b: Input should be a valid integer, unable to parse string as an integer"
+    )
+
+
+def test_render_cli_error_uses_structured_validation_errors_for_invalid_file():
+    from pydantic import BaseModel, ValidationError
+
+    class FakeModel(BaseModel):
+        port: int
+
+    cause = None
+    try:
+        FakeModel.model_validate({"port": "bad"})
+    except ValidationError as e:
+        cause = e
+
+    assert cause is not None
+    try:
+        raise InvalidSettingsError(
+            f"Invalid settings file at '/tmp/settings.json': {cause}",
+            code=ErrorCode.INVALID_FILE,
+            path="/tmp/settings.json",
+        ) from cause
+    except InvalidSettingsError as err:
+        message = render_cli_error(err)
+
+    assert message == (
+        "Persisted settings are invalid at '/tmp/settings.json': "
+        "port: Input should be a valid integer, unable to parse string as an integer"
+    )
+
+
+def test_render_cli_error_uses_structured_validation_errors_for_invalid_effective():
+    from pydantic import BaseModel, ValidationError
+
+    class FakeModel(BaseModel):
+        port: int
+
+    cause = None
+    try:
+        FakeModel.model_validate({"port": "bad"})
+    except ValidationError as e:
+        cause = e
+
+    assert cause is not None
+    try:
+        raise InvalidSettingsError(
+            f"Invalid effective settings from persisted settings: {cause}",
+            code=ErrorCode.INVALID_EFFECTIVE,
+        ) from cause
+    except InvalidSettingsError as err:
+        message = render_cli_error(err)
+
+    assert message == (
+        "Effective settings are invalid: port: Input should be a valid integer, unable to parse string as an integer"
+    )
+
+
 def test_render_cli_error_for_optional_dependency_error_is_concise():
     message = render_cli_error(MissingOptionalDependencyError("`jukebox-admin ui`", "ui", "jukebox-admin ui"))
 

--- a/tests/jukebox/admin/test_cli_presentation.py
+++ b/tests/jukebox/admin/test_cli_presentation.py
@@ -11,6 +11,7 @@ from jukebox.admin.commands import SettingsResetCommand, SettingsSetCommand, Set
 from jukebox.admin.sonos_households import GroupedSonosHousehold
 from jukebox.settings.entities import SelectedSonosGroupSettings, SelectedSonosSpeakerSettings
 from jukebox.settings.errors import (
+    ErrorCode,
     InvalidSettingsError,
     MalformedSettingsFileError,
     UnsupportedSettingsVersionError,
@@ -610,7 +611,13 @@ def test_render_settings_output_json_mode_preserves_payload_shape():
 
 
 def test_render_cli_error_for_unsupported_settings_path_is_actionable():
-    message = render_cli_error(InvalidSettingsError("Unsupported settings path for write: 'admin.api.host'"))
+    message = render_cli_error(
+        InvalidSettingsError(
+            "Unsupported settings path for write: 'admin.api.host'",
+            code=ErrorCode.UNSUPPORTED_PATH,
+            path="admin.api.host",
+        )
+    )
 
     assert "Unsupported settings path: 'admin.api.host'." in message
     assert "`jukebox-admin settings show --effective --json`" in message
@@ -618,7 +625,11 @@ def test_render_cli_error_for_unsupported_settings_path_is_actionable():
 
 def test_render_cli_error_for_invalid_json_value_is_concise():
     message = render_cli_error(
-        InvalidSettingsError("Settings value for 'jukebox.player.sonos.selected_group' must be valid JSON.")
+        InvalidSettingsError(
+            "Settings value for 'jukebox.player.sonos.selected_group' must be valid JSON.",
+            code=ErrorCode.INVALID_JSON_VALUE,
+            path="jukebox.player.sonos.selected_group",
+        )
     )
 
     assert message == "Invalid value for 'jukebox.player.sonos.selected_group'. Pass a JSON object or `null`."
@@ -649,7 +660,9 @@ def test_render_cli_error_for_invalid_settings_file_preserves_failing_path():
             "admin.api.port\n"
             "  Input should be a valid integer, unable to parse string as an integer "
             "[type=int_parsing, input_value='bad', input_type=str]\n"
-            "For further information visit https://errors.pydantic.dev/2.11/v/int_parsing"
+            "For further information visit https://errors.pydantic.dev/2.11/v/int_parsing",
+            code=ErrorCode.INVALID_FILE,
+            path="/tmp/settings.json",
         )
     )
 
@@ -668,7 +681,8 @@ def test_render_cli_error_for_invalid_effective_settings_preserves_failing_paths
             "[type=int_parsing, input_value='bad', input_type=str]\n"
             "admin.ui.port\n"
             "  Input should be less than or equal to 65535 [type=less_than_equal, input_value=70000, input_type=int]\n"
-            "For further information visit https://errors.pydantic.dev/2.11/v/int_parsing"
+            "For further information visit https://errors.pydantic.dev/2.11/v/int_parsing",
+            code=ErrorCode.INVALID_EFFECTIVE,
         )
     )
 

--- a/tests/jukebox/admin/test_cli_presentation.py
+++ b/tests/jukebox/admin/test_cli_presentation.py
@@ -635,6 +635,18 @@ def test_render_cli_error_for_invalid_json_value_is_concise():
     assert message == "Invalid value for 'jukebox.player.sonos.selected_group'. Pass a JSON object or `null`."
 
 
+def test_render_cli_error_for_invalid_json_type_is_concise():
+    message = render_cli_error(
+        InvalidSettingsError(
+            "Settings value for 'jukebox.player.sonos.selected_group' must be a JSON object or null.",
+            code=ErrorCode.INVALID_JSON_TYPE,
+            path="jukebox.player.sonos.selected_group",
+        )
+    )
+
+    assert message == "Invalid value for 'jukebox.player.sonos.selected_group'. Expected a JSON object or `null`."
+
+
 def test_render_cli_error_for_malformed_settings_file_is_friendly():
     message = render_cli_error(
         MalformedSettingsFileError("Malformed settings file at '/tmp/settings.json': Expecting value: line 1 column 1")

--- a/tests/jukebox/admin/test_pn532_command_handlers.py
+++ b/tests/jukebox/admin/test_pn532_command_handlers.py
@@ -12,7 +12,7 @@ from jukebox.admin.pn532_command_handlers import (
 )
 from jukebox.admin.pn532_commands import Pn532ProbeCommand, Pn532ProfilesCommand, Pn532SelectCommand
 from jukebox.pn532.profiles import PN532_PROFILES, SpiConnectionParams
-from jukebox.settings.errors import InvalidSettingsError
+from jukebox.settings.errors import ErrorCode, InvalidSettingsError
 from jukebox.shared.errors import MissingOptionalDependencyError
 
 
@@ -224,7 +224,9 @@ def test_execute_pn532_command_select_cancel_does_not_write_settings():
 
 def test_execute_pn532_command_select_interactive_invalid_pin_propagates_settings_error():
     service = MagicMock()
-    service.set_persisted_value.side_effect = InvalidSettingsError("invalid value for spi.cs")
+    service.set_persisted_value.side_effect = InvalidSettingsError(
+        "invalid value for spi.cs", code=ErrorCode.INVALID_UPDATE
+    )
     profile_prompt_fn = MagicMock(return_value="waveshare_hat")
     pin_prompt_fn = MagicMock(side_effect=["20", "not_a_number", ""])
 

--- a/tests/jukebox/settings/test_file_settings_repository.py
+++ b/tests/jukebox/settings/test_file_settings_repository.py
@@ -86,6 +86,17 @@ def test_repository_rejects_legacy_selected_group_fields(tmp_path):
         repository.load_persisted_settings_data()
 
 
+def test_repository_migration_error_carries_filepath(tmp_path):
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    repository = FileSettingsRepository(str(settings_path))
+
+    with pytest.raises(InvalidSettingsError) as exc_info:
+        repository.load_persisted_settings_data()
+
+    assert exc_info.value.path == str(settings_path)
+
+
 def test_repository_accepts_selected_group_household_id(tmp_path):
     settings_path = tmp_path / "settings.json"
     settings_path.write_text(

--- a/tests/jukebox/test_jukebox_app.py
+++ b/tests/jukebox/test_jukebox_app.py
@@ -7,7 +7,7 @@ from typer.testing import CliRunner
 from jukebox import app
 from jukebox.pn532.profiles import SpiConnectionParams
 from jukebox.settings.entities import ResolvedJukeboxRuntimeConfig
-from jukebox.settings.errors import InvalidSettingsError
+from jukebox.settings.errors import ErrorCode, InvalidSettingsError
 from jukebox.settings.file_settings_repository import FileSettingsRepository
 
 runner = CliRunner()
@@ -61,7 +61,9 @@ def test_main_uses_resolved_runtime_config(app_mocks):
 
 
 def test_main_exits_on_settings_error(app_mocks):
-    app_mocks.build_settings_service.side_effect = InvalidSettingsError("broken settings")
+    app_mocks.build_settings_service.side_effect = InvalidSettingsError(
+        "broken settings", code=ErrorCode.INVALID_EFFECTIVE
+    )
 
     result = runner.invoke(app.app)
 
@@ -72,7 +74,9 @@ def test_main_exits_on_settings_error(app_mocks):
 def test_main_exits_on_runtime_resolver_settings_error(app_mocks):
     settings_service = MagicMock()
     app_mocks.build_settings_service.return_value = settings_service
-    app_mocks.build_runtime_resolver.side_effect = InvalidSettingsError("resolver failed")
+    app_mocks.build_runtime_resolver.side_effect = InvalidSettingsError(
+        "resolver failed", code=ErrorCode.INVALID_EFFECTIVE
+    )
 
     result = runner.invoke(app.app)
 
@@ -98,7 +102,7 @@ def test_main_exits_on_build_jukebox_settings_error(app_mocks):
     runtime_resolver.resolve.return_value = runtime_config
     app_mocks.build_settings_service.return_value = settings_service
     app_mocks.build_runtime_resolver.return_value = runtime_resolver
-    app_mocks.build_jukebox.side_effect = InvalidSettingsError("sonos startup failed")
+    app_mocks.build_jukebox.side_effect = InvalidSettingsError("sonos startup failed", code=ErrorCode.INVALID_EFFECTIVE)
 
     result = runner.invoke(app.app)
 


### PR DESCRIPTION
## Summary

Refs #169 

- Settings errors now carry a machine-readable code and the path of the affected setting, so there is a reliable way to inspect what failed without parsing error strings.
- The CLI uses these fields to build user-facing messages, replacing brittle string matching on error text.
- Pydantic validation failures are rendered using the structured errors API rather than a custom text parser.
- Migration errors (invalid JSON root structure) now also carry the file path — previously lost before reaching the CLI renderer.

## Test plan

- [ ] Run `jukebox-admin settings set <unsupported.path> value` and verify the error message names the path.
- [ ] Set a setting to an invalid JSON value and verify the message distinguishes between a parse failure and a wrong type.
- [ ] Trigger a Pydantic validation failure (e.g. set a port to a string) and verify the field name and constraint appear in the output.
- [ ] Run with `--verbose` and verify full details are still visible.
- [ ]  Write a settings file whose JSON root is an array (e.g. [1,2,3]) and verify the error message includes the file path.