### PR TITLE
✅ Introduce architecture tests

### DIFF
--- a/jukebox/adapters/inbound/admin/api/current_tag_router.py
+++ b/jukebox/adapters/inbound/admin/api/current_tag_router.py
@@ -11,11 +11,7 @@ from jukebox.adapters.inbound.admin.api.models import (
     DiscPatchInput,
 )
 from jukebox.domain.entities import CurrentTagStatus, Disc, DiscMetadata, DiscOption
-from jukebox.domain.use_cases.library.add_disc import AddDisc
-from jukebox.domain.use_cases.library.edit_disc import EditDisc
-from jukebox.domain.use_cases.library.get_current_tag_status import GetCurrentTagStatus
-from jukebox.domain.use_cases.library.get_disc import GetDisc
-from jukebox.domain.use_cases.library.remove_disc import RemoveDisc
+from jukebox.domain.use_cases import AddDisc, EditDisc, GetCurrentTagStatus, GetDisc, RemoveDisc
 
 
 def build_current_tag_router(

--- a/jukebox/adapters/inbound/admin/api/discs_router.py
+++ b/jukebox/adapters/inbound/admin/api/discs_router.py
@@ -3,11 +3,7 @@ from pydantic import ValidationError
 
 from jukebox.adapters.inbound.admin.api.models import DiscInput, DiscOutput, DiscPatchInput
 from jukebox.domain.entities import Disc, DiscMetadata, DiscOption
-from jukebox.domain.use_cases.library.add_disc import AddDisc
-from jukebox.domain.use_cases.library.edit_disc import EditDisc
-from jukebox.domain.use_cases.library.get_disc import GetDisc
-from jukebox.domain.use_cases.library.list_discs import ListDiscs
-from jukebox.domain.use_cases.library.remove_disc import RemoveDisc
+from jukebox.domain.use_cases import AddDisc, EditDisc, GetDisc, ListDiscs, RemoveDisc
 
 
 def build_discs_router(

--- a/jukebox/adapters/inbound/admin/api_controller.py
+++ b/jukebox/adapters/inbound/admin/api_controller.py
@@ -21,12 +21,7 @@ except ModuleNotFoundError as e:
     if e.name != "fastapi":
         raise
     raise MissingOptionalDependencyError("The `api_controller` module", "api", "jukebox-admin api") from e
-from jukebox.domain.use_cases.library.add_disc import AddDisc
-from jukebox.domain.use_cases.library.edit_disc import EditDisc
-from jukebox.domain.use_cases.library.get_current_tag_status import GetCurrentTagStatus
-from jukebox.domain.use_cases.library.get_disc import GetDisc
-from jukebox.domain.use_cases.library.list_discs import ListDiscs
-from jukebox.domain.use_cases.library.remove_disc import RemoveDisc
+from jukebox.domain.use_cases import AddDisc, EditDisc, GetCurrentTagStatus, GetDisc, ListDiscs, RemoveDisc
 from jukebox.settings.entities import SelectedSonosGroupSettings
 from jukebox.settings.selected_sonos_group_repository import SettingsSelectedSonosGroupRepository
 from jukebox.settings.service_protocols import SettingsService

--- a/jukebox/adapters/inbound/admin/cli_controller.py
+++ b/jukebox/adapters/inbound/admin/cli_controller.py
@@ -10,13 +10,7 @@ from jukebox.admin.library_commands import (
     CliSearchCommand,
 )
 from jukebox.domain.entities import Disc, DiscMetadata, DiscOption
-from jukebox.domain.use_cases.library.add_disc import AddDisc
-from jukebox.domain.use_cases.library.edit_disc import EditDisc
-from jukebox.domain.use_cases.library.get_disc import GetDisc
-from jukebox.domain.use_cases.library.list_discs import ListDiscs
-from jukebox.domain.use_cases.library.remove_disc import RemoveDisc
-from jukebox.domain.use_cases.library.resolve_tag_id import ResolveTagId
-from jukebox.domain.use_cases.library.search_discs import SearchDiscs
+from jukebox.domain.use_cases import AddDisc, EditDisc, GetDisc, ListDiscs, RemoveDisc, ResolveTagId, SearchDiscs
 
 
 class CLIController:

--- a/jukebox/adapters/inbound/admin/interactive_cli_controller.py
+++ b/jukebox/adapters/inbound/admin/interactive_cli_controller.py
@@ -2,11 +2,7 @@ import typer
 
 from jukebox.adapters.inbound.admin.cli_display import display_library_line, display_library_table
 from jukebox.domain.entities import CurrentTagStatus, Disc, DiscMetadata, DiscOption
-from jukebox.domain.use_cases.library.add_disc import AddDisc
-from jukebox.domain.use_cases.library.edit_disc import EditDisc
-from jukebox.domain.use_cases.library.get_current_tag_status import GetCurrentTagStatus
-from jukebox.domain.use_cases.library.list_discs import ListDiscs
-from jukebox.domain.use_cases.library.remove_disc import RemoveDisc
+from jukebox.domain.use_cases import AddDisc, EditDisc, GetCurrentTagStatus, ListDiscs, RemoveDisc
 
 
 class InteractiveCLIController:

--- a/jukebox/adapters/inbound/admin/ui_controller.py
+++ b/jukebox/adapters/inbound/admin/ui_controller.py
@@ -19,12 +19,7 @@ from jukebox.adapters.inbound.admin.ui_pages.library import DiscForm, LibraryUIP
 from jukebox.adapters.inbound.admin.ui_pages.settings import SettingsUIPageBuilder
 from jukebox.adapters.inbound.admin.ui_pages.sonos import SonosSelectionForm, SonosUIPageBuilder
 from jukebox.domain.entities import Disc, DiscMetadata, DiscOption
-from jukebox.domain.use_cases.library.add_disc import AddDisc
-from jukebox.domain.use_cases.library.edit_disc import EditDisc
-from jukebox.domain.use_cases.library.get_current_tag_status import GetCurrentTagStatus
-from jukebox.domain.use_cases.library.get_disc import GetDisc
-from jukebox.domain.use_cases.library.list_discs import ListDiscs
-from jukebox.domain.use_cases.library.remove_disc import RemoveDisc
+from jukebox.domain.use_cases import AddDisc, EditDisc, GetCurrentTagStatus, GetDisc, ListDiscs, RemoveDisc
 from jukebox.settings.definitions import get_setting_definition
 from jukebox.settings.errors import SettingsError
 from jukebox.settings.selected_sonos_group_repository import SettingsSelectedSonosGroupRepository

--- a/jukebox/adapters/inbound/admin/ui_pages/library.py
+++ b/jukebox/adapters/inbound/admin/ui_pages/library.py
@@ -9,9 +9,7 @@ from fastui.events import BackEvent, GoToEvent, PageEvent
 from pydantic import BaseModel, Field
 
 from jukebox.domain.entities import CurrentTagStatus, DiscMetadata, DiscOption
-from jukebox.domain.use_cases.library.get_current_tag_status import GetCurrentTagStatus
-from jukebox.domain.use_cases.library.get_disc import GetDisc
-from jukebox.domain.use_cases.library.list_discs import ListDiscs
+from jukebox.domain.use_cases import GetCurrentTagStatus, GetDisc, ListDiscs
 
 
 class DiscTable(DiscMetadata, DiscOption):

--- a/jukebox/adapters/inbound/cli_controller.py
+++ b/jukebox/adapters/inbound/cli_controller.py
@@ -3,8 +3,7 @@ from time import sleep
 
 from jukebox.domain.entities import CurrentTagState, Idle, NoTag, PlaybackState, TagEvent
 from jukebox.domain.ports import ReaderPort
-from jukebox.domain.use_cases.handle_tag_event import HandleTagEvent
-from jukebox.domain.use_cases.sync_current_tag import SyncCurrentTag
+from jukebox.domain.use_cases import HandleTagEvent, SyncCurrentTag
 from jukebox.shared.timing import DEFAULT_LOOP_INTERVAL_SECONDS
 
 

--- a/jukebox/admin/di_container.py
+++ b/jukebox/admin/di_container.py
@@ -3,14 +3,16 @@ from typing import cast
 from jukebox.adapters.outbound.json_library_adapter import JsonLibraryAdapter
 from jukebox.adapters.outbound.sonos_discovery_adapter import SoCoSonosDiscoveryAdapter
 from jukebox.adapters.outbound.text_current_tag_adapter import TextCurrentTagAdapter
-from jukebox.domain.use_cases.library.add_disc import AddDisc
-from jukebox.domain.use_cases.library.edit_disc import EditDisc
-from jukebox.domain.use_cases.library.get_current_tag_status import GetCurrentTagStatus
-from jukebox.domain.use_cases.library.get_disc import GetDisc
-from jukebox.domain.use_cases.library.list_discs import ListDiscs
-from jukebox.domain.use_cases.library.remove_disc import RemoveDisc
-from jukebox.domain.use_cases.library.resolve_tag_id import ResolveTagId
-from jukebox.domain.use_cases.library.search_discs import SearchDiscs
+from jukebox.domain.use_cases import (
+    AddDisc,
+    EditDisc,
+    GetCurrentTagStatus,
+    GetDisc,
+    ListDiscs,
+    RemoveDisc,
+    ResolveTagId,
+    SearchDiscs,
+)
 from jukebox.settings.file_settings_repository import FileSettingsRepository
 from jukebox.settings.resolve import SettingsService as SettingsServiceImpl
 from jukebox.settings.resolve import build_environment_settings_overrides

--- a/jukebox/di_container.py
+++ b/jukebox/di_container.py
@@ -12,8 +12,7 @@ from jukebox.domain.entities import (
     CurrentTagContext,
     TransitionContext,
 )
-from jukebox.domain.use_cases.handle_tag_event import HandleTagEvent
-from jukebox.domain.use_cases.sync_current_tag import SyncCurrentTag
+from jukebox.domain.use_cases import HandleTagEvent, SyncCurrentTag
 from jukebox.settings.entities import ResolvedJukeboxRuntimeConfig
 from jukebox.settings.file_settings_repository import FileSettingsRepository
 from jukebox.settings.resolve import SettingsService as SettingsServiceImpl

--- a/jukebox/domain/use_cases/__init__.py
+++ b/jukebox/domain/use_cases/__init__.py
@@ -1,4 +1,23 @@
 from .handle_tag_event import HandleTagEvent
+from .library.add_disc import AddDisc
+from .library.edit_disc import EditDisc
+from .library.get_current_tag_status import GetCurrentTagStatus
+from .library.get_disc import GetDisc
+from .library.list_discs import ListDiscs
+from .library.remove_disc import RemoveDisc
+from .library.resolve_tag_id import ResolveTagId
+from .library.search_discs import SearchDiscs
 from .sync_current_tag import SyncCurrentTag
 
-__all__ = ["HandleTagEvent", "SyncCurrentTag"]
+__all__ = [
+    "HandleTagEvent",
+    "AddDisc",
+    "EditDisc",
+    "GetCurrentTagStatus",
+    "GetDisc",
+    "ListDiscs",
+    "RemoveDisc",
+    "ResolveTagId",
+    "SearchDiscs",
+    "SyncCurrentTag",
+]

--- a/jukebox/domain/use_cases/handle_tag_event.py
+++ b/jukebox/domain/use_cases/handle_tag_event.py
@@ -14,7 +14,8 @@ from jukebox.domain.entities import (
 from jukebox.domain.errors import PlaybackError
 from jukebox.domain.ports import PlayerPort
 from jukebox.domain.repositories import LibraryRepository
-from jukebox.domain.use_cases.transition_playback import transition_playback
+
+from .transition_playback import transition_playback
 
 LOGGER = logging.getLogger("jukebox")
 

--- a/jukebox/domain/use_cases/sync_current_tag.py
+++ b/jukebox/domain/use_cases/sync_current_tag.py
@@ -3,7 +3,8 @@ import logging
 
 from jukebox.domain.entities import CurrentTagContext, CurrentTagState, TagEvent
 from jukebox.domain.repositories import CurrentTagRepository
-from jukebox.domain.use_cases.transition_current_tag import transition_current_tag
+
+from .transition_current_tag import transition_current_tag
 
 LOGGER = logging.getLogger("jukebox")
 

--- a/tests/jukebox/architecture/helpers.py
+++ b/tests/jukebox/architecture/helpers.py
@@ -1,0 +1,36 @@
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SRC = ROOT / "jukebox"
+
+
+def collect_import_lines(tree: ast.Module, prefix: str) -> list[tuple[int, str]]:
+    results: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module and node.module.startswith(prefix):
+                results.append((node.lineno, node.module))
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith(prefix):
+                    results.append((node.lineno, alias.name))
+    return results
+
+
+def find_private_import_violations(
+    src: Path,
+    public_module: str,
+    allowed_dirs: list[Path] | None = None,
+) -> list[str]:
+    private_prefix = f"{public_module}."
+    violations: list[str] = []
+
+    for py_file in src.rglob("*.py"):
+        if any(py_file.is_relative_to(d) for d in (allowed_dirs or [])):
+            continue
+        tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
+        for lineno, module in collect_import_lines(tree, private_prefix):
+            violations.append(f"{py_file}:{lineno} forbidden import from '{module}'")
+
+    return violations

--- a/tests/jukebox/architecture/test_adapters_isolation.py
+++ b/tests/jukebox/architecture/test_adapters_isolation.py
@@ -1,0 +1,64 @@
+import ast
+
+import pytest
+
+from .helpers import SRC, collect_import_lines
+
+ADAPTERS_DIR = SRC / "adapters"
+INBOUND_PREFIX = "jukebox.adapters.inbound"
+OUTBOUND_PREFIX = "jukebox.adapters.outbound"
+
+COMPOSITION_ROOTS = {
+    SRC / "di_container.py",
+    SRC / "admin" / "di_container.py",
+    SRC / "app.py",
+}
+
+
+def find_external_adapter_violations() -> list[str]:
+    violations: list[str] = []
+    for py_file in SRC.rglob("*.py"):
+        if py_file in COMPOSITION_ROOTS:
+            continue
+        if py_file.is_relative_to(ADAPTERS_DIR):
+            continue
+        tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
+        for lineno, module in collect_import_lines(tree, "jukebox.adapters"):
+            violations.append(f"{py_file}:{lineno} forbidden import from '{module}'")
+    return violations
+
+
+def find_cross_direction_violations() -> list[str]:
+    violations: list[str] = []
+    checks = [
+        (ADAPTERS_DIR / "inbound", OUTBOUND_PREFIX),
+        (ADAPTERS_DIR / "outbound", INBOUND_PREFIX),
+    ]
+    for scan_dir, forbidden_prefix in checks:
+        for py_file in scan_dir.rglob("*.py"):
+            tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
+            for lineno, module in collect_import_lines(tree, forbidden_prefix):
+                violations.append(f"{py_file}:{lineno} forbidden import from '{module}'")
+    return violations
+
+
+def test_composition_roots_exist() -> None:
+    missing = [str(p) for p in COMPOSITION_ROOTS if not p.exists()]
+    if missing:
+        pytest.fail(
+            "COMPOSITION_ROOTS contains paths that do not exist. "
+            "Update the list to reflect the current project structure.\n\n" + "\n".join(missing)
+        )
+
+
+@pytest.mark.xfail(reason="admin/pn532_command_handlers.py imports adapter directly", strict=True)
+def test_only_composition_roots_import_adapters() -> None:
+    violations = find_external_adapter_violations()
+    if violations:
+        pytest.fail("Only composition roots may import from adapters.\n\n" + "\n".join(sorted(violations)))
+
+
+def test_adapters_no_cross_direction() -> None:
+    violations = find_cross_direction_violations()
+    if violations:
+        pytest.fail("Inbound and outbound adapters must not import each other.\n\n" + "\n".join(sorted(violations)))

--- a/tests/jukebox/architecture/test_domain_isolation.py
+++ b/tests/jukebox/architecture/test_domain_isolation.py
@@ -1,0 +1,20 @@
+import ast
+
+import pytest
+
+from .helpers import SRC, collect_import_lines
+
+
+def find_violations() -> list[str]:
+    violations: list[str] = []
+    for py_file in (SRC / "domain").rglob("*.py"):
+        tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
+        for lineno, module in collect_import_lines(tree, "jukebox.adapters"):
+            violations.append(f"{py_file}:{lineno} forbidden import from '{module}'")
+    return violations
+
+
+def test_domain_does_not_import_adapters() -> None:
+    violations = find_violations()
+    if violations:
+        pytest.fail("Domain must not import from adapters.\n\n" + "\n".join(sorted(violations)))

--- a/tests/jukebox/architecture/test_domain_public_api.py
+++ b/tests/jukebox/architecture/test_domain_public_api.py
@@ -10,7 +10,6 @@ DOMAIN_MODULES = [
         "jukebox.domain.use_cases",
         marks=pytest.mark.xfail(
             reason=(
-                "library/ use cases not re-exported from use_cases/__init__.py; "
                 "adapters and composition roots also import sub-modules directly"
             ),
             strict=True,

--- a/tests/jukebox/architecture/test_domain_public_api.py
+++ b/tests/jukebox/architecture/test_domain_public_api.py
@@ -1,0 +1,31 @@
+import pytest
+
+from .helpers import SRC, find_private_import_violations
+
+DOMAIN_MODULES = [
+    "jukebox.domain.entities",
+    "jukebox.domain.ports",
+    "jukebox.domain.repositories",
+    pytest.param(
+        "jukebox.domain.use_cases",
+        marks=pytest.mark.xfail(
+            reason=(
+                "library/ use cases not re-exported from use_cases/__init__.py; "
+                "adapters and composition roots also import sub-modules directly"
+            ),
+            strict=True,
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize("module", DOMAIN_MODULES)
+def test_domain_public_api_only(module: str) -> None:
+    subpackage = module.removeprefix("jukebox.")
+    violations = find_private_import_violations(
+        SRC,
+        module,
+        allowed_dirs=[SRC / subpackage.replace(".", "/")],
+    )
+    if violations:
+        pytest.fail(f"Imports must go through '{module}' only.\n\n" + "\n".join(sorted(violations)))

--- a/tests/jukebox/architecture/test_domain_public_api.py
+++ b/tests/jukebox/architecture/test_domain_public_api.py
@@ -6,15 +6,7 @@ DOMAIN_MODULES = [
     "jukebox.domain.entities",
     "jukebox.domain.ports",
     "jukebox.domain.repositories",
-    pytest.param(
-        "jukebox.domain.use_cases",
-        marks=pytest.mark.xfail(
-            reason=(
-                "adapters and composition roots also import sub-modules directly"
-            ),
-            strict=True,
-        ),
-    ),
+    "jukebox.domain.use_cases",
 ]
 
 

--- a/tests/jukebox/architecture/test_pn532_public_api.py
+++ b/tests/jukebox/architecture/test_pn532_public_api.py
@@ -1,0 +1,16 @@
+import pytest
+
+from .helpers import SRC, find_private_import_violations
+
+PUBLIC_MODULE = "jukebox.pn532"
+
+
+@pytest.mark.xfail(reason="codebase imports pn532 sub-modules directly", strict=True)
+def test_pn532_public_api_only() -> None:
+    violations = find_private_import_violations(
+        SRC,
+        PUBLIC_MODULE,
+        allowed_dirs=[SRC / "pn532"],
+    )
+    if violations:
+        pytest.fail(f"Imports must go through '{PUBLIC_MODULE}' only.\n\n" + "\n".join(sorted(violations)))

--- a/tests/jukebox/architecture/test_settings_public_api.py
+++ b/tests/jukebox/architecture/test_settings_public_api.py
@@ -1,0 +1,16 @@
+import pytest
+
+from .helpers import SRC, find_private_import_violations
+
+PUBLIC_MODULE = "jukebox.settings"
+
+
+@pytest.mark.xfail(reason="codebase imports settings sub-modules directly", strict=True)
+def test_settings_public_api_only() -> None:
+    violations = find_private_import_violations(
+        SRC,
+        PUBLIC_MODULE,
+        allowed_dirs=[SRC / "settings"],
+    )
+    if violations:
+        pytest.fail(f"Imports must go through '{PUBLIC_MODULE}' only.\n\n" + "\n".join(sorted(violations)))

--- a/tests/jukebox/architecture/test_sonos_public_api.py
+++ b/tests/jukebox/architecture/test_sonos_public_api.py
@@ -1,0 +1,16 @@
+import pytest
+
+from .helpers import SRC, find_private_import_violations
+
+PUBLIC_MODULE = "jukebox.sonos"
+
+
+@pytest.mark.xfail(reason="codebase imports sonos sub-modules directly", strict=True)
+def test_sonos_public_api_only() -> None:
+    violations = find_private_import_violations(
+        SRC,
+        PUBLIC_MODULE,
+        allowed_dirs=[SRC / "sonos"],
+    )
+    if violations:
+        pytest.fail(f"Imports must go through '{PUBLIC_MODULE}' only.\n\n" + "\n".join(sorted(violations)))


### PR DESCRIPTION
## Summary

Static AST-based tests that enforce hexagonal architecture boundaries without runtime overhead. Shared `helpers.py` with `collect_import_lines` / `find_private_import_violations` avoids duplication across test files. Known violations are marked `xfail(strict=True)` to document tech debt without blocking CI: pytest will alert with `XPASS` when a violation is fixed and the marker can be removed.

## Rules enforced

| Test | Rule |
|---|---|
| `test_domain_public_api.py` | All imports of `domain.*` must go through `__init__` (entities, ports, repositories, use_cases) |
| `test_domain_isolation.py` | `domain -> adapters` forbidden |
| `test_adapters_isolation.py` | Only composition roots (`di_container.py`, `admin/di_container.py`, `app.py`) may import from adapters; no cross-direction between inbound and outbound |
| `test_pn532_public_api.py` | All imports of `jukebox.pn532.*` must go through `__init__` |
| `test_settings_public_api.py` | All imports of `jukebox.settings.*` must go through `__init__` |
| `test_sonos_public_api.py` | All imports of `jukebox.sonos.*` must go through `__init__` |

## Known violations (xfail)

- `adapters isolation`: `admin/pn532_command_handlers.py` imports an outbound adapter directly
- `pn532`: widespread direct sub-module imports
- `settings`: widespread direct sub-module imports
- `sonos`: widespread direct sub-module imports