### PR TITLE
🔥 Remove unused AdminCommand alias

### DIFF
--- a/jukebox/admin/commands.py
+++ b/jukebox/admin/commands.py
@@ -1,4 +1,4 @@
-from typing import Literal, Self, TypeAlias
+from typing import Literal, Self
 
 from pydantic import BaseModel, model_validator
 
@@ -51,34 +51,6 @@ class SettingsResetCommand(BaseModel):
     type: Literal["settings_reset"]
     dotted_path: str
     json_output: bool = False
-
-
-AdminCommand: TypeAlias = (
-    ApiCommand
-    | SettingsResetCommand
-    | SettingsSetCommand
-    | SettingsShowCommand
-    | SonosListCommand
-    | SonosSelectCommand
-    | SonosShowCommand
-    | UiCommand
-)
-
-
-def is_admin_command(command: object) -> bool:
-    return isinstance(
-        command,
-        (
-            ApiCommand,
-            SettingsResetCommand,
-            SettingsSetCommand,
-            SettingsShowCommand,
-            SonosListCommand,
-            SonosSelectCommand,
-            SonosShowCommand,
-            UiCommand,
-        ),
-    )
 
 
 def is_sonos_command(command: object) -> bool:


### PR DESCRIPTION
## Summary

- Remove the `AdminCommand` type alias and `is_admin_command` helper from `jukebox/admin/commands.py`, which had no remaining callers now that dispatch uses `is_sonos_command`/`is_pn532_command` with isinstance checks.
- Drop the now-unused `TypeAlias` import that resulted from the removal.

## Test plan

- [ ] Grep the repository for `AdminCommand` and `is_admin_command` and confirm no references remain.
- [ ] Run the full test suite and confirm it still passes.