### PR TITLE
🐛 Handle unexpected errors in the list-discs route

### DIFF
--- a/jukebox/adapters/inbound/admin/api/discs_router.py
+++ b/jukebox/adapters/inbound/admin/api/discs_router.py
@@ -17,7 +17,10 @@ def build_discs_router(
 
     @router.get("/discs", response_model=dict[str, DiscOutput], summary="List discs")
     def list_discs_route() -> dict[str, Disc]:
-        return list_discs.execute()
+        try:
+            return list_discs.execute()
+        except Exception as err:
+            raise HTTPException(status_code=500, detail=f"Server error: {err!s}")
 
     @router.get("/discs/{tag_id}", response_model=DiscOutput, summary="Get a disc")
     def get_disc_route(tag_id: str) -> Disc:

--- a/tests/jukebox/adapters/inbound/admin/api/test_discs_router.py
+++ b/tests/jukebox/adapters/inbound/admin/api/test_discs_router.py
@@ -59,6 +59,20 @@ def test_list_discs_returns_disc_list(get_route):
 
 
 @pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
+def test_list_discs_returns_500_on_unexpected_error(get_route):
+    list_discs = create_autospec(ListDiscs, instance=True)
+    list_discs.execute.side_effect = RuntimeError("boom")
+    router = build_router(list_discs=list_discs)
+    route = get_route(router, "/api/v1/discs", "GET")
+
+    with pytest.raises(HTTPException) as err:
+        route.endpoint()
+
+    assert err.value.status_code == 500
+    assert err.value.detail == "Server error: boom"
+
+
+@pytest.mark.skipif(not FASTAPI_INSTALLED, reason="FastAPI dependencies are not installed")
 def test_get_disc_returns_disc_payload(get_route):
     get_disc = create_autospec(GetDisc, instance=True)
     get_disc.execute.return_value = Disc(


### PR DESCRIPTION
## Summary

- Add the same boundary try/except used by every other route in the discs router to `list_discs_route`, so an adapter failure returns a consistent formatted 500 response instead of an unhandled exception.

## Test plan

- [ ] Run the discs router test suite with the api extra and confirm it passes.
- [ ] Add a test that makes list_discs.execute() raise and asserts the route now returns a formatted 500 instead of propagating an unhandled exception.