### PR TITLE
🔒 Disable interactive API docs on the admin server

### DIFF
--- a/jukebox/adapters/inbound/admin/api_controller.py
+++ b/jukebox/adapters/inbound/admin/api_controller.py
@@ -101,8 +101,8 @@ class APIController:
         self.app = FastAPI(
             title="Jukebox Admin API",
             description="API for managing Jukebox disc library and settings",
-            docs_url="/docs",
-            redoc_url="/redoc",
+            docs_url=None,
+            redoc_url=None,
         )
         self.register_routes()
 


### PR DESCRIPTION
## Summary

- Disable the interactive Swagger UI (`/docs`) and ReDoc (`/redoc`) pages on the admin API server, since the server has no authentication and these pages expose the full route and schema surface to anyone who can reach it.

## Test plan

- [ ] Run the API controller test suite with the api extra and confirm it passes.
- [ ] Manually start the admin API and confirm GET /docs and GET /redoc now both 404.