### PR TITLE
♻️ Use direct attribute access for Sonos speaker host lookup

### DIFF
--- a/jukebox/adapters/outbound/sonos_discovery_adapter.py
+++ b/jukebox/adapters/outbound/sonos_discovery_adapter.py
@@ -350,7 +350,7 @@ def _safe_speaker_identifier(speaker: "_SonosSpeakerLike") -> str:
 
 def _safe_speaker_host(speaker: "_SonosSpeakerLike") -> str | None:
     try:
-        ip_address = getattr(speaker, "ip_address", None)
+        ip_address = speaker.ip_address
     except _SONOS_TRANSPORT_ERRORS:
         return None
 

--- a/tests/jukebox/adapters/outbound/test_sonos_discovery_adapter.py
+++ b/tests/jukebox/adapters/outbound/test_sonos_discovery_adapter.py
@@ -288,6 +288,10 @@ def test_soco_sonos_discovery_adapter_ignores_stale_discovered_zones(mocker):
         def uid(self):
             raise OSError("stale zone")
 
+        @property
+        def ip_address(self):
+            raise OSError("stale zone")
+
         def __hash__(self):
             return hash("stale")
 


### PR DESCRIPTION
## Summary

- `_safe_speaker_host` now reads `speaker.ip_address` directly instead of going through `getattr` with a default, matching the direct attribute access already used by the sibling `_safe_speaker_identifier`/`_safe_speaker_uid` helpers, since the `_SonosSpeakerLike` protocol already declares `ip_address` as a required attribute.
- Updated the stale-speaker discovery test fixture so it models a real transport failure on `ip_address` (matching how `uid` is modeled) rather than simply omitting the attribute.

## Test plan

- [ ] Run the sonos discovery adapter test suite and confirm it still passes: `uv run pytest tests/jukebox/adapters/outbound/test_sonos_discovery_adapter.py`
- [ ] Run the full test suite, lint, and format checks: `uv run pytest`, `uv run ruff check`, `uv run ruff format --check`