### PR TITLE
🔒 Bind admin servers to loopback by default

### DIFF
--- a/jukebox/admin/command_handlers.py
+++ b/jukebox/admin/command_handlers.py
@@ -231,7 +231,7 @@ def execute_server_command(
             extra_name="api",
             source_command=source_command,
         )
-        uvicorn.run(api.app, host="0.0.0.0", port=runtime_config.api_port)
+        uvicorn.run(api.app, host=runtime_config.api_host, port=runtime_config.api_port)
         return
 
     if isinstance(command, UiCommand):
@@ -244,7 +244,7 @@ def execute_server_command(
             extra_name="ui",
             source_command=source_command,
         )
-        uvicorn.run(ui.app, host="0.0.0.0", port=runtime_config.ui_port)
+        uvicorn.run(ui.app, host=runtime_config.ui_host, port=runtime_config.ui_port)
         return
 
     raise TypeError("Unsupported server command")

--- a/jukebox/settings/entities.py
+++ b/jukebox/settings/entities.py
@@ -105,6 +105,7 @@ class JukeboxSettings(PersistedJukeboxSettings):
 
 
 class ServerSettings(StrictModel):
+    host: str = "127.0.0.1"
     port: int = Field(default=8000, ge=1, le=65535)
 
 
@@ -284,6 +285,8 @@ class ResolvedJukeboxRuntimeConfig(StrictModel):
 
 class ResolvedAdminRuntimeConfig(StrictModel):
     library_path: str
+    api_host: str
     api_port: int
+    ui_host: str
     ui_port: int
     verbose: bool = False

--- a/jukebox/settings/resolve.py
+++ b/jukebox/settings/resolve.py
@@ -97,7 +97,9 @@ class SettingsService:
         effective_settings = self._resolve_effective_settings()
         return ResolvedAdminRuntimeConfig(
             library_path=_expand_path(effective_settings.paths.library_path),
+            api_host=effective_settings.admin.api.host,
             api_port=effective_settings.admin.api.port,
+            ui_host=effective_settings.admin.ui.host,
             ui_port=effective_settings.admin.ui.port,
             verbose=verbose,
         )

--- a/tests/jukebox/admin/test_command_handlers.py
+++ b/tests/jukebox/admin/test_command_handlers.py
@@ -847,18 +847,22 @@ def test_execute_sonos_command_rejects_duplicate_scripted_uids():
 
 
 @pytest.mark.parametrize(
-    ("command", "builder_name", "expected_port"),
+    ("command", "builder_name", "expected_host", "expected_port"),
     [
-        (ApiCommand(type="api", port=1111), "build_api_app", 7777),
-        (UiCommand(type="ui", port=2222), "build_ui_app", 8888),
+        (ApiCommand(type="api", port=1111), "build_api_app", "10.0.0.7", 7777),
+        (UiCommand(type="ui", port=2222), "build_ui_app", "10.0.0.8", 8888),
     ],
 )
-def test_execute_server_command_starts_server_with_resolved_runtime(mocker, command, builder_name, expected_port):
+def test_execute_server_command_starts_server_with_resolved_runtime(
+    mocker, command, builder_name, expected_host, expected_port
+):
     mock_uvicorn = mocker.patch.dict("sys.modules", {"uvicorn": MagicMock()})["uvicorn"]
     services = build_services()
     services.settings.resolve_admin_runtime.return_value = ResolvedAdminRuntimeConfig(
         library_path="/resolved/library.json",
+        api_host="10.0.0.7",
         api_port=7777,
+        ui_host="10.0.0.8",
         ui_port=8888,
         verbose=True,
     )
@@ -882,7 +886,7 @@ def test_execute_server_command_starts_server_with_resolved_runtime(mocker, comm
     else:
         build_ui_app.assert_called_once_with("/resolved/library.json", services)
         build_api_app.assert_not_called()
-    mock_uvicorn.run.assert_called_once_with(fake_app.app, host="0.0.0.0", port=expected_port)
+    mock_uvicorn.run.assert_called_once_with(fake_app.app, host=expected_host, port=expected_port)
 
 
 @pytest.mark.parametrize(
@@ -896,7 +900,9 @@ def test_execute_server_command_reports_missing_optional_dependencies(mocker, co
     services = build_services()
     services.settings.resolve_admin_runtime.return_value = ResolvedAdminRuntimeConfig(
         library_path="/resolved/library.json",
+        api_host="127.0.0.1",
         api_port=8000,
+        ui_host="127.0.0.1",
         ui_port=9000,
         verbose=False,
     )
@@ -929,7 +935,9 @@ def test_execute_server_command_propagates_missing_optional_dependency_error(moc
     services = build_services()
     services.settings.resolve_admin_runtime.return_value = ResolvedAdminRuntimeConfig(
         library_path="/resolved/library.json",
+        api_host="127.0.0.1",
         api_port=8000,
+        ui_host="127.0.0.1",
         ui_port=9000,
         verbose=False,
     )
@@ -971,7 +979,9 @@ def test_execute_server_command_reports_missing_optional_dependencies_from_build
     services = build_services()
     services.settings.resolve_admin_runtime.return_value = ResolvedAdminRuntimeConfig(
         library_path="/resolved/library.json",
+        api_host="127.0.0.1",
         api_port=8000,
+        ui_host="127.0.0.1",
         ui_port=9000,
         verbose=False,
     )

--- a/tests/jukebox/admin/test_library_command_handlers.py
+++ b/tests/jukebox/admin/test_library_command_handlers.py
@@ -14,7 +14,9 @@ def test_execute_library_command_runs_standard_cli_with_resolved_library_path():
     settings_service = create_autospec(SettingsService)
     settings_service.resolve_admin_runtime.return_value = ResolvedAdminRuntimeConfig(
         library_path="/resolved/library.json",
+        api_host="127.0.0.1",
         api_port=8000,
+        ui_host="127.0.0.1",
         ui_port=9000,
         verbose=True,
     )
@@ -41,7 +43,9 @@ def test_execute_library_command_runs_interactive_cli_with_resolved_library_path
     settings_service = create_autospec(SettingsService)
     settings_service.resolve_admin_runtime.return_value = ResolvedAdminRuntimeConfig(
         library_path="/resolved/library.json",
+        api_host="127.0.0.1",
         api_port=8000,
+        ui_host="127.0.0.1",
         ui_port=9000,
         verbose=False,
     )

--- a/tests/jukebox/settings/test_settings_service_runtime_resolution.py
+++ b/tests/jukebox/settings/test_settings_service_runtime_resolution.py
@@ -37,7 +37,9 @@ def test_settings_service_allows_admin_runtime_resolution_without_sonos_target(t
     runtime_config = service.resolve_admin_runtime()
 
     assert runtime_config.library_path == os.path.abspath(os.path.expanduser("~/.config/jukebox/library.json"))
+    assert runtime_config.api_host == "127.0.0.1"
     assert runtime_config.api_port == 8000
+    assert runtime_config.ui_host == "127.0.0.1"
     assert runtime_config.ui_port == 8000
 
 


### PR DESCRIPTION
## Summary

- Admin API and UI servers now default to binding on `127.0.0.1` instead of `0.0.0.0`, so they are not reachable from outside the host unless explicitly configured otherwise.
- Adds a configurable `host` field to server settings, threaded through admin runtime resolution and into the `uvicorn.run` calls for both the API and UI servers.

## Test plan

- [ ] Run the full test suite and confirm it passes with the new host field wired through settings resolution.
- [ ] Start jukebox-admin api (dryrun-safe) and confirm the server binds to 127.0.0.1 by default instead of 0.0.0.0.