### PR TITLE
🐛 Guard against duplicate log handlers on repeated setup

### DIFF
--- a/jukebox/shared/logger.py
+++ b/jukebox/shared/logger.py
@@ -5,9 +5,11 @@ def set_logger(logger_name: str, verbose: bool = False):
     level = logging.DEBUG if verbose else logging.INFO
     logger = logging.getLogger(logger_name)
     logger.setLevel(level)
-    console_handler = logging.StreamHandler()
-    console_handler.setLevel(level)
-    formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s\t - %(message)s")
-    console_handler.setFormatter(formatter)
-    logger.addHandler(console_handler)
+    logger.propagate = False
+    if not logger.handlers:
+        console_handler = logging.StreamHandler()
+        console_handler.setLevel(level)
+        formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s\t - %(message)s")
+        console_handler.setFormatter(formatter)
+        logger.addHandler(console_handler)
     return logger

--- a/tests/jukebox/shared/test_logger.py
+++ b/tests/jukebox/shared/test_logger.py
@@ -11,11 +11,12 @@ from jukebox.shared.logger import set_logger
 @pytest.fixture(autouse=True)
 def clean_logger():
     logger = logging.getLogger("dummy")
-    if logger.hasHandlers():
-        logger.handlers.clear()
-
-    if logger.hasHandlers():
-        logger.handlers.clear()
+    logger.handlers.clear()
+    # pytest's log-capturing machinery attaches its own handlers directly to
+    # non-propagating loggers, so propagate must be reset too or a leftover
+    # `propagate = False` from a previous test call would fool the guard in
+    # `set_logger` into thinking a handler is already attached.
+    logger.propagate = True
 
 
 @pytest.mark.parametrize(
@@ -34,3 +35,11 @@ def test_set_logger(verbose, expected_regex):
 
     output = log_capture_string.getvalue()
     assert re.match(expected_regex, output)
+
+
+def test_set_logger_called_twice_attaches_a_single_handler():
+    set_logger("dummy")
+    set_logger("dummy")
+
+    logger = logging.getLogger("dummy")
+    assert len(logger.handlers) == 1


### PR DESCRIPTION
## Summary

- `set_logger` now only attaches a console handler when the logger doesn't already have one, preventing duplicated log lines if setup is invoked more than once for the same logger name.
- The logger is also set to non-propagating so records aren't additionally emitted via an ancestor logger's handlers.

## Test plan

- [ ] Add a unit test for set_logger asserting that calling it twice for the same logger name results in exactly one handler attached.
- [ ] Run the full test suite and confirm no regression from setting propagate = False.